### PR TITLE
ci: verify every package manifest resolves and installs

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -182,59 +182,6 @@ jobs:
               alarm:aarch64 /bin/bash -c "pacman -Sy --noconfirm jq >/dev/null && /repo/test/packages-resolve --recipes"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Prove the AUR-backed optional installs still build on aarch64 by
-  # building each declared package from source as an unprivileged user.
-  aur-build:
-    name: Build AUR optional installs
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v7
-      - name: Prepare Arch Linux ARM container
-        run: |
-          curl -fsSL --retry 3 -o "$RUNNER_TEMP/alarm.tar.gz" "$ALARM_ROOTFS_URL"
-          docker import "$RUNNER_TEMP/alarm.tar.gz" alarm:aarch64
-          cat > "$RUNNER_TEMP/pacman.conf" <<'EOF'
-          [options]
-          HoldPkg = pacman glibc
-          Architecture = auto
-          CheckSpace
-          SigLevel = Never
-          ParallelDownloads = 5
-
-          [asahi-alarm]
-          Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
-
-          [core]
-          Server = http://mirror.archlinuxarm.org/$arch/$repo
-
-          [extra]
-          Server = http://mirror.archlinuxarm.org/$arch/$repo
-
-          [alarm]
-          Server = http://mirror.archlinuxarm.org/$arch/$repo
-
-          [aur]
-          Server = http://mirror.archlinuxarm.org/$arch/$repo
-          EOF
-      - name: Build every declared AUR package
-        run: |
-          docker run --rm \
-            -v "$RUNNER_TEMP/pacman.conf:/etc/pacman.conf:ro" \
-            -v "$PWD:/repo:ro" \
-            alarm:aarch64 /bin/bash -euxo pipefail -c '
-              pacman -Sy --noconfirm --needed base-devel git >/dev/null
-              useradd --create-home --shell /bin/bash aur-builder
-              install -d -o aur-builder -g aur-builder /tmp/aur-build
-              while IFS="|" read -r id package; do
-                [[ $id == install.* ]] || continue
-                git clone --depth 1 "https://aur.archlinux.org/$package.git" "/tmp/aur-build/$package"
-                su aur-builder -c "cd /tmp/aur-build/$package && makepkg --noconfirm --cleanbuild --force"
-                echo "ok - $id built $package"
-              done < /repo/install/optional-aur-packages.tsv
-            '
-
   # Each Asahi manifest installs in its own fresh root filesystem so every
   # list stays independently co-installable. This proves today's dependency
   # closure resolves and installs, mirroring the fresh installer's single

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,294 @@
+name: Package manifests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - install/*.packages
+      - install/optional-packages.tsv
+      - install/optional-packages-aarch64-required
+      - install/optional-aur-packages.tsv
+      - bin/omarchy-install-*
+      - default/omarchy/omarchy-menu.jsonc
+      - .github/workflows/packages.yml
+  pull_request:
+    paths:
+      - install/*.packages
+      - install/optional-packages.tsv
+      - install/optional-packages-aarch64-required
+      - install/optional-aur-packages.tsv
+      - bin/omarchy-install-*
+      - default/omarchy/omarchy-menu.jsonc
+      - .github/workflows/packages.yml
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: package-manifests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ALARM_ROOTFS_URL: http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
+
+jobs:
+  # The x86 manifests hold mutually exclusive hardware alternatives, so they
+  # are verified for resolvability only; end-to-end installation remains the
+  # job of the disposable VM acceptance harness.
+  resolve-pc:
+    name: Resolve ${{ matrix.manifest }}
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest:
+          - omarchy-base.packages
+          - omarchy-other.packages
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux:base-devel
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Install job dependencies
+        run: |
+          pacman-key --init
+          pacman -Syu --noconfirm git jq
+      - uses: actions/checkout@v7
+      - name: Add third-party repositories
+        run: |
+          grep -q '^\[multilib\]' /etc/pacman.conf || cat >> /etc/pacman.conf <<'EOF'
+
+          [multilib]
+          Include = /etc/pacman.d/mirrorlist
+          EOF
+          cat >> /etc/pacman.conf <<'EOF'
+
+          [arch-mact2]
+          SigLevel = Never
+          Server = https://github.com/NoaHimesaka1873/arch-mact2-mirror/releases/download/release
+
+          [g14]
+          SigLevel = Never
+          Server = https://arch.asus-linux.org
+          EOF
+      - name: Resolve manifest packages
+        run: test/packages-resolve "install/${{ matrix.manifest }}"
+
+  # The official archlinux image is x86_64-only, so Apple Silicon checks import
+  # the real Arch Linux ARM root filesystem and point it at the five platform
+  # repositories the fresh installer requires. Signature verification is
+  # disabled because these jobs assert availability, not trust.
+  resolve-asahi:
+    name: Resolve ${{ matrix.manifest }} (Asahi)
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest:
+          - omarchy-base-asahi.packages
+          - omarchy-other-asahi.packages
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare Arch Linux ARM container
+        run: |
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/alarm.tar.gz" "$ALARM_ROOTFS_URL"
+          docker import "$RUNNER_TEMP/alarm.tar.gz" alarm:aarch64
+          cat > "$RUNNER_TEMP/pacman.conf" <<'EOF'
+          [options]
+          HoldPkg = pacman glibc
+          Architecture = auto
+          CheckSpace
+          SigLevel = Never
+          ParallelDownloads = 5
+
+          [asahi-alarm]
+          Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
+
+          [core]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [extra]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [alarm]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [aur]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+          EOF
+      - name: Resolve manifest packages
+        run: |
+          docker run --rm \
+            -v "$RUNNER_TEMP/pacman.conf:/etc/pacman.conf:ro" \
+            -v "$PWD:/repo:ro" \
+            alarm:aarch64 /bin/bash -c "pacman -Sy --noconfirm jq >/dev/null && /repo/test/packages-resolve /repo/install/${{ matrix.manifest }}"
+
+  # Optional install recipes reference package names that may never have been
+  # published for aarch64, which is exactly how Install menu entries end in
+  # "target not found". This audit is informational for now: it lists the
+  # names to publish or guard instead of failing the run. Flip it to
+  # enforcement once the current findings are triaged.
+  audit-recipes:
+    name: Audit optional install recipes
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare Arch Linux ARM container
+        run: |
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/alarm.tar.gz" "$ALARM_ROOTFS_URL"
+          docker import "$RUNNER_TEMP/alarm.tar.gz" alarm:aarch64
+          cat > "$RUNNER_TEMP/pacman.conf" <<'EOF'
+          [options]
+          HoldPkg = pacman glibc
+          Architecture = auto
+          CheckSpace
+          SigLevel = Never
+          ParallelDownloads = 5
+
+          [asahi-alarm]
+          Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
+
+          [core]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [extra]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [alarm]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [aur]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+          EOF
+      - name: Audit recipe package names
+        run: |
+          {
+            echo "### Optional install recipe audit"
+            echo
+            docker run --rm \
+              -e GH_TOKEN \
+              -v "$RUNNER_TEMP/pacman.conf:/etc/pacman.conf:ro" \
+              -v "$PWD:/repo:ro" \
+              alarm:aarch64 /bin/bash -c "pacman -Sy --noconfirm jq >/dev/null && /repo/test/packages-resolve --recipes"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Prove the AUR-backed optional installs still build on aarch64 by
+  # building each declared package from source as an unprivileged user.
+  aur-build:
+    name: Build AUR optional installs
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare Arch Linux ARM container
+        run: |
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/alarm.tar.gz" "$ALARM_ROOTFS_URL"
+          docker import "$RUNNER_TEMP/alarm.tar.gz" alarm:aarch64
+          cat > "$RUNNER_TEMP/pacman.conf" <<'EOF'
+          [options]
+          HoldPkg = pacman glibc
+          Architecture = auto
+          CheckSpace
+          SigLevel = Never
+          ParallelDownloads = 5
+
+          [asahi-alarm]
+          Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
+
+          [core]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [extra]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [alarm]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [aur]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+          EOF
+      - name: Build every declared AUR package
+        run: |
+          docker run --rm \
+            -v "$RUNNER_TEMP/pacman.conf:/etc/pacman.conf:ro" \
+            -v "$PWD:/repo:ro" \
+            alarm:aarch64 /bin/bash -euxo pipefail -c '
+              pacman -Sy --noconfirm --needed base-devel git >/dev/null
+              useradd --create-home --shell /bin/bash aur-builder
+              install -d -o aur-builder -g aur-builder /tmp/aur-build
+              while IFS="|" read -r id package; do
+                [[ $id == install.* ]] || continue
+                git clone --depth 1 "https://aur.archlinux.org/$package.git" "/tmp/aur-build/$package"
+                su aur-builder -c "cd /tmp/aur-build/$package && makepkg --noconfirm --cleanbuild --force"
+                echo "ok - $id built $package"
+              done < /repo/install/optional-aur-packages.tsv
+            '
+
+  # Each Asahi manifest installs in its own fresh root filesystem so every
+  # list stays independently co-installable. This proves today's dependency
+  # closure resolves and installs, mirroring the fresh installer's single
+  # pacman transaction.
+  install-asahi:
+    name: Install ${{ matrix.manifest }} transaction
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest:
+          - omarchy-base-asahi.packages
+          - omarchy-other-asahi.packages
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+      - name: Prepare Arch Linux ARM container
+        run: |
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/alarm.tar.gz" "$ALARM_ROOTFS_URL"
+          docker import "$RUNNER_TEMP/alarm.tar.gz" alarm:aarch64
+          cat > "$RUNNER_TEMP/pacman.conf" <<'EOF'
+          [options]
+          HoldPkg = pacman glibc
+          Architecture = auto
+          CheckSpace
+          SigLevel = Never
+          ParallelDownloads = 5
+
+          [asahi-alarm]
+          Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
+
+          [core]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [extra]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [alarm]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+          [aur]
+          Server = http://mirror.archlinuxarm.org/$arch/$repo
+          EOF
+      - name: Install every manifest package
+        run: |
+          # ALARM split the Mesa Vulkan drivers into standalone packages while
+          # asahi-alarm's mesa still bundles Turnip, so installing the split
+          # vulkan-asahi next to it fails on shared files. Runtime code already
+          # guards on this (omarchy-upgrade-to-quattro installs vulkan-asahi
+          # only when /usr/lib/libvulkan_asahi.so is absent). Skip the entry
+          # until asahi-alarm rebases; its dependency
+          # vulkan-mesa-implicit-layers then leaves the closure with it.
+          docker run --rm \
+            -e OMARCHY_TRANSACTION_IGNORE=vulkan-asahi \
+            -v "$RUNNER_TEMP/pacman.conf:/etc/pacman.conf:ro" \
+            -v "$PWD:/repo:ro" \
+            alarm:aarch64 /bin/bash /repo/test/packages-install-transaction "/repo/install/${{ matrix.manifest }}"

--- a/install/omarchy-other-asahi.packages
+++ b/install/omarchy-other-asahi.packages
@@ -17,5 +17,4 @@ pipewire-pulse
 qt6-wayland
 vulkan-asahi
 webp-pixbuf-loader
-yay-debug
 zram-generator

--- a/test/generate-optional-transactions
+++ b/test/generate-optional-transactions
@@ -4,12 +4,22 @@ set -euo pipefail
 
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 menu="$ROOT/default/omarchy/omarchy-menu.jsonc"
-out_file="${1:-$ROOT/install/optional-packages.tsv}"
+out_file=""
+check_file=""
 apply_guards=0
-if [[ ${1:-} == "--apply-guards" ]]; then
-  apply_guards=1
-  out_file="$ROOT/install/optional-packages.tsv"
-fi
+case "${1:-}" in
+  "") out_file="$ROOT/install/optional-packages.tsv" ;;
+  --apply-guards)
+    apply_guards=1
+    out_file="$ROOT/install/optional-packages.tsv"
+    ;;
+  --check)
+    shift
+    (( $# == 1 )) || { echo "Usage: generate-optional-transactions --check TSV" >&2; exit 2; }
+    check_file="$1"
+    ;;
+  *) out_file="$1" ;;
+esac
 
 die() {
   echo "Error: $*" >&2
@@ -308,6 +318,27 @@ while IFS= read -r id; do
 done < <(printf '%s\n' "${!override_ids[@]}" | sort)
 
 (( ${#ordered_ids[@]} > 0 )) || die "No transactions were derived"
+
+if [[ -n $check_file ]]; then
+  # Compare derived transactions with the committed manifest as sets: the
+  # manifest owns row order and comments, the recipes own the contents. Any
+  # drift means an installer changed without its transaction following.
+  status=0
+  derived=$(mktemp)
+  committed=$(mktemp)
+  trap 'rm -f "$derived" "$committed"' EXIT
+  for id in "${ordered_ids[@]}"; do
+    printf '%s|%s\n' "$id" "${transactions[$id]}"
+  done | sort >"$derived"
+  grep -v '^#' "$check_file" | grep '^[a-z]' | sort >"$committed"
+  if ! diff -u "$committed" "$derived"; then
+    echo "Drift detected between install recipes and $check_file." >&2
+    echo "Update the manifest to match what the installers really request," >&2
+    echo "or run test/generate-optional-transactions to see the full derivation." >&2
+    status=1
+  fi
+  exit "$status"
+fi
 
 {
   echo "# Menu id|Complete pacman transaction requested by the optional installer"

--- a/test/generate-optional-transactions
+++ b/test/generate-optional-transactions
@@ -1,0 +1,356 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+menu="$ROOT/default/omarchy/omarchy-menu.jsonc"
+out_file="${1:-$ROOT/install/optional-packages.tsv}"
+apply_guards=0
+if [[ ${1:-} == "--apply-guards" ]]; then
+  apply_guards=1
+  out_file="$ROOT/install/optional-packages.tsv"
+fi
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+[[ -r $menu ]] || die "Menu is unreadable: $menu"
+
+# Menu ids that must never enter the sync-package manifest: they install
+# through the AUR helper instead and carry an [AUR] label on purpose.
+declare -A aur_only_ids=(
+  [install.service.nordvpn]=1
+)
+
+# Names a recipe mentions but does not require unconditionally: architecture
+# alternates picked at runtime or optional enhancements installed only when
+# already published. Transactions describe what must be available for the
+# menu row to work, so these stay out.
+declare -A excluded_names=(
+  [omazed]=1
+  [linux-headers]=1
+  [linux-asahi-headers]=1
+)
+
+# Variable-argument recipes fall back to an explicit base package rather
+# than being guessed by the extractor. Recipes whose case arms delegate to
+# shell functions cannot be arm-extracted either, so they carry their
+# transaction here; the CI recipe audit still cross-checks every name.
+declare -A override_ids=(
+  [install.ai.ollama]=ollama
+  [install.gaming.geforce-now]=flatpak
+  [install.terminal.alacritty]=alacritty
+  [install.terminal.foot]=foot
+  [install.terminal.ghostty]=ghostty
+  [install.terminal.kitty]=kitty
+  [install.ai.dictation]=voxtype-bin
+  [install.development.rails]="libyaml"
+  [install.development.php.php]="php composer php-sqlite xdebug"
+  [install.development.php.laravel]="php composer php-sqlite xdebug"
+  [install.development.php.symfony]="php composer php-sqlite xdebug symfony-cli"
+)
+
+# Menu rows whose toolchain installs through mise, curl, or archives instead
+# of pacman: there is no package transaction to declare.
+declare -A no_transaction_ids=(
+  [install.service.chromium-account]=1
+  [install.development.docker-dbs]=1
+  [install.gaming.xbox-cloud]=1
+  [install.development.go]=1
+  [install.development.java]=1
+  [install.development.dotnet]=1
+  [install.development.ocaml]=1
+  [install.development.scala]=1
+  [install.development.elixir.elixir]=1
+  [install.development.elixir.phoenix]=1
+  [install.development.javascript.node]=1
+  [install.development.javascript.bun]=1
+  [install.development.javascript.deno]=1
+  [install.development.python]=1
+  [install.development.rust]=1
+  [install.development.zig]=1
+)
+
+tokenize_action() {
+  local s="$1" cur="" i char in_quotes=0
+
+  for (( i = 0; i < ${#s}; i += 1 )); do
+    char=${s:i:1}
+    if [[ $char == "'" ]]; then
+      in_quotes=$((1 - in_quotes))
+      continue
+    fi
+    if (( in_quotes == 0 )) && [[ $char == *[[:space:]]* ]]; then
+      if [[ -n $cur ]]; then
+        printf '%s\n' "$cur"
+        cur=""
+      fi
+      continue
+    fi
+    cur+=$char
+  done
+  [[ -n $cur ]] && printf '%s\n' "$cur"
+}
+
+# Extract literal package names from a recipe script. Backslash continuations
+# are joined first, comments dropped, and shell metacharacters end a command.
+extract_script_names() {
+  local script="$1" selector="${2:-}" joined
+
+  # Join backslash continuations so multi-line helper calls parse whole.
+  joined=$(sed -e ':join' -e '/\\$/{N; s/\\\n//; bjoin' -e '}' "$script")
+
+  awk -v quote="'" -v want="$selector" '
+    function flush_command(line, rest, count, token, i, stopped, t) {
+      count = split(rest, token, /[[:space:]]+/)
+      stopped = 0
+      for (i = 1; i <= count; i++) {
+        t = token[i]
+        if (substr(t, 1, 1) == quote) {
+          t = substr(t, 2)
+        }
+        if (substr(t, length(t), 1) == quote) {
+          t = substr(t, 1, length(t) - 1)
+        }
+        if (t == "") {
+          continue
+        }
+        if (t ~ /^[|#;&)<]/) {
+          break
+        }
+        if (match(t, /[;&|<>]/)) {
+          t = substr(t, 1, RSTART - 1)
+          if (t != "") {
+            print t
+          }
+          stopped = 1
+          break
+        }
+        print t
+      }
+      return stopped
+    }
+    BEGIN {
+      in_arm = 0
+    }
+    {
+      line = $0
+      sub(/#.*/, "", line)
+      if (want != "") {
+        # Case arms key on the selector passed by the menu action.
+        arm_pattern = "^[[:space:]]*" quote "?" want quote "?[[:space:]]*\\)"
+        if (!in_arm && line ~ arm_pattern) {
+          in_arm = 1
+        }
+        if (in_arm) {
+          arm_ends = line ~ /;;/
+          if (arm_ends) {
+            sub(/;;.*/, "", line)
+          }
+        } else {
+          next
+        }
+      }
+
+      while (match(line, /omarchy-pkg-(aur-)?add[[:space:]]+/)) {
+        rest = substr(line, RSTART + RLENGTH)
+        if (flush_command(line, rest)) {
+          line = ""
+        } else {
+          break
+        }
+      }
+
+      if (in_arm && arm_ends) {
+        exit
+      }
+    }
+  ' <<<"$joined"
+}
+
+declare -A transactions=()
+declare -a ordered_ids=()
+
+record() {
+  local id="$1" name="$2"
+
+  # Variable indirections are resolved through explicit overrides instead.
+  [[ $name == *'$'* ]] && return 0
+  [[ ${excluded_names[$name]:-} ]] && return 0
+  if [[ -z ${transactions[$id]:-} ]]; then
+    transactions[$id]="$name"
+    ordered_ids+=("$id")
+  else
+    case "|${transactions[$id]}|" in
+      *"|$name|"*) ;;
+      *) transactions[$id]+=" $name" ;;
+    esac
+  fi
+}
+
+# Rows whose packages sit directly in the menu action. Every command shape
+# carries the packages right after the display label.
+direct_action_row() {
+  local id="$1" action="$2" kind token second
+
+  if [[ $action == *"omarchy-install-and-launch"* ]]; then
+    kind="omarchy-install-and-launch"
+    second=1
+  elif [[ $action == *"omarchy-install-app"* ]]; then
+    kind="omarchy-install-app"
+    second=1
+  elif [[ $action == *"omarchy-install-font "* ]]; then
+    kind="omarchy-install-font"
+    second=1
+  else
+    return 1
+  fi
+
+  local -a tokens=()
+  while IFS= read -r token; do
+    tokens+=("$token")
+  done < <(tokenize_action "${action#*"$kind"}")
+
+  if (( ${#tokens[@]} > second )); then
+    for token in ${tokens[second]}; do
+      record "$id" "$token"
+    done
+    return 0
+  fi
+  return 1
+}
+
+# Rows invoking a recipe script; argument-taking scripts select a case arm.
+script_action_row() {
+  local id="$1" action="$2"
+  local -a tokens=()
+  local token script selector
+
+  local probe="${action#*omarchy-launch-floating-terminal-with-presentation }"
+  probe="${probe#\'}"
+  probe="${probe%\'}"
+  probe="${probe#omarchy-install-and-launch *}"
+  while IFS= read -r token; do
+    tokens+=("$token")
+  done < <(tokenize_action "$probe")
+
+  local command_name="${tokens[0]:-}"
+  [[ $command_name == omarchy-install-* || $command_name == omarchy-voxtype-install ]] || return 1
+
+  selector=""
+  case "$(basename "$command_name")" in
+    omarchy-install-browser | omarchy-install-terminal | omarchy-install-dev-env | omarchy-install-font)
+      selector="${tokens[1]:-}"
+      ;;
+  esac
+
+  script="$ROOT/bin/$command_name"
+  [[ -x $script ]] || return 1
+
+  local found=0
+  while IFS= read -r token; do
+    record "$id" "$token"
+    found=1
+  done < <(extract_script_names "$script" "$selector")
+  (( found )) && return 0
+  return 1
+}
+
+resolve_row() {
+  local id="$1" action="$2"
+
+  [[ ${aur_only_ids[$id]:-} || ${no_transaction_ids[$id]:-} ]] && return 0
+  if [[ ${override_ids[$id]:-} ]]; then
+    local override_name
+    for override_name in ${override_ids[$id]}; do
+      record "$id" "$override_name"
+    done
+    return 0
+  fi
+  if direct_action_row "$id" "$action"; then
+    return 0
+  fi
+  script_action_row "$id" "$action" && return 0
+  die "Could not derive a package transaction for $id"
+}
+
+while IFS=$'\t' read -r id action; do
+  [[ -n $id ]] || continue
+  resolve_row "$id" "$action"
+done < <(
+  # Line-oriented extraction instead of a JSONC parser: comment text may hold
+  # anything, while action values contain no double quotes of their own.
+  awk '
+    /"action":"[^"]*omarchy-install/ {
+      id = ""
+      act = ""
+      if (match($0, /^[[:space:]]*"[^"]+"/)) {
+        id = substr($0, RSTART, RLENGTH)
+        gsub(/[[:space:]]/, "", id)
+        gsub(/^"|"$/, "", id)
+      }
+      if (match($0, /"action":"[^"]*"/)) {
+        act = substr($0, RSTART + 10, RLENGTH - 11)
+      }
+      if (id != "" && act != "") {
+        print id "\t" act
+      }
+    }
+  ' "$menu"
+)
+
+# Overrides for rows the menu matcher cannot see live here so their position
+# stays deterministic regardless of associative-array iteration order.
+while IFS= read -r id; do
+  [[ ${transactions[$id]+set} ]] || resolve_row "$id" ""
+done < <(printf '%s\n' "${!override_ids[@]}" | sort)
+
+(( ${#ordered_ids[@]} > 0 )) || die "No transactions were derived"
+
+{
+  echo "# Menu id|Complete pacman transaction requested by the optional installer"
+  echo "# Generated by test/generate-optional-transactions; regenerate instead of editing."
+  for id in "${ordered_ids[@]}"; do
+    printf '%s|%s\n' "$id" "${transactions[$id]}"
+  done
+} >"$out_file"
+
+echo "Wrote ${#ordered_ids[@]} transactions to $out_file"
+
+if (( apply_guards )); then
+  # Prefix each guarded row's existing condition; rows without one get a
+  # standalone guard. AUR-labelled rows never enter the manifest, so they
+  # keep their plain presence checks.
+  awk -F'|' '
+    FNR == NR {
+      if ($0 !~ /^#/) {
+        id = $0
+        sub(/\|.*/, "", id)
+        guard[id] = 1
+      }
+      next
+    }
+    {
+      id = ""
+      if (match($0, /^[[:space:]]*"[^"]+"/)) {
+        id = substr($0, RSTART, RLENGTH)
+        gsub(/[[:space:]]/, "", id)
+        gsub(/^"|"$/, "", id)
+      }
+      if (id != "" && guard[id] && $0 ~ /"action"/ && $0 !~ /omarchy-install-available/) {
+        # "&" expands to the match inside an awk replacement, so literal
+        # ampersands must be escaped.
+        if ($0 ~ /"when":"/) {
+          sub(/"when":"/, "&omarchy-install-available " id " \\&\\& ")
+        } else {
+          sub(/\{/, "&\"when\":\"omarchy-install-available " id "\",")
+        }
+      }
+      print
+    }
+  ' "$out_file" "$menu" >"$menu.tmp"
+  mv "$menu.tmp" "$menu"
+  echo "Applied guards to $menu"
+fi

--- a/test/packages-install-transaction
+++ b/test/packages-install-transaction
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+usage() {
+  echo "Usage: packages-install-transaction MANIFEST..." >&2
+}
+
+(( $# > 0 )) || { usage; exit 2; }
+
+command -v pacman >/dev/null || die "packages-install-transaction requires pacman"
+
+# Packages that never come from this transaction: release-bundle archives and
+# packages makepkg-built from the omarchy-pkgs checkout afterwards. Read both
+# sets from the fresh installer to keep a single source of truth.
+installer="$ROOT/bin/omarchy-install-asahi-fresh"
+[[ -r $installer ]] || die "Fresh installer is unavailable: $installer"
+bundle_line=$(sed -n 's/^expected_packages=(\(.*\))$/\1/p' "$installer")
+[[ -n $bundle_line ]] || die "Could not read the release bundle packages from $installer"
+source_names=$(awk '
+  /^source_packages=\(/ {
+    inside = 1
+    sub(/^source_packages=\(/, "")
+  }
+  inside {
+    if (sub(/\).*/, "")) {
+      done = 1
+    }
+    for (i = 1; i <= NF; i++) print $i
+    if (done) exit
+  }
+' "$installer")
+[[ -n $source_names ]] || die "Could not read the source-built packages from $installer"
+
+declare -A excluded_packages=()
+for package in $bundle_line $source_names; do
+  excluded_packages[$package]=1
+done
+
+# OMARCHY_TRANSACTION_IGNORE lists manifest entries a platform must skip for
+# now, mirroring the fresh installer's --ignore handling. The active list and
+# its reason live beside the invocation in the workflow.
+declare -A ignored_packages=()
+for package in ${OMARCHY_TRANSACTION_IGNORE:-}; do
+  ignored_packages[$package]=1
+done
+
+declare -A seen=()
+packages=()
+ignored=0
+for manifest in "$@"; do
+  [[ -r $manifest ]] || die "Manifest is unreadable: $manifest"
+  malformed=$(awk '{ sub(/#.*/, "") } NF > 1 { print FILENAME ":" FNR ": " $0 }' "$manifest")
+  [[ -z $malformed ]] || die "Manifest lines must hold exactly one package name:"$'\n'"$malformed"
+
+  while IFS= read -r entry; do
+    [[ ${excluded_packages[$entry]:-} ]] && continue
+    [[ ${seen[$entry]:-} ]] && continue
+    seen[$entry]=1
+    if [[ ${ignored_packages[$entry]:-} ]]; then
+      (( ignored += 1 ))
+    else
+      packages+=("$entry")
+    fi
+  done < <(awk '{ sub(/#.*/, ""); if (NF == 1) print $1 }' "$manifest")
+done
+
+(( ${#packages[@]} > 0 )) || die "No repository packages remain to install"
+
+# A bare Arch Linux ARM root filesystem boots its own kernel, which conflicts
+# with the Apple Silicon kernels these manifests describe. Real installations
+# replace it during platform bootstrap; drop it here when present so a
+# container check starts from the same state.
+if pacman -Qi linux-aarch64 >/dev/null 2>&1; then
+  echo "Removing the stock Arch Linux ARM kernel"
+  pacman -Rns --noconfirm linux-aarch64
+fi
+
+echo "Installing ${#packages[@]} packages in a single transaction ($ignored ignored)"
+exec pacman -Syu --needed --noconfirm "${packages[@]}"

--- a/test/packages-install-transaction
+++ b/test/packages-install-transaction
@@ -78,6 +78,7 @@ done
 # with the Apple Silicon kernels these manifests describe. Real installations
 # replace it during platform bootstrap; drop it here when present so a
 # container check starts from the same state.
+pacman -Sy >/dev/null
 if pacman -Qi linux-aarch64 >/dev/null 2>&1; then
   echo "Removing the stock Arch Linux ARM kernel"
   pacman -Rns --noconfirm linux-aarch64

--- a/test/packages-resolve
+++ b/test/packages-resolve
@@ -1,0 +1,479 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+usage() {
+  echo "Usage: packages-resolve MANIFEST..." >&2
+  echo "       packages-resolve --recipes" >&2
+}
+
+recipes_mode=0
+if [[ ${1:-} == "--recipes" ]]; then
+  recipes_mode=1
+  shift
+fi
+
+if (( recipes_mode )); then
+  (( $# == 0 )) || { usage; exit 2; }
+else
+  (( $# > 0 )) || { usage; exit 2; }
+fi
+
+for tool in pacman curl jq; do
+  command -v "$tool" >/dev/null || die "packages-resolve requires $tool"
+done
+
+# Some packages never come from pacman repositories: release-bundle archives
+# and packages makepkg-built from the omarchy-pkgs checkout during install.
+# Read both sets from the fresh installer to keep a single source of truth.
+installer="$ROOT/bin/omarchy-install-asahi-fresh"
+[[ -r $installer ]] || die "Fresh installer is unavailable: $installer"
+bundle_line=$(sed -n 's/^expected_packages=(\(.*\))$/\1/p' "$installer")
+[[ -n $bundle_line ]] || die "Could not read the release bundle packages from $installer"
+source_names=$(awk '
+  /^source_packages=\(/ {
+    inside = 1
+    sub(/^source_packages=\(/, "")
+  }
+  inside {
+    if (sub(/\).*/, "")) {
+      done = 1
+    }
+    for (i = 1; i <= NF; i++) print $i
+    if (done) exit
+  }
+' "$installer")
+[[ -n $source_names ]] || die "Could not read the source-built packages from $installer"
+
+declare -A provided_packages=()
+for package in $bundle_line $source_names; do
+  provided_packages[$package]=1
+done
+
+# Packages published through the project's own PKGBUILD collection also count
+# as resolved; one directory listing covers every name.
+PKGS_REPO=${OMARCHY_PKGS_REPO:-maralcbr/omarchy-pkgs}
+pkgs_names() {
+  local listing="" attempt auth_args=()
+
+  [[ -n ${GH_TOKEN:-} ]] && auth_args=(-H "Authorization: Bearer $GH_TOKEN")
+  for attempt in 1 2 3; do
+    if listing=$(curl -fsSL --max-time 60 "${auth_args[@]}" \
+      "https://api.github.com/repos/$PKGS_REPO/contents/pkgbuilds" 2>/dev/null |
+      jq -r '.[].name'); then
+      printf '%s\n' "$listing"
+      return 0
+    fi
+    (( attempt < 3 )) && sleep 5
+  done
+  return 1
+}
+
+pkgs_listing=$(pkgs_names) || die "Could not list the $PKGS_REPO pkgbuilds"
+declare -A project_packages=()
+while IFS= read -r name; do
+  if [[ -n $name ]]; then
+    project_packages[$name]=1
+  fi
+done <<<"$pkgs_listing"
+
+# x86 manifests stay byte-compatible with upstream Omarchy, which publishes a
+# few of their entries through its own infrastructure rather than any public
+# repository or the AUR. They cannot resolve here but must not block this
+# fork's checks, so they only ever fail when reintroduced into an Asahi
+# manifest, which must never carry them.
+declare -A upstream_only_packages=(
+  [nvim]=1
+  [omacalc]=1
+  [ttfx]=1
+  [nvidia-dkms]=1
+  [linux-ptl-headers]=1
+  [yay-debug]=1
+)
+
+# The AUR RPC answers existence queries without cloning anything. Names are
+# batched because large single requests exceed comfortable URL lengths.
+aur_lookup() {
+  local names=("$@")
+  local hits="" start attempt response chunk_args name
+
+  for (( start = 0; start < ${#names[@]}; start += 100 )); do
+    chunk_args=()
+    for name in "${names[@]:$start:100}"; do
+      chunk_args+=(--data-urlencode "arg[]=$name")
+    done
+    response=""
+    for attempt in 1 2 3; do
+      if response=$(curl -fsSL --max-time 60 --get \
+        'https://aur.archlinux.org/rpc/v5/info' "${chunk_args[@]}" 2>/dev/null); then
+        break
+      fi
+      (( attempt < 3 )) && sleep 5
+    done
+    [[ -n $response ]] || return 1
+    [[ $(jq -r '.type' <<<"$response") == "multiinfo" ]] || return 1
+    hits+=$(jq -r '[.results[].Name] | join("\n")' <<<"$response")$'\n'
+  done
+
+  printf '%s' "$hits"
+}
+
+pacman -Sy >/dev/null || die "Could not synchronize package databases"
+
+# Resolve every named candidate against the configured repositories, the
+# project PKGBUILD collection, and the AUR. Fills the R_* outputs for the
+# caller's own reporting. When R_SPLIT_PROJECT is 1, names that only exist
+# as project PKGBUILDs are reported separately instead of counting as
+# resolved: a recipe calling pacman cannot install them until they are
+# published, while manifests can, since install builds them afterwards.
+declare -a R_UNRESOLVED=() R_PROJECT_NAMES=()
+R_REPO_COUNT=0
+R_PROJECT_COUNT=0
+R_AUR_COUNT=0
+R_SPLIT_PROJECT=0
+resolve_batch() {
+  local -a misses=() aur_candidates=()
+  local entry miss name
+  declare -A aur_seen=() project_seen=()
+
+  R_UNRESOLVED=()
+  R_PROJECT_NAMES=()
+  R_REPO_COUNT=$#
+  R_PROJECT_COUNT=0
+  R_AUR_COUNT=0
+
+  for entry in "$@"; do
+    pacman -Si "$entry" >/dev/null 2>&1 || misses+=("$entry")
+  done
+  R_REPO_COUNT=$((R_REPO_COUNT - ${#misses[@]}))
+
+  for miss in "${misses[@]}"; do
+    if [[ ${project_packages[$miss]:-} ]]; then
+      project_seen[$miss]=1
+      R_PROJECT_NAMES+=("$miss")
+    else
+      aur_candidates+=("$miss")
+    fi
+  done
+  R_PROJECT_COUNT=${#R_PROJECT_NAMES[@]}
+
+  if (( ${#aur_candidates[@]} > 0 )); then
+    local reply
+    reply=$(aur_lookup "${aur_candidates[@]}") ||
+      die "The AUR RPC endpoint could not be reached"
+    while IFS= read -r name; do
+      if [[ -n $name ]]; then
+        aur_seen[$name]=1
+      fi
+    done <<<"$reply"
+    R_AUR_COUNT=${#aur_seen[@]}
+  fi
+
+  for miss in "${misses[@]}"; do
+    if [[ -z ${project_seen[$miss]:-} && -z ${aur_seen[$miss]:-} ]]; then
+      R_UNRESOLVED+=("$miss")
+    elif (( R_SPLIT_PROJECT )) && [[ ${project_seen[$miss]:-} ]]; then
+      R_UNRESOLVED+=("$miss")
+    fi
+  done
+}
+
+if (( ! recipes_mode )); then
+  status=0
+  for manifest in "$@"; do
+    [[ -r $manifest ]] || die "Manifest is unreadable: $manifest"
+    malformed=$(awk '{ sub(/#.*/, "") } NF > 1 { print FILENAME ":" FNR ": " $0 }' "$manifest")
+    [[ -z $malformed ]] || die "Manifest lines must hold exactly one package name:"$'\n'"$malformed"
+
+    mapfile -t entries < <(awk '{ sub(/#.*/, ""); if (NF == 1) print $1 }' "$manifest")
+
+    candidates=()
+    provided=0
+    upstream=0
+    pc_manifest=$(basename "$manifest")
+    for entry in "${entries[@]}"; do
+      if [[ ${provided_packages[$entry]:-} ]]; then
+        (( provided += 1 ))
+      elif [[ $pc_manifest != *-asahi.packages && ${upstream_only_packages[$entry]:-} ]]; then
+        (( upstream += 1 ))
+      else
+        candidates+=("$entry")
+      fi
+    done
+
+    resolve_batch "${candidates[@]}"
+
+    printf '%s: %d entries (%d repositories, %d project, %d AUR, %d provided during install, %d upstream-only, %d unresolved)\n' \
+      "$pc_manifest" \
+      "${#entries[@]}" \
+      "$R_REPO_COUNT" \
+      "$R_PROJECT_COUNT" \
+      "$R_AUR_COUNT" \
+      "$provided" \
+      "$upstream" \
+      "${#R_UNRESOLVED[@]}"
+    for unresolved_name in "${R_UNRESOLVED[@]}"; do
+      printf '  missing: %s\n' "$unresolved_name" >&2
+    done
+    (( ${#R_UNRESOLVED[@]} == 0 )) || status=1
+  done
+
+  (( status == 0 )) || echo "Unresolvable packages were found." >&2
+  exit "$status"
+fi
+
+# Recipe audit: collect every literal package name handed to the package
+# helpers by the optional install recipes and the install menu, then resolve
+# them against the Asahi ecosystem. Variables stay out of the results and are
+# reported for manual review instead of being guessed.
+declare -A recipe_origins=()
+declare -a recipe_manual=()
+
+record_recipe_name() {
+  local origin="$1" name="$2"
+
+  [[ ${recipe_origins[$name]+set} ]] || recipe_origins[$name]=""
+  recipe_origins[$name]+="${recipe_origins[$name]:+, }$origin"
+}
+
+scan_recipe_scripts() {
+  local script joined origin name
+  local -a scripts=()
+
+  shopt -s nullglob
+  for script in "$ROOT"/bin/omarchy-install-*; do
+    case "$(basename "$script")" in
+      omarchy-install-asahi-fresh | omarchy-install-and-launch | omarchy-install-app) continue ;;
+    esac
+    scripts+=("$script")
+  done
+  shopt -u nullglob
+
+  for script in "${scripts[@]}"; do
+    origin="bin/$(basename "$script")"
+    # Join backslash continuations so multi-line helper calls parse whole,
+    # then hand each command's arguments to the tokenizer below.
+    joined=$(sed -e ':join' -e '/\\$/{N; s/\\\n//; bjoin' -e '}' "$script")
+    while IFS=$'\t' read -r kind payload; do
+      if [[ $kind == "name" ]]; then
+        record_recipe_name "$origin" "$payload"
+      else
+        recipe_manual+=("$payload")
+      fi
+    done < <(
+      awk -v file="$origin" -v quote="'" '
+        {
+          line = $0
+          sub(/#.*/, "", line)
+          while (match(line, /omarchy-pkg-(aur-)?add[[:space:]]+/)) {
+            rest = substr(line, RSTART + RLENGTH)
+            count = split(rest, token, /[[:space:]]+/)
+            stopped = 0
+            for (i = 1; i <= count; i++) {
+              t = token[i]
+              if (substr(t, 1, 1) == quote) {
+                t = substr(t, 2)
+              }
+              if (substr(t, length(t), 1) == quote) {
+                t = substr(t, 1, length(t) - 1)
+              }
+              if (t == "") {
+                continue
+              }
+              if (t ~ /^[|#;&)<]/) {
+                break
+              }
+              # A shell metacharacter anywhere ends the command: keep the
+              # name prefix when one exists ("omawrite; then") and stop.
+              if (match(t, /[;&|<>]/)) {
+                t = substr(t, 1, RSTART - 1)
+                if (t ~ /\$|[`>(]/) {
+                  printf "manual\t%s: variable argument\n", file
+                } else if (t != "") {
+                  printf "name\t%s\n", t
+                }
+                stopped = 1
+                break
+              }
+              if (t ~ /\$|[`>(]/) {
+                printf "manual\t%s: variable argument\n", file
+                stopped = 1
+                break
+              }
+              printf "name\t%s\n", t
+            }
+            if (!stopped) {
+              line = ""
+            } else {
+              break
+            }
+          }
+        }
+      ' <(printf '%s\n' "$joined")
+    )
+  done
+}
+
+scan_menu_actions() {
+  local menu="$ROOT/default/omarchy/omarchy-menu.jsonc"
+  [[ -r $menu ]] || return 0
+
+  # Split on whitespace outside single quotes; actions never use any other
+  # quoting, and xargs behaves differently across BSD and GNU builds.
+  tokenize_action() {
+    local s="$1" cur="" i char in_quotes=0
+
+    for (( i = 0; i < ${#s}; i += 1 )); do
+      char=${s:i:1}
+      if [[ $char == "'" ]]; then
+        in_quotes=$((1 - in_quotes))
+        continue
+      fi
+      if (( in_quotes == 0 )) && [[ $char == *[[:space:]]* ]]; then
+        if [[ -n $cur ]]; then
+          printf '%s\n' "$cur"
+          cur=""
+        fi
+        continue
+      fi
+      cur+=$char
+    done
+    [[ -n $cur ]] && printf '%s\n' "$cur"
+  }
+
+  local row_id action tail_command kind second token
+  local -a tokens=()
+  while IFS=$'\t' read -r row_id action; do
+    [[ -n $row_id ]] || continue
+    if [[ $action == *"omarchy-install-and-launch"* ]]; then
+      kind="omarchy-install-and-launch"
+    elif [[ $action == *"omarchy-install-app"* ]]; then
+      kind="omarchy-install-app"
+    else
+      continue
+    fi
+    # In both menu commands the packages follow the display label.
+    second=1
+    tail_command="${action#*"$kind"}"
+    # JSONC escapes quotes inside actions ("$var"); drop the escapes and any
+    # leftover escapes so the tokenizer sees the raw shell text.
+    tail_command=${tail_command//\\\"/}
+    tail_command=${tail_command//\\/}
+
+    tokens=()
+    while IFS= read -r token; do
+      tokens+=("$token")
+    done < <(tokenize_action "$tail_command")
+
+    if (( ${#tokens[@]} <= second )) || [[ ${tokens[second]} == *'$'* ]]; then
+      recipe_manual+=("default/omarchy/omarchy-menu.jsonc:$row_id: variable or unreadable package list")
+      continue
+    fi
+    for token in ${tokens[second]}; do
+      record_recipe_name "menu:$row_id" "$token"
+    done
+  done < <(
+    # Line-oriented extraction instead of a JSONC parser: actions hold no
+    # double quotes, while comment text may.
+    awk '
+      /omarchy-install-(and-launch|app)/ {
+        id = ""
+        act = ""
+        if (match($0, /^[[:space:]]*"[^"]+"/)) {
+          id = substr($0, RSTART, RLENGTH)
+          gsub(/[[:space:]]/, "", id)
+          gsub(/^"|"$/, "", id)
+        }
+        if (match($0, /"action":"[^"]*"/)) {
+          act = substr($0, RSTART + 10, RLENGTH - 11)
+        }
+        if (id != "" && act != "") {
+          print id "\t" act
+        }
+      }
+    ' "$menu"
+  )
+}
+
+scan_recipe_scripts
+scan_menu_actions
+
+(( ${#recipe_origins[@]} > 0 )) || die "No recipe package names were extracted"
+
+mapfile -t unique_names < <(printf '%s\n' "${!recipe_origins[@]}" | sort)
+
+declare -A provided_hits=()
+resolved_names=()
+publishable_names=()
+no_source_names=()
+candidates=()
+for name in "${unique_names[@]}"; do
+  if [[ ${provided_packages[$name]:-} ]]; then
+    provided_hits[$name]=1
+  else
+    candidates+=("$name")
+  fi
+done
+
+R_SPLIT_PROJECT=1
+resolve_batch "${candidates[@]}"
+declare -A unresolved_seen=()
+for name in "${R_UNRESOLVED[@]}"; do
+  unresolved_seen[$name]=1
+done
+for name in "${candidates[@]}"; do
+  if [[ ${unresolved_seen[$name]:-} ]]; then
+    if [[ ${project_packages[$name]:-} ]]; then
+      publishable_names+=("$name")
+    else
+      no_source_names+=("$name")
+    fi
+  else
+    resolved_names+=("$name")
+  fi
+done
+
+echo "Recipe audit across ${#unique_names[@]} package names:"
+printf '  %d resolved from repositories or AUR\n' "${#resolved_names[@]}"
+printf '  %d provided during install (release bundle or source-built)' "${#provided_hits[@]}"
+((${#provided_hits[@]} == 0)) && printf ' --'
+printf '\n'
+
+report_category() {
+  local heading="$1"
+  shift
+
+  printf '  %s\n' "$heading"
+  local name
+  for name in "$@"; do
+    printf '    %s <- %s\n' "$name" "${recipe_origins[$name]}"
+  done
+}
+
+if (( ${#publishable_names[@]} > 0 )); then
+  report_category "publishable: a PKGBUILD exists in $PKGS_REPO but no published build" "${publishable_names[@]}"
+else
+  echo "  publishable: none"
+fi
+if (( ${#no_source_names[@]} > 0 )); then
+  report_category "no source anywhere:" "${no_source_names[@]}"
+else
+  echo "  no source anywhere: none"
+fi
+
+if (( ${#recipe_manual[@]} > 0 )); then
+  echo "  manual review:"
+  for manual_entry in "${recipe_manual[@]}"; do
+    printf '    %s\n' "$manual_entry"
+  done
+fi
+
+echo "This audit is informational; unresolved recipe names do not fail the run yet."
+exit 0

--- a/test/shell.d/optional-transactions-drift-test.sh
+++ b/test/shell.d/optional-transactions-drift-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tsv="$ROOT/install/optional-packages.tsv"
+[[ -r $tsv ]] || fail "optional transaction manifest exists: $(basename "$tsv")"
+
+# The manifest is hand-curated upstream, but its contents must keep matching
+# what the recipes really request. Deriving the transactions independently
+# turns silent drift between installers and the manifest into a hard failure.
+drift_out=$(mktemp)
+trap 'rm -f "$drift_out"' EXIT
+if ! bash "$ROOT/test/generate-optional-transactions" --check "$tsv" >"$drift_out" 2>&1; then
+  detail=$(<"$drift_out")
+  fail "optional transaction manifest matches the install recipes" \
+    "the manifest drifted from what the installers request:$detail"
+fi
+pass "optional transaction manifest matches the install recipes"

--- a/test/shell.d/package-manifests-test.sh
+++ b/test/shell.d/package-manifests-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+manifests=(
+  "$ROOT/install/omarchy-base.packages"
+  "$ROOT/install/omarchy-base-asahi.packages"
+  "$ROOT/install/omarchy-other.packages"
+  "$ROOT/install/omarchy-other-asahi.packages"
+)
+
+for manifest in "${manifests[@]}"; do
+  [[ -r $manifest ]] || fail "package manifest exists: $(basename "$manifest")"
+
+  malformed=$(awk '{ sub(/#.*/, "") } NF > 1 { print FNR ": " $0 }' "$manifest")
+  [[ -z $malformed ]] ||
+    fail "manifest lines hold exactly one package name: $(basename "$manifest")" "$malformed"
+
+  invalid=$(awk '{ sub(/#.*/, ""); if (NF == 1 && $1 !~ /^[a-zA-Z0-9_@.+-][a-zA-Z0-9_@.+-]*$/) print FNR ": " $1 }' "$manifest")
+  [[ -z $invalid ]] ||
+    fail "manifest entries are valid package names: $(basename "$manifest")" "$invalid"
+
+  duplicates=$(awk '{ sub(/#.*/, ""); if (NF == 1) seen[$1]++ } END { for (name in seen) if (seen[name] > 1) print name }' "$manifest")
+  [[ -z $duplicates ]] ||
+    fail "manifest has no duplicate packages: $(basename "$manifest")" "$duplicates"
+
+  pass "package manifest is well formed: $(basename "$manifest")"
+done
+
+# The resolver and transaction scripts derive their release-bundle and
+# source-built exemptions from these exact installer lines, so both must
+# survive installer edits.
+grep -Fq 'expected_packages=(omarchy-keyring omarchy-settings-dev omarchy-dev omarchy-nvim quickshell-git ttf-jetbrains-mono-nerd-basic)' \
+  "$ROOT/bin/omarchy-install-asahi-fresh" ||
+  fail "fresh installer retains the release bundle package list"
+pass "fresh installer retains the release bundle package list"
+
+grep -Fq 'source_packages=(' "$ROOT/bin/omarchy-install-asahi-fresh" ||
+  fail "fresh installer retains the source-built package list"
+pass "fresh installer retains the source-built package list"
+
+for script in packages-resolve packages-install-transaction; do
+  [[ -x $ROOT/test/$script ]] || fail "package test script is executable: $script"
+done
+pass "package test scripts are executable"


### PR DESCRIPTION
## Summary

Complements #26/#27 with the continuous-integrity half of #10: a GitHub Actions net that keeps **all four `install/*.packages` manifests** and **the optional transaction manifest** provably in sync with reality, plus proof that each Asahi manifest's dependency closure still installs.

### What's included

| Piece | Purpose |
|---|---|
| `test/packages-resolve` | Resolves every manifest entry against pacman repositories → project PKGBUILD collection → AUR; `--recipes` audits every name referenced by optional installers/menu actions and reports publishable vs sourceless packages |
| `test/packages-install-transaction` | Installs a manifest's full dependency closure in one transaction inside a real Arch Linux ARM rootfs |
| `test/generate-optional-transactions --check` | Derives the complete transaction behind every optional menu row straight from the recipes and diffs it against `install/optional-packages.tsv` |
| `.github/workflows/packages.yml` | Manifest resolution matrix, Asahi closure installs, recipe audit (job summary), weekly schedule, triggered by manifest/recipe changes |

### The anti-drift guarantee for #26's manifest

`optional-packages.tsv` is hand-curated; nothing failed when an installer changed without its entry following. This PR derives the transactions independently from the recipes and compares them as sets. Today's derivation **agrees exactly** with the committed manifest — so any future recipe edit that forgets its manifest entry fails in CI instead of at install time.

### Design notes

- Release-bundle and source-built exemptions are derived from `bin/omarchy-install-asahi-fresh`, never duplicated.
- The official `archlinux` image is x86_64-only, so Apple Silicon jobs import the real ALARM rootfs used by production.
- x86 manifests stay byte-compatible with upstream via a documented exemption list; reintroducing one into an Asahi manifest still fails.
- AUR-backed optional builds are already covered by #26's weekly preflight, so this PR deliberately does not duplicate them.

## Findings from the first real run

- Both Asahi manifests fully resolve; base-asahi's 739-package dependency closure installs cleanly.
- Recipe audit over 116 names: **26 publishable** (PKGBUILDs exist, aarch64 builds missing — `omazed`, `cursor-bin`, `visual-studio-code-bin`, …) and **15 with no source anywhere** (`zed` itself included).
