### PR TITLE
fix: unlock GNOME Keyring on password login

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -107,8 +107,10 @@ asahi_migration_disposition() {
     1786482992.sh) printf 'skipped\tLimine boot image repair is not applicable to Asahi\n' ;;
     1786567036.sh) printf 'skipped\tNetworkManager remains on the validated Asahi iwd backend\n' ;;
     1786605598.sh) printf 'skipped\tNVIDIA Limine initramfs repair is not applicable to Asahi\n' ;;
-    1786922691.sh|1787231692.sh|1787491150.sh|1787552167.sh) printf 'run\treviewed as architecture-neutral\n' ;;
+    1786922691.sh|1787231692.sh) printf 'run\treviewed as architecture-neutral\n' ;;
+    1787491150.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     1787552067.sh) printf 'run\treviewed Apple Silicon audio package repair\n' ;;
+    1787552167.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     *) return 1 ;;
   esac
 }

--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -107,8 +107,7 @@ asahi_migration_disposition() {
     1786482992.sh) printf 'skipped\tLimine boot image repair is not applicable to Asahi\n' ;;
     1786567036.sh) printf 'skipped\tNetworkManager remains on the validated Asahi iwd backend\n' ;;
     1786605598.sh) printf 'skipped\tNVIDIA Limine initramfs repair is not applicable to Asahi\n' ;;
-    1786922691.sh|1787231692.sh) printf 'run\treviewed as architecture-neutral\n' ;;
-    1787491150.sh) printf 'run\treviewed as architecture-neutral\n' ;;
+    1786922691.sh|1787231692.sh|1787491150.sh|1787552167.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     1787552067.sh) printf 'run\treviewed Apple Silicon audio package repair\n' ;;
     *) return 1 ;;
   esac

--- a/install/login/sddm.sh
+++ b/install/login/sddm.sh
@@ -1,7 +1,19 @@
-# Prevent password-based SDDM logins from creating an encrypted login keyring
-# that conflicts with Omarchy's passwordless default keyring behavior. The ISO
-# owns autologin/session state because it knows whether the target is encrypted.
-if [[ -f /etc/pam.d/sddm ]]; then
-  sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
-  sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
+pam_file="${OMARCHY_SDDM_PAM_FILE:-/etc/pam.d/sddm}"
+
+if [[ -f $pam_file ]] && ! grep -Eq '^[[:space:]]*-?auth[[:space:]]+.*pam_gnome_keyring\.so([[:space:]]|$)' "$pam_file"; then
+  tmp="${pam_file}.omarchy.$$"
+  if ! awk '
+    { print }
+    !inserted && $1 ~ /^-?auth$/ {
+      print "-auth       optional    pam_gnome_keyring.so"
+      inserted = 1
+    }
+    END { if (!inserted) exit 1 }
+  ' "$pam_file" >"$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  chmod --reference="$pam_file" "$tmp"
+  chown --reference="$pam_file" "$tmp"
+  mv "$tmp" "$pam_file"
 fi

--- a/migrations/1787552167.sh
+++ b/migrations/1787552167.sh
@@ -1,0 +1,10 @@
+echo "Restore GNOME Keyring unlock for password-based SDDM login"
+
+omarchy-pkg-present gnome-keyring || exit 0
+
+pam_file="${OMARCHY_SDDM_PAM_FILE:-/etc/pam.d/sddm}"
+[[ -f $pam_file ]] || exit 0
+grep -Eq '^[[:space:]]*-?auth[[:space:]]+.*pam_gnome_keyring\.so([[:space:]]|$)' "$pam_file" && exit 0
+
+sudo env OMARCHY_SDDM_PAM_FILE="$pam_file" \
+  bash -euo pipefail -c 'source "$1"' _ "$OMARCHY_PATH/install/login/sddm.sh"

--- a/test/shell.d/sddm-keyring-test.sh
+++ b/test/shell.d/sddm-keyring-test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+pam_file="$test_tmp/sddm"
+autologin_file="$test_tmp/sddm-autologin"
+leaf="$ROOT/install/login/sddm.sh"
+
+cat >"$pam_file" <<'PAM'
+#%PAM-1.0
+auth        include     system-login
+-auth       optional    pam_kwallet5.so
+account     include     system-login
+session     include     system-login
+-session    optional    pam_gnome_keyring.so auto_start
+PAM
+cat >"$autologin_file" <<'PAM'
+#%PAM-1.0
+auth        required    pam_permit.so
+-auth       optional    pam_gnome_keyring.so
+session     include     system-local-login
+PAM
+
+autologin_before=$(sha256sum "$autologin_file")
+OMARCHY_SDDM_PAM_FILE="$pam_file" bash -euo pipefail -c 'source "$1"' _ "$leaf"
+grep -Fxq -- '-auth       optional    pam_gnome_keyring.so' "$pam_file" || fail "SDDM setup restores the GNOME Keyring auth hook"
+[[ $(grep -Ec '^[[:space:]]*-?auth[[:space:]]+.*pam_gnome_keyring\.so([[:space:]]|$)' "$pam_file") == 1 ]] || fail "SDDM setup writes one GNOME Keyring auth hook"
+grep -Fxq -- '-auth       optional    pam_kwallet5.so' "$pam_file" || fail "SDDM setup preserves other auth hooks"
+grep -Fxq -- '-session    optional    pam_gnome_keyring.so auto_start' "$pam_file" || fail "SDDM setup preserves the keyring session hook"
+[[ $(sha256sum "$autologin_file") == "$autologin_before" ]] || fail "SDDM setup leaves the autologin PAM stack unchanged"
+pass "password login gains keyring unlock without changing autologin"
+
+after_first=$(sha256sum "$pam_file")
+OMARCHY_SDDM_PAM_FILE="$pam_file" bash -euo pipefail -c 'source "$1"' _ "$leaf"
+[[ $(sha256sum "$pam_file") == "$after_first" ]] || fail "SDDM keyring setup is idempotent"
+pass "SDDM keyring setup is idempotent"
+
+cat >"$pam_file" <<'PAM'
+#%PAM-1.0
+auth include system-login
+auth optional pam_gnome_keyring.so
+account include system-login
+PAM
+before_existing=$(sha256sum "$pam_file")
+OMARCHY_SDDM_PAM_FILE="$pam_file" bash -euo pipefail -c 'source "$1"' _ "$leaf"
+[[ $(sha256sum "$pam_file") == "$before_existing" ]] || fail "SDDM setup preserves an existing non-dashed auth hook"
+pass "SDDM setup accepts the packaged hook variants"
+
+grep -Fq 'SDDM GNOME Keyring auth hook' "$ROOT/test/vm/asahi-fresh/guest/verify" || fail "fresh-install VM verifies keyring authentication"
+pass "fresh-install VM requires both GNOME Keyring PAM phases"

--- a/test/shell.d/sddm-keyring-test.sh
+++ b/test/shell.d/sddm-keyring-test.sh
@@ -53,3 +53,34 @@ pass "SDDM setup accepts the packaged hook variants"
 
 grep -Fq 'SDDM GNOME Keyring auth hook' "$ROOT/test/vm/asahi-fresh/guest/verify" || fail "fresh-install VM verifies keyring authentication"
 pass "fresh-install VM requires both GNOME Keyring PAM phases"
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+cat >"$mock_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+exit "${OMARCHY_TEST_PACKAGE_MISSING:-0}"
+SH
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+exec "$@"
+SH
+chmod +x "$mock_bin"/*
+
+cat >"$pam_file" <<'PAM'
+#%PAM-1.0
+auth include system-login
+account include system-login
+-session optional pam_gnome_keyring.so auto_start
+PAM
+OMARCHY_PATH="$ROOT" OMARCHY_SDDM_PAM_FILE="$pam_file" PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$ROOT/migrations/1787552167.sh"
+grep -Eq '^-auth[[:space:]]+optional[[:space:]]+pam_gnome_keyring\.so$' "$pam_file" || fail "migration repairs a previously stripped SDDM stack"
+pass "existing password-login installations regain keyring unlock"
+
+sed -i '/pam_gnome_keyring\.so/d' "$pam_file"
+before_missing=$(sha256sum "$pam_file")
+OMARCHY_TEST_PACKAGE_MISSING=1 OMARCHY_PATH="$ROOT" OMARCHY_SDDM_PAM_FILE="$pam_file" PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$ROOT/migrations/1787552167.sh"
+[[ $(sha256sum "$pam_file") == "$before_missing" ]] || fail "migration skips systems without GNOME Keyring"
+grep -Fq '1787552167.sh)' "$ROOT/bin/omarchy-migrate" || fail "keyring migration is reviewed for Asahi"
+pass "keyring migration is package-aware and reviewed"

--- a/test/vm/asahi-fresh/guest/verify
+++ b/test/vm/asahi-fresh/guest/verify
@@ -18,6 +18,8 @@ id omarchy >/dev/null || fail "install user"
 [[ $(passwd -S alarm | awk '{ print $2 }') == "L" ]] || fail "stock Alarm account is not locked"
 grep -Fxq "User=omarchy" /var/lib/sddm/state.conf || fail "SDDM last-user seeded"
 grep -Fxq "Session=omarchy.desktop" /var/lib/sddm/state.conf || fail "SDDM last-session seeded"
+grep -Eq '^[[:space:]]*-?auth[[:space:]]+.*pam_gnome_keyring\.so([[:space:]]|$)' /etc/pam.d/sddm || fail "SDDM GNOME Keyring auth hook"
+grep -Eq '^[[:space:]]*-?session[[:space:]]+.*pam_gnome_keyring\.so.*auto_start' /etc/pam.d/sddm || fail "SDDM GNOME Keyring session hook"
 [[ -f /home/omarchy/.local/state/omarchy/done/finalize-user ]] || fail "user finalization marker"
 pacman -Q omarchy-dev omarchy-settings-dev linux-asahi networkmanager iwd rtkit >/dev/null || fail "required packages"
 for unit in NetworkManager.service sddm.service systemd-resolved.service; do


### PR DESCRIPTION
Fixes #28

Restores the optional GNOME Keyring auth hook in the password-login SDDM PAM stack while leaving `sddm-autologin` untouched. The install leaf and migration preserve custom PAM entries and metadata and are idempotent.

Verification:
- stock, stripped, and preexisting PAM fixture coverage
- autologin stack hash remains unchanged
- package-aware migration coverage
- Asahi migration policy coverage
- fresh-install VM auth and session invariants