### PR TITLE
fix: use curl backend for rustup

### DIFF
--- a/bin/omarchy-install-dev-env
+++ b/bin/omarchy-install-dev-env
@@ -119,7 +119,7 @@ phoenix)
   ;;
 rust)
   echo -e "Installing Rust...\n"
-  bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y
+  RUSTUP_USE_CURL=1 bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y
   ;;
 java)
   echo -e "Installing Java...\n"


### PR DESCRIPTION
Fixes #9. rustup's default reqwest backend is prone to connection resets on Asahi Linux/Apple Silicon. Fallback to the curl backend.