### PR TITLE
feat: Add install script to simplify installation steps (resolve #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ nmtui
 Update the system and install the release verification tools:
 
 ```bash
-pacman -Syu --needed curl gnupg networkmanager iwd
+pacman -Syu --needed curl gnupg linux-asahi-headers networkmanager iwd
 ```
 
 ### 3. Install The Latest Stable Mac Release
 
-Download and run the installer script. It will automatically download the stable release and verify all cryptographic signatures:
+Download and run the installer script. It will automatically download the
+stable release and verify all cryptographic signatures:
 
 ```bash
 curl -fLO https://raw.githubusercontent.com/maralcbr/omarchy-mx-mac/main/install-omarchy-mx-mac.sh

--- a/README.md
+++ b/README.md
@@ -107,20 +107,11 @@ pacman -Syu --needed curl gnupg networkmanager iwd
 
 ### 3. Install The Latest Stable Mac Release
 
-Download and verify the installer from the latest stable release:
+Download and run the installer script. It will automatically download the stable release and verify all cryptographic signatures:
 
 ```bash
-mkdir -p /root/omarchy-mx-mac-install
-cd /root/omarchy-mx-mac-install
-release=https://github.com/maralcbr/omarchy-mx-mac/releases/latest/download
-curl -fLO "$release/install-omarchy-mx-mac"
-curl -fLO "$release/install-omarchy-mx-mac.sig"
-curl -fLO "$release/omarchy-release.gpg"
-test "$(gpg --show-keys --with-colons omarchy-release.gpg | awk -F: '$1 == "fpr" { print $10; exit }')" = \
-  5983B1CA32CB778F4D74D24ECFF35022CA5B5959
-gpgv --keyring ./omarchy-release.gpg install-omarchy-mx-mac.sig install-omarchy-mx-mac
-bash install-omarchy-mx-mac --verify-only
-bash install-omarchy-mx-mac
+curl -fLO https://raw.githubusercontent.com/maralcbr/omarchy-mx-mac/main/install-omarchy-mx-mac.sh
+bash install-omarchy-mx-mac.sh
 ```
 
 The signed installer will:

--- a/install-omarchy-mx-mac.sh
+++ b/install-omarchy-mx-mac.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Fetches and verifies the latest signed Omarchy MX Mac installer.
+
+set -euo pipefail
+
+fail() { echo "Error: $*" >&2; exit 1; }
+
+for cmd in curl gpg awk; do
+  command -v "$cmd" >/dev/null 2>&1 || fail "Required command is unavailable: $cmd"
+done
+
+work_dir="/root/omarchy-mx-mac-install"
+if (( EUID != 0 )); then
+  work_dir=$(mktemp -d "${TMPDIR:-/tmp}/omarchy-mx-mac-install.XXXXXXXX")
+  trap 'rm -rf "$work_dir"' EXIT
+else
+  mkdir -p "$work_dir"
+fi
+
+cd "$work_dir"
+
+release="https://github.com/maralcbr/omarchy-mx-mac/releases/latest/download"
+fingerprint="5983B1CA32CB778F4D74D24ECFF35022CA5B5959"
+
+echo "=> Downloading installer and signatures..."
+curl -fLO --retry 3 "$release/install-omarchy-mx-mac"
+curl -fLO --retry 3 "$release/install-omarchy-mx-mac.sig"
+curl -fLO --retry 3 "$release/omarchy-release.gpg"
+
+echo "=> Verifying release key..."
+actual_fingerprint=$(gpg --show-keys --with-colons omarchy-release.gpg | awk -F: '$1 == "fpr" { print $10; exit }')
+if [[ "$actual_fingerprint" != "$fingerprint" ]]; then
+  fail "Release signing key fingerprint mismatch."
+fi
+
+echo "=> Verifying installer signature..."
+gpgv --keyring ./omarchy-release.gpg install-omarchy-mx-mac.sig install-omarchy-mx-mac || \
+  fail "Installer signature verification failed."
+
+echo "=> Pre-verifying package integrity..."
+bash install-omarchy-mx-mac --verify-only
+
+echo "=> Starting installation..."
+exec bash install-omarchy-mx-mac "$@"

--- a/install-omarchy-mx-mac.sh
+++ b/install-omarchy-mx-mac.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 fail() { echo "Error: $*" >&2; exit 1; }
 
-for cmd in curl gpg awk; do
+for cmd in curl gpg gpgv awk; do
   command -v "$cmd" >/dev/null 2>&1 || fail "Required command is unavailable: $cmd"
 done
 
@@ -29,7 +29,7 @@ curl -fLO --retry 3 "$release/omarchy-release.gpg"
 
 echo "=> Verifying release key..."
 actual_fingerprint=$(gpg --show-keys --with-colons omarchy-release.gpg | awk -F: '$1 == "fpr" { print $10; exit }')
-if [[ "$actual_fingerprint" != "$fingerprint" ]]; then
+if [[ $actual_fingerprint != $fingerprint ]]; then
   fail "Release signing key fingerprint mismatch."
 fi
 
@@ -41,4 +41,4 @@ echo "=> Pre-verifying package integrity..."
 bash install-omarchy-mx-mac --verify-only
 
 echo "=> Starting installation..."
-exec bash install-omarchy-mx-mac "$@"
+bash install-omarchy-mx-mac "$@"

--- a/test/shell.d/asahi-bootstrap-test.sh
+++ b/test/shell.d/asahi-bootstrap-test.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+bootstrap="$ROOT/install-omarchy-mx-mac.sh"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/tmp"
+
+cat >"$test_tmp/bin/curl" <<'EOF'
+#!/bin/bash
+
+for argument in "$@"; do
+  [[ $argument == https://* ]] && output=${argument##*/}
+done
+
+case "$output" in
+  install-omarchy-mx-mac)
+    cat >"$output" <<'INSTALLER'
+#!/bin/bash
+printf '%s\n' "$*" >>"$INVOCATION_LOG"
+INSTALLER
+    ;;
+  *)
+    : >"$output"
+    ;;
+esac
+EOF
+
+cat >"$test_tmp/bin/gpg" <<'EOF'
+#!/bin/bash
+printf 'fpr:::::::::%s:\n' "${GPG_FINGERPRINT:-5983B1CA32CB778F4D74D24ECFF35022CA5B5959}"
+EOF
+
+cat >"$test_tmp/bin/gpgv" <<'EOF'
+#!/bin/bash
+exit "${GPGV_EXIT:-0}"
+EOF
+
+chmod +x "$test_tmp/bin"/*
+
+run_bootstrap() {
+  PATH="$test_tmp/bin:/usr/bin" TMPDIR="$test_tmp/tmp" \
+    INVOCATION_LOG="$test_tmp/invocations" bash "$bootstrap" "$@"
+}
+
+bash -n "$bootstrap"
+grep -Fq 'for cmd in curl gpg gpgv awk' "$bootstrap" || fail "bootstrap checks every verification command"
+pass "bootstrap syntax and prerequisites are valid"
+
+: >"$test_tmp/invocations"
+run_bootstrap --user example >/dev/null
+mapfile -t invocations <"$test_tmp/invocations"
+[[ ${invocations[0]} == "--verify-only" ]] || fail "bootstrap pre-verifies the signed installer"
+[[ ${invocations[1]} == "--user example" ]] || fail "bootstrap forwards installer arguments"
+(( ${#invocations[@]} == 2 )) || fail "bootstrap invokes the installer exactly twice"
+pass "bootstrap verifies before forwarding installer arguments"
+
+if find "$test_tmp/tmp" -mindepth 1 -print -quit | grep -q .; then
+  fail "bootstrap cleans its non-root working directory"
+fi
+pass "bootstrap cleans its non-root working directory"
+
+: >"$test_tmp/invocations"
+if GPG_FINGERPRINT=invalid run_bootstrap >"$test_tmp/fingerprint.out" 2>&1; then
+  fail "bootstrap rejects an unexpected release fingerprint"
+fi
+grep -Fq 'Release signing key fingerprint mismatch' "$test_tmp/fingerprint.out" || fail "bootstrap reports a fingerprint mismatch"
+[[ ! -s $test_tmp/invocations ]] || fail "bootstrap does not run an installer with an unexpected fingerprint"
+pass "bootstrap rejects an unexpected release fingerprint"
+
+: >"$test_tmp/invocations"
+if GPGV_EXIT=1 run_bootstrap >"$test_tmp/signature.out" 2>&1; then
+  fail "bootstrap rejects an invalid installer signature"
+fi
+grep -Fq 'Installer signature verification failed' "$test_tmp/signature.out" || fail "bootstrap reports an invalid signature"
+[[ ! -s $test_tmp/invocations ]] || fail "bootstrap does not run an installer with an invalid signature"
+pass "bootstrap rejects an invalid installer signature"
+
+: >"$test_tmp/invocations"
+run_bootstrap --verify-only >/dev/null
+mapfile -t invocations <"$test_tmp/invocations"
+[[ ${invocations[0]} == "--verify-only" && ${invocations[1]} == "--verify-only" ]] || \
+  fail "bootstrap preserves the verify-only request"
+pass "bootstrap preserves the verify-only request"


### PR DESCRIPTION
Fixes https://github.com/maralcbr/omarchy-mx-mac/issues/19.

Adds `install-omarchy-mx-mac.sh` to automate downloading and verifying the latest stable installer, and updates the README to use the wrapper.

The wrapper explicitly checks all verification tools, cleans its temporary directory, and is covered for fingerprint rejection, signature rejection, argument forwarding, and `--verify-only`. The preparation instructions now include the required `linux-asahi-headers` package.