### PR TITLE
Fix Apple Silicon bundle update crashing on fresh install release state

### DIFF
--- a/bin/omarchy-update-asahi-bundle
+++ b/bin/omarchy-update-asahi-bundle
@@ -130,6 +130,7 @@ if [[ -e $state_file ]]; then
       sequence=*) state_sequence=${line#sequence=} ;;
       tag=*) ;;
       source_commit=*) state_source=${line#source_commit=} ;;
+      package_source_commit=*) ;;
       "") ;;
       *) fail "release state is malformed" ;;
     esac
@@ -154,6 +155,7 @@ if [[ -e $pending_file ]]; then
       sequence=*) pending_sequence=${line#sequence=} ;;
       tag=*) ;;
       source_commit=*) pending_source=${line#source_commit=} ;;
+      package_source_commit=*) ;;
       "") ;;
       *) fail "pending release state is malformed" ;;
     esac


### PR DESCRIPTION
Fixes #12. The fresh installer recently added `package_source_commit=` to the release state file to track the package source. This caused `omarchy-update-asahi-bundle` to crash with 'release state is malformed' because its parser was strict and did not expect this new field.