### PR TITLE
Draft: fix(hardware): Add Wi-Fi resume fix for Apple Silicon

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -36,6 +36,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-wifi-resume.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/fix-wifi-resume.sh
+++ b/install/hardware/apple/fix-wifi-resume.sh
@@ -1,0 +1,24 @@
+# Fix Wi-Fi failing to reconnect after wake from suspend on Apple Silicon
+# iwd and NetworkManager become desynced from the Wi-Fi hardware state upon waking up
+
+omarchy-hw-apple-silicon || return 0
+
+echo "Applying Wi-Fi resume fix for Apple Silicon..."
+
+mkdir -p /etc/systemd/system
+cat > /etc/systemd/system/omarchy-wifi-resume.service <<'EOF'
+[Unit]
+Description=Omarchy Wi-Fi Resume Fix for Apple Silicon
+After=suspend.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sleep 2
+ExecStart=/usr/bin/systemctl restart iwd
+ExecStartPost=/usr/bin/systemctl restart NetworkManager
+
+[Install]
+WantedBy=suspend.target
+EOF
+
+systemctl enable omarchy-wifi-resume.service


### PR DESCRIPTION
Fixes #11

**Note:** The bug described in #11 seems to no longer be reproducible on latest Asahi Linux / Omarchy environments. It might have been caused by an upstream issue that got resolved, or a different local configuration.
Creating this PR as a draft to keep track of the workaround script (`omarchy-wifi-resume.service`) in case the issue re-appears or needs further investigation.