### PR TITLE
Test optional package installs in Asahi VM

### DIFF
--- a/.github/workflows/optional-packages.yml
+++ b/.github/workflows/optional-packages.yml
@@ -13,8 +13,10 @@ on:
       - 'shell/plugins/menu/MenuModel.js'
       - 'test/optional-packages-live'
       - 'test/shell.d/optional-packages-test.sh'
+      - 'test/shell.d/optional-packages-vm-test.sh'
       - 'test/shell.d/install-editor-zed-test.sh'
       - 'test/shell.d/menu-guards-test.sh'
+      - 'test/vm/asahi-fresh/**'
   workflow_dispatch:
   schedule:
     - cron: '17 5 * * 1'
@@ -31,6 +33,7 @@ jobs:
         run: |
           ./test/cli
           bash test/shell.d/optional-packages-test.sh
+          bash test/shell.d/optional-packages-vm-test.sh
           bash test/shell.d/install-editor-zed-test.sh
           bash test/shell.d/menu-guards-test.sh
 

--- a/test/shell.d/optional-packages-vm-test.sh
+++ b/test/shell.d/optional-packages-vm-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/pacman" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_PACMAN_LOG"
+case $1 in
+  -S)
+    [[ " $* " != *' broken '* ]]
+    ;;
+  -Q)
+    [[ $2 != unregistered ]]
+    ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$test_tmp/bin/pacman"
+
+cat >"$test_tmp/transactions.tsv" <<'EOF'
+install.good|primary secondary
+install.broken|broken
+install.unregistered|unregistered
+EOF
+printf '%s\n' install.good install.broken install.unregistered >"$test_tmp/required"
+
+export OMARCHY_TEST_PACMAN_LOG="$test_tmp/pacman.log"
+set +e
+output=$(PATH="$test_tmp/bin:$PATH" \
+  OMARCHY_OPTIONAL_PACKAGES_FILE="$test_tmp/transactions.tsv" \
+  OMARCHY_OPTIONAL_REQUIRED_FILE="$test_tmp/required" \
+  OMARCHY_OPTIONAL_LOG_DIR="$test_tmp/logs" \
+  bash "$ROOT/test/vm/asahi-fresh/guest/optional-packages" 2>&1)
+status=$?
+set -e
+
+(( status != 0 )) || fail 'optional package VM stage fails when any transaction fails'
+[[ $output == *'1 installed, 2 failed'* ]] ||
+  fail 'optional package VM stage reports every transaction' "$output"
+grep -Fqx -- '-S --noconfirm --needed primary secondary' "$OMARCHY_TEST_PACMAN_LOG" ||
+  fail 'optional package VM stage installs complete transactions'
+grep -Fqx -- '-S --noconfirm --needed broken' "$OMARCHY_TEST_PACMAN_LOG" ||
+  fail 'optional package VM stage continues after a failed transaction'
+grep -Fqx -- '-S --noconfirm --needed unregistered' "$OMARCHY_TEST_PACMAN_LOG" ||
+  fail 'optional package VM stage checks later transactions'
+[[ -f $test_tmp/logs/install-good.log && -f $test_tmp/logs/install-broken.log ]] ||
+  fail 'optional package VM stage retains per-transaction logs'
+pass 'optional package VM stage installs all transactions and reports every failure'
+
+printf '%s\n' install.unknown >"$test_tmp/required"
+if PATH="$test_tmp/bin:$PATH" \
+  OMARCHY_OPTIONAL_PACKAGES_FILE="$test_tmp/transactions.tsv" \
+  OMARCHY_OPTIONAL_REQUIRED_FILE="$test_tmp/required" \
+  OMARCHY_OPTIONAL_LOG_DIR="$test_tmp/logs" \
+  bash "$ROOT/test/vm/asahi-fresh/guest/optional-packages" >/dev/null 2>&1; then
+  fail 'optional package VM stage rejects unknown required transactions'
+fi
+pass 'optional package VM stage rejects unknown required transactions'

--- a/test/vm/asahi-fresh/README.md
+++ b/test/vm/asahi-fresh/README.md
@@ -28,3 +28,10 @@ The guest uses 8 vCPUs, 8 GiB RAM, and a 96 GiB sparse disk.
 Use `--rebuild-base` to discard the cached Arch Linux ARM base and `--keep` to
 retain the VM container after a run. State and failure artifacts are written to
 `test/vm/asahi-fresh/test-runs/`, which is ignored by Git.
+
+Use `--optional-packages` to install every transaction in
+`install/optional-packages-aarch64-required` with real `pacman -S` operations
+after the reboot checks. Each transaction gets a separate log under
+`test-runs/run/optional-package-logs/`. This validates package installation and
+post-install hooks in a disposable system, but it does not automate application
+login, GUI interaction, or hardware behavior.

--- a/test/vm/asahi-fresh/guest/optional-packages
+++ b/test/vm/asahi-fresh/guest/optional-packages
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -u
+
+manifest=${OMARCHY_OPTIONAL_PACKAGES_FILE:-/root/optional-packages.tsv}
+required_file=${OMARCHY_OPTIONAL_REQUIRED_FILE:-/root/optional-packages-aarch64-required}
+log_dir=${OMARCHY_OPTIONAL_LOG_DIR:-/root/optional-package-logs}
+installed=0
+failed=0
+
+declare -A transactions=()
+while IFS='|' read -r id packages; do
+  [[ $id == install.* ]] && transactions[$id]=$packages
+done <"$manifest"
+
+rm -rf "$log_dir"
+mkdir -p "$log_dir"
+
+while read -r id; do
+  [[ $id == install.* ]] || continue
+  packages=${transactions[$id]-}
+  if [[ -z $packages ]]; then
+    printf 'not ok - required transaction is missing from manifest: %s\n' "$id" >&2
+    ((failed++))
+    continue
+  fi
+
+  read -ra package_names <<<"$packages"
+  log="$log_dir/${id//./-}.log"
+  if pacman -S --noconfirm --needed "${package_names[@]}" >"$log" 2>&1; then
+    missing=()
+    for package in "${package_names[@]}"; do
+      pacman -Q "$package" &>/dev/null || missing+=("$package")
+    done
+    if (( ${#missing[@]} == 0 )); then
+      printf 'ok - %s\n' "$id"
+      ((installed++))
+      continue
+    fi
+    printf 'registration check failed: %s\n' "${missing[*]}" >>"$log"
+  fi
+
+  printf 'not ok - %s failed to install (log: %s)\n' "$id" "$log" >&2
+  ((failed++))
+done <"$required_file"
+
+printf '\nOptional VM package installs: %d installed, %d failed\n' "$installed" "$failed"
+(( failed == 0 ))

--- a/test/vm/asahi-fresh/run
+++ b/test/vm/asahi-fresh/run
@@ -11,10 +11,12 @@ ssh_port=${OMARCHY_VM_SSH_PORT:-22222}
 vnc_port=${OMARCHY_VM_VNC_PORT:-25900}
 keep=0
 rebuild=0
+optional_packages=0
 
 while (($#)); do
   case "$1" in
     --keep) keep=1 ;;
+    --optional-packages) optional_packages=1 ;;
     --rebuild-base) rebuild=1 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -104,6 +106,25 @@ ssh "${ssh_args[@]}" root@127.0.0.1 systemctl reboot --no-block || true
 wait_for_reboot "$boot_id" || { tail -200 "$state/run/serial.log"; exit 1; }
 scp "${scp_args[@]}" "$harness/guest/verify" root@127.0.0.1:/root/omarchy-vm-verify
 ssh "${ssh_args[@]}" root@127.0.0.1 bash /root/omarchy-vm-verify | tee "$state/run/verify.log"
+
+if (( optional_packages )); then
+  scp "${scp_args[@]}" \
+    "$root/install/optional-packages.tsv" \
+    root@127.0.0.1:/root/optional-packages.tsv
+  scp "${scp_args[@]}" \
+    "$root/install/optional-packages-aarch64-required" \
+    root@127.0.0.1:/root/optional-packages-aarch64-required
+  scp "${scp_args[@]}" \
+    "$harness/guest/optional-packages" \
+    root@127.0.0.1:/root/omarchy-vm-optional-packages
+
+  optional_status=0
+  ssh "${ssh_args[@]}" root@127.0.0.1 bash /root/omarchy-vm-optional-packages |
+    tee "$state/run/optional-packages.log" || optional_status=$?
+  scp -r "${scp_args[@]}" root@127.0.0.1:/root/optional-package-logs "$state/run/"
+  (( optional_status == 0 )) || exit "$optional_status"
+fi
+
 scp "${scp_args[@]}" "$harness/guest/rerun" root@127.0.0.1:/root/omarchy-vm-rerun
 ssh -tt "${ssh_args[@]}" root@127.0.0.1 bash /root/omarchy-vm-rerun | tee "$state/run/rerun.log"
 


### PR DESCRIPTION
## Summary
- add an opt-in `--optional-packages` stage to the disposable Asahi fresh-install VM harness
- install all 20 required aarch64 transactions with real `pacman -S` operations and verify package registration
- retain one package-manager log per transaction and report every failure instead of stopping at the first
- add deterministic failure aggregation coverage and include it in optional-package PR checks

## Verification
- `./test/cli`
- `./test/shell` (193 test files)
- `test/vm/asahi-fresh/run --optional-packages`
- VM result: 20 installed, 0 failed; fresh lifecycle and safe rerun also passed
- retained logs contained no `error`, `failed`, or `not ok` records