### PR TITLE
fix: provide PipeWire realtime scheduling on Apple Silicon

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -109,6 +109,7 @@ asahi_migration_disposition() {
     1786605598.sh) printf 'skipped\tNVIDIA Limine initramfs repair is not applicable to Asahi\n' ;;
     1786922691.sh|1787231692.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     1787491150.sh) printf 'run\treviewed as architecture-neutral\n' ;;
+    1787552067.sh) printf 'run\treviewed Apple Silicon audio package repair\n' ;;
     *) return 1 ;;
   esac
 }

--- a/install/omarchy-base-asahi.packages
+++ b/install/omarchy-base-asahi.packages
@@ -108,6 +108,7 @@ quickshell-git
 qrencode
 zbar
 ripgrep
+rtkit
 ruby
 sddm
 slurp

--- a/migrations/1787552067.sh
+++ b/migrations/1787552067.sh
@@ -1,0 +1,4 @@
+echo "Install the PipeWire realtime scheduling provider on Apple Silicon"
+
+omarchy-hw-apple-silicon || exit 0
+omarchy-pkg-add rtkit

--- a/test/shell.d/asahi-packages-test.sh
+++ b/test/shell.d/asahi-packages-test.sh
@@ -7,7 +7,7 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 base_manifest="$ROOT/install/omarchy-base-asahi.packages"
 other_manifest="$ROOT/install/omarchy-other-asahi.packages"
 
-for package in linux-asahi linux-asahi-headers asahi-desktop-meta asahi-fwextract mesa vulkan-asahi ddcutil gnome-calculator qrencode libvips zbar; do
+for package in linux-asahi linux-asahi-headers asahi-desktop-meta asahi-fwextract mesa vulkan-asahi ddcutil gnome-calculator qrencode libvips rtkit zbar; do
   grep -Fx "$package" "$base_manifest" "$other_manifest" >/dev/null || fail "Asahi manifests include $package"
 done
 pass "Asahi manifests include Apple Silicon platform requirements"

--- a/test/shell.d/rtkit-test.sh
+++ b/test/shell.d/rtkit-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+calls="$test_tmp/calls"
+migration="$ROOT/migrations/1787552067.sh"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/omarchy-hw-apple-silicon" <<'SH'
+#!/bin/bash
+exit "${OMARCHY_TEST_APPLE:-1}"
+SH
+cat >"$mock_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+printf 'pkg:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+chmod +x "$mock_bin"/*
+
+OMARCHY_TEST_APPLE=0 OMARCHY_TEST_CALLS="$calls" PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration"
+grep -Fxq 'pkg:rtkit' "$calls" || fail "realtime migration installs rtkit on Apple Silicon"
+pass "realtime migration installs the bounded scheduling provider"
+
+: >"$calls"
+OMARCHY_TEST_APPLE=1 OMARCHY_TEST_CALLS="$calls" PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration"
+[[ ! -s $calls ]] || fail "realtime migration leaves non-Apple systems unchanged"
+pass "realtime migration is scoped to Apple Silicon"
+
+grep -Fxq rtkit "$ROOT/install/omarchy-base-asahi.packages" || fail "fresh Asahi package closure includes rtkit"
+grep -Fq 'networkmanager iwd rtkit' "$ROOT/test/vm/asahi-fresh/guest/verify" || fail "fresh-install VM requires rtkit"
+grep -Fq '1787552067.sh)' "$ROOT/bin/omarchy-migrate" || fail "rtkit migration is reviewed for Asahi"
+pass "fresh installs and upgrades require realtime scheduling support"

--- a/test/vm/asahi-fresh/guest/verify
+++ b/test/vm/asahi-fresh/guest/verify
@@ -19,7 +19,7 @@ id omarchy >/dev/null || fail "install user"
 grep -Fxq "User=omarchy" /var/lib/sddm/state.conf || fail "SDDM last-user seeded"
 grep -Fxq "Session=omarchy.desktop" /var/lib/sddm/state.conf || fail "SDDM last-session seeded"
 [[ -f /home/omarchy/.local/state/omarchy/done/finalize-user ]] || fail "user finalization marker"
-pacman -Q omarchy-dev omarchy-settings-dev linux-asahi networkmanager iwd >/dev/null || fail "required packages"
+pacman -Q omarchy-dev omarchy-settings-dev linux-asahi networkmanager iwd rtkit >/dev/null || fail "required packages"
 for unit in NetworkManager.service sddm.service systemd-resolved.service; do
   systemctl is-enabled --quiet "$unit" || fail "$unit enabled"
 done


### PR DESCRIPTION
Fixes #29

Adds `rtkit` to the fresh Apple Silicon package closure and installs it through a reviewed, hardware-gated migration for existing systems. VM and shell coverage enforce both paths.

Hardware evidence on the M1 Max test machine:
- `rtkit-daemon.service` active on demand
- PipeWire threads granted RT priority 20
- audio processes granted nice level -11
- no broad realtime-group privileges

Verification:
- `bash test/shell.d/rtkit-test.sh`
- `bash test/shell.d/asahi-packages-test.sh`
- `bash test/shell.d/migrate-asahi-test.sh`
- `bash test/shell.d/asahi-fresh-install-test.sh`