### PR TITLE
Add versioned changelog and release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ jobs:
           [[ $RELEASE_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-mac\.[0-9]+$ ]]
           [[ $RELEASE_SEQUENCE =~ ^[1-9][0-9]*$ ]]
           git fetch origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          notes_file="docs/releases/$RELEASE_TAG.md"
+          git show "$RELEASE_TAG:$notes_file" > /tmp/release-notes.md
+          grep -Fxq "# Omarchy MX Mac ${RELEASE_TAG#v}" /tmp/release-notes.md
+          grep -Fxq '## Validation' /tmp/release-notes.md
+          grep -Fq '**Full Changelog**:' /tmp/release-notes.md
           latest_tag=$(gh release list --limit 100 --json tagName --jq '.[].tagName' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-mac\.[0-9]+$' | sort -V | tail -1)
           [[ -z $latest_tag || $(printf '%s\n%s\n' "$latest_tag" "$RELEASE_TAG" | sort -V | tail -1) == "$RELEASE_TAG" && $latest_tag != "$RELEASE_TAG" ]]
       - name: Import release key
@@ -79,4 +84,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
-        run: gh release create "$RELEASE_TAG" dist/stable-release/* --verify-tag --title "Omarchy MX Mac ${RELEASE_TAG#v}" --generate-notes
+        run: gh release create "$RELEASE_TAG" dist/stable-release/* --verify-tag --title "Omarchy MX Mac ${RELEASE_TAG#v}" --notes-file /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+Release notes for the maintained Apple Silicon line are version-controlled in
+[`docs/releases/`](docs/releases/). GitHub Releases publish those files
+verbatim.
+
+## [4.0.0-mac.13] - 2026-08-24
+
+- Rebuilt `quickshell-git` against Qt 6.11.2 and raised its package release to
+  ensure existing installations receive the ABI-compatible binary.
+- Published signed Apple Silicon bundle sequence 17 from source commit
+  `59c188fa`.
+- Superseded `4.0.0-mac.12` after real-hardware reboot validation exposed the
+  Quickshell/Qt ABI mismatch.
+
+[Release notes](docs/releases/v4.0.0-mac.13.md) | [Full diff](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.12...v4.0.0-mac.13)
+
+## [4.0.0-mac.12] - 2026-08-23
+
+- Added complete optional-package transaction manifests shared by menu guards,
+  tests, and CI.
+- Added scheduled native-aarch64 package resolution, download, and AUR build
+  validation.
+- Extended the disposable Asahi VM to install and verify all 20 required
+  optional transactions.
+
+[Release notes](docs/releases/v4.0.0-mac.12.md) | [Full diff](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.11...v4.0.0-mac.12)
+
+## [4.0.0-mac.11] - 2026-08-22
+
+- Retired the legacy seamless-login service before enabling SDDM.
+- Added migration repair for affected installations and corrected Quattro
+  upgrade cleanup ordering.
+
+[Release notes](docs/releases/v4.0.0-mac.11.md) | [Full diff](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.10...v4.0.0-mac.11)
+
+## Historical Releases
+
+- [4.0.0-mac.10](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.9...v4.0.0-mac.10) - 2026-08-21
+- [4.0.0-mac.9](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.8...v4.0.0-mac.9) - 2026-08-20
+- [4.0.0-mac.8](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.7...v4.0.0-mac.8) - 2026-08-20
+- [4.0.0-mac.7](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.6...v4.0.0-mac.7) - 2026-08-19
+- [4.0.0-mac.6](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.5...v4.0.0-mac.6) - 2026-08-17
+- [4.0.0-mac.5](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.4...v4.0.0-mac.5) - 2026-08-16
+- [4.0.0-mac.4](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.3...v4.0.0-mac.4) - 2026-08-16
+- [4.0.0-mac.3](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.1...v4.0.0-mac.3) - 2026-08-15
+- [4.0.0-mac.1](https://github.com/maralcbr/omarchy-mx-mac/compare/v3.8.4-mac.4...v4.0.0-mac.1) - 2026-08-15
+
+[4.0.0-mac.13]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.0-mac.13
+[4.0.0-mac.12]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.0-mac.12
+[4.0.0-mac.11]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.0-mac.11

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Run Omarchy on Apple Silicon through Arch Linux ARM and Asahi Linux.
 [![License](https://img.shields.io/github/license/maralcbr/omarchy-mx-mac)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/maralcbr/omarchy-mx-mac?style=social)](https://github.com/maralcbr/omarchy-mx-mac/stargazers)
 
+See the [changelog](CHANGELOG.md) for release history and validation notes.
+
 Omarchy 4 (Quattro) is the maintained release:
 
 | Version | Status | Installation |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,17 @@
+# Release Notes
+
+Each stable Mac release has one curated notes file named after its immutable
+tag, for example `v4.0.0-mac.14.md`. The release workflow publishes that file
+verbatim instead of generating notes from pull request titles.
+
+Release preparation must:
+
+1. Update `version` and the recommended version in `README.md`.
+2. Add the release to `CHANGELOG.md`.
+3. Add `docs/releases/vX.Y.Z-mac.N.md` with user-facing changes, validation,
+   known limitations when applicable, and a full-diff link.
+4. Run `tests/stable-release-test.sh` before creating the tag.
+
+The notes file must exist in the tagged commit. The publishing workflow reads
+it with `git show`, validates its title and required sections, and passes the
+immutable copy to `gh release create --notes-file`.

--- a/docs/releases/v4.0.0-mac.11.md
+++ b/docs/releases/v4.0.0-mac.11.md
@@ -1,0 +1,21 @@
+# Omarchy MX Mac 4.0.0-mac.11
+
+## Fixes
+
+- Retires `omarchy-seamless-login.service` before enabling SDDM, preventing
+  both services from competing for `/dev/tty1`.
+- Repairs affected installations through migration `1787387209.sh`.
+- Corrects Quattro upgrade cleanup ordering and removes dangling systemd
+  enablement links.
+
+Fixes #21.
+
+## Validation
+
+- All 190 source test files passed.
+- Signed six-package Apple Silicon bundle sequence 15 built successfully.
+- The disposable direct-Asahi-install VM passed interruption recovery, fresh
+  installation, reboot verification, SDDM greeter capture, and completed-install
+  rerun rejection.
+
+**Full Changelog**: https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.10...v4.0.0-mac.11

--- a/docs/releases/v4.0.0-mac.12.md
+++ b/docs/releases/v4.0.0-mac.12.md
@@ -1,0 +1,28 @@
+# Omarchy MX Mac 4.0.0-mac.12
+
+## Highlights
+
+- Centralizes complete optional-package transactions for installers, menu
+  availability guards, tests, and CI.
+- Adds scheduled and manual native-aarch64 resolution, download, and AUR build
+  validation.
+- Extends the disposable Asahi VM with an opt-in stage that installs every
+  required optional transaction and retains one package-manager log per
+  transaction.
+
+## Validation
+
+- All 193 shell test files and CLI tests passed.
+- Native aarch64 CI resolved and downloaded the supported transactions and
+  built the NordVPN AUR package.
+- The disposable VM installed and registered all 20 required transactions with
+  no package errors.
+- Visual menu verification confirmed unavailable applications are hidden.
+
+## Known Limitations
+
+- This release was superseded by `4.0.0-mac.13` after real-hardware validation
+  found a Quickshell/Qt ABI mismatch in the package bundle.
+- Zed was unavailable in fresh aarch64 repositories and remained hidden.
+
+**Full Changelog**: https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.11...v4.0.0-mac.12

--- a/docs/releases/v4.0.0-mac.13.md
+++ b/docs/releases/v4.0.0-mac.13.md
@@ -1,0 +1,30 @@
+# Omarchy MX Mac 4.0.0-mac.13
+
+## Highlights
+
+- Rebuilds `quickshell-git` against Qt 6.11.2 and raises the package release to
+  `0.3.0.r20.g28771c7-2`, ensuring existing installations receive the
+  ABI-compatible binary.
+- Publishes signed Apple Silicon bundle sequence 17 from source commit
+  `59c188fa`.
+- Supersedes `4.0.0-mac.12`, whose real-hardware validation exposed the Qt ABI
+  mismatch before the release checkpoint was accepted.
+
+## Validation
+
+- All 193 shell test files and CLI tests passed.
+- Stable source assets and the exact six-package bundle passed GPG signature
+  and SHA-256 verification.
+- A disposable aarch64 VM passed signed fresh installation, reboot, all 20
+  required optional package transactions, and completed-install rerun rejection.
+- A 2021 M1 Pro MacBook Pro passed installation, Qt compatibility checks, two
+  reboots, NetworkManager/iwd checks, and desktop startup with no failed units.
+
+## Known Limitations
+
+- Zed remains unavailable in the current aarch64 repositories and is hidden by
+  the install menu availability guard.
+- Generic VM validation cannot cover Apple GPU, Wi-Fi, audio, suspend, or other
+  physical hardware behavior.
+
+**Full Changelog**: https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.0-mac.12...v4.0.0-mac.13

--- a/tests/stable-release-test.sh
+++ b/tests/stable-release-test.sh
@@ -3,6 +3,14 @@
 set -euo pipefail
 
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+version=$(<"$ROOT/version")
+notes="$ROOT/docs/releases/v$version.md"
+[[ -s $notes ]]
+grep -Fxq "# Omarchy MX Mac $version" "$notes"
+grep -Fxq '## Validation' "$notes"
+grep -Fq '**Full Changelog**:' "$notes"
+grep -Fq "## [$version]" "$ROOT/CHANGELOG.md"
+
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/bin" "$tmp/state/omarchy/releases" "$tmp/release"


### PR DESCRIPTION
## Summary
- add a repository changelog with detailed current releases and immutable historical links
- store curated GitHub Release bodies under `docs/releases/`
- require release notes, validation evidence, and a full-diff link for the current version
- publish notes from the immutable tagged commit instead of autogenerated PR titles
- backfill complete notes for mac.11 through mac.13

## Verification
- `./test/all` (193 shell test files plus CLI)
- `bash tests/stable-release-test.sh`
- workflow YAML parsing and shell syntax checks