### PR TITLE
fix: leave fresh installs with a UTF-8 system locale

### DIFF
--- a/bin/omarchy-install-asahi-fresh
+++ b/bin/omarchy-install-asahi-fresh
@@ -365,6 +365,7 @@ ln -sfn /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 pacman -Q omarchy-dev omarchy-settings-dev linux-asahi linux-asahi-headers m1n1 networkmanager iwd >/dev/null
 [[ $(cat /usr/share/omarchy/version) == 4.* ]] || fail "Installed Omarchy version is not 4.x"
 NetworkManager --print-config 2>/dev/null | grep -Fxq 'wifi.backend=iwd' || fail "NetworkManager iwd backend was not configured"
+grep -Eqi '^LANG=.*\.(UTF-8|utf8)$' /etc/locale.conf || fail "The system locale is not UTF-8"
 sha256sum --check --status <<<"$asahi_kernel_sha256" || fail "The Asahi kernel changed unexpectedly"
 sha256sum --check --status <<<"$grub_sha256" || fail "The GRUB configuration changed unexpectedly"
 

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -108,6 +108,7 @@ asahi_migration_disposition() {
     1786567036.sh) printf 'skipped\tNetworkManager remains on the validated Asahi iwd backend\n' ;;
     1786605598.sh) printf 'skipped\tNVIDIA Limine initramfs repair is not applicable to Asahi\n' ;;
     1786922691.sh|1787231692.sh) printf 'run\treviewed as architecture-neutral\n' ;;
+    1787491150.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     *) return 1 ;;
   esac
 }

--- a/install/config/all.sh
+++ b/install/config/all.sh
@@ -1,3 +1,4 @@
+run_logged "$OMARCHY_INSTALL/config/locale.sh"
 run_logged "$OMARCHY_INSTALL/config/theme-system.sh"
 run_logged "$OMARCHY_INSTALL/config/increase-lockout-limit.sh"
 run_logged "$OMARCHY_INSTALL/config/lockscreen-pam.sh"

--- a/install/config/locale.sh
+++ b/install/config/locale.sh
@@ -1,0 +1,12 @@
+# The Asahi Arch Minimal base ships /etc/locale.conf with LANG=C, and only the
+# built-in C/C.utf8/POSIX locales are generated. System services then run in a
+# non-UTF-8 locale (SDDM/Qt warn and substitute C.UTF-8 on their own), so seed
+# the neutral UTF-8 default when no regional UTF-8 locale is configured.
+#
+# Direct write rather than localectl: this runs in install contexts (ISO
+# chroot, fresh-install finalization) with no dbus/systemd-localed available.
+if [[ -r /etc/locale.conf ]] && grep -Eqi '^LANG=.*\.(UTF-8|utf8)$' /etc/locale.conf; then
+  return 0
+fi
+
+printf 'LANG=C.UTF-8\n' >/etc/locale.conf

--- a/migrations/1787491150.sh
+++ b/migrations/1787491150.sh
@@ -1,0 +1,13 @@
+echo "Set the system locale to UTF-8 (C.UTF-8) when it is missing"
+
+# Fresh installs from the Asahi base image keep /etc/locale.conf at LANG=C, so
+# system services run non-UTF-8 while user sessions repair themselves. Repair
+# once through localectl, which validates the value and applies it live.
+#
+# Idempotent: a configured UTF-8 locale (any region, any spelling) is left
+# alone; machines without /etc/locale.conf never had the problem.
+if [[ -r /etc/locale.conf ]] && grep -Eqi '^LANG=.*\.(UTF-8|utf8)$' /etc/locale.conf; then
+  exit 0
+fi
+
+sudo localectl set-locale LANG=C.UTF-8

--- a/test/shell.d/locale-test.sh
+++ b/test/shell.d/locale-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+locale_leaf="$ROOT/install/config/locale.sh"
+config_all="$ROOT/install/config/all.sh"
+fresh_installer="$ROOT/bin/omarchy-install-asahi-fresh"
+migration="$ROOT/migrations/1787491150.sh"
+migrate="$ROOT/bin/omarchy-migrate"
+vm_verify="$ROOT/test/vm/asahi-fresh/guest/verify"
+
+bash -n "$locale_leaf" "$fresh_installer" "$migration" "$migrate"
+
+! head -1 "$locale_leaf" | grep -q '^#!' || fail "locale setup leaf stays shebang-free like its sourced siblings"
+grep -Fq "printf 'LANG=C.UTF-8\\n' >/etc/locale.conf" "$locale_leaf" ||
+  fail "locale setup leaf seeds the neutral C.UTF-8 default"
+grep -Fq "grep -Eqi '^LANG=.*\\.(UTF-8|utf8)\$' /etc/locale.conf" "$locale_leaf" ||
+  fail "locale setup leaf keeps an already configured UTF-8 locale"
+if grep -Eq '^[[:space:]]*localectl' "$locale_leaf"; then
+  fail "locale setup leaf avoids localectl so it works from the ISO chroot"
+fi
+pass "install-time locale setup seeds C.UTF-8 without disturbing regional choices"
+
+grep -Fq 'run_logged "$OMARCHY_INSTALL/config/locale.sh"' "$config_all" ||
+  fail "system config wires the locale setup into every install path"
+locale_line=$(grep -n -m1 'config/locale.sh' "$config_all" | cut -d: -f1)
+theme_line=$(grep -n -m1 'config/theme-system.sh' "$config_all" | cut -d: -f1)
+(( locale_line < theme_line )) || fail "locale setup runs before the themed config steps"
+pass "every omarchy-apply-system path applies the UTF-8 locale default"
+
+check_line=$(grep -n -m1 'The system locale is not UTF-8' "$fresh_installer" | cut -d: -f1)
+apply_line=$(grep -n -m1 'omarchy-apply-system --install-user "$target_user" --first-install' "$fresh_installer" | cut -d: -f1)
+alarm_line=$(grep -n -m1 'usermod -L alarm' "$fresh_installer" | cut -d: -f1)
+(( apply_line < check_line && check_line < alarm_line )) ||
+  fail "fresh installer validates the UTF-8 locale after system finalization and before retiring the stock administrator"
+pass "fresh Asahi install refuses to complete with a non-UTF-8 system locale"
+
+[[ -f $migration ]] || fail "existing installs receive the UTF-8 locale repair migration"
+grep -Fq "grep -Eqi '^LANG=.*\\.(UTF-8|utf8)\$' /etc/locale.conf" "$migration" ||
+  fail "UTF-8 locale repair migration keeps an already configured UTF-8 locale"
+grep -Fq 'sudo localectl set-locale LANG=C.UTF-8' "$migration" ||
+  fail "UTF-8 locale repair migration goes through localectl"
+disposition=$(grep '1787491150.sh)' "$migrate") ||
+  fail "UTF-8 locale repair migration is registered in the Asahi dispositions"
+[[ $disposition == *"printf 'run"* && $disposition == *'reviewed as architecture-neutral'* ]] ||
+  fail "UTF-8 locale repair migration is reviewed for Apple Silicon"
+pass "existing LANG=C installs are repaired through a reviewed migration"
+
+grep -Fq 'system locale is not UTF-8' "$vm_verify" ||
+  fail "fresh-install VM verification asserts the UTF-8 system locale"
+pass "fresh-install VM regression asserts the configured locale is UTF-8"

--- a/test/vm/asahi-fresh/guest/verify
+++ b/test/vm/asahi-fresh/guest/verify
@@ -27,6 +27,7 @@ done
 [[ ! -L /etc/systemd/system/graphical.target.wants/omarchy-seamless-login.service ]] || fail "legacy seamless login remains enabled"
 [[ ! -e /usr/local/bin/seamless-login ]] || fail "legacy seamless login helper remains"
 NetworkManager --print-config | grep -Fxq 'wifi.backend=iwd' || fail "iwd backend"
+grep -Eqi '^LANG=.*\.(UTF-8|utf8)$' /etc/locale.conf || fail "system locale is not UTF-8"
 pacman-conf --repo-list | grep -Fxq asahi-alarm || fail "Asahi repository"
 [[ -f /boot/Image && -f /boot/vmlinuz-linux-asahi && -f /boot/grub/grub.cfg ]] || fail "boot payloads"
 (( $(swapon --show --noheadings | wc -l) == 0 )) || fail "swap disabled"


### PR DESCRIPTION
Fixes #30

## Problem

A fresh install keeps `/etc/locale.conf` at `LANG=C` (the Asahi Arch Minimal base default; only `C`/`C.utf8`/`POSIX` are generated). No install path ever corrected it, so system services run non-UTF-8 and SDDM/Qt warn about the `ANSI_X3.4-1968` encoding at every login, substituting `C.UTF-8` themselves. User sessions only paper over it via `default/bash/envs`.

## Fix (4 layers)

1. **Install time** — new `install/config/locale.sh` leaf wired into `install/config/all.sh`: seeds `LANG=C.UTF-8` when no UTF-8 `LANG` is configured, preserving any regional choice (`fr_FR.UTF-8`, `C.utf8`, …). Direct file write instead of `localectl` because `omarchy-apply-system` also runs from the ISO chroot with no dbus/systemd-localed.
2. **Fresh installer invariant** — `bin/omarchy-install-asahi-fresh` refuses to complete when the configured locale is not UTF-8 (alongside its existing iwd/version/kernel-hash checks).
3. **Existing installs** — migration `1787491150.sh` repairs already-deployed machines through `sudo localectl set-locale LANG=C.UTF-8` on next update; registered as `run\treviewed as architecture-neutral` in `bin/omarchy-migrate`.
4. **Regression coverage** — UTF-8 locale assertion in `test/vm/asahi-fresh/guest/verify` plus new `test/shell.d/locale-test.sh`.

## Verification

- `bash test/shell.d/locale-test.sh`: 5/5 assertions pass
- Leaf logic exercised across 4 scenarios: missing file → `C.UTF-8`, `LANG=C` → rewritten, regional UTF-8 preserved verbatim, `C.utf8` preserved
- `asahi-fresh-install-test.sh` still passes
- The signed `omarchy-install-asahi-fresh` asset picks this up at the next stable release build