### PR TITLE
Configure signed Apple Silicon package repository

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -111,6 +111,7 @@ asahi_migration_disposition() {
     1787491150.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     1787552067.sh) printf 'run\treviewed Apple Silicon audio package repair\n' ;;
     1787552167.sh) printf 'run\treviewed as architecture-neutral\n' ;;
+    1787560726.sh) printf 'run\treviewed Apple Silicon package repository setup\n' ;;
     *) return 1 ;;
   esac
 }

--- a/install/hardware/pacman.sh
+++ b/install/hardware/pacman.sh
@@ -1,5 +1,48 @@
 # Hardware-specific pacman repository extensions that must survive the final
 # pacman.conf restore.
+if omarchy-hw-apple-silicon; then
+  release_key="${OMARCHY_ASAHI_PACKAGE_KEY_FILE:-$OMARCHY_PATH/default/omarchy-release.gpg}"
+  release_fingerprint=5983B1CA32CB778F4D74D24ECFF35022CA5B5959
+  release_tag=asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24
+  release_server="https://github.com/maralcbr/omarchy-pkgs/releases/download/$release_tag"
+  pacman_conf="${OMARCHY_PACMAN_CONF:-/etc/pacman.conf}"
+
+  actual_fingerprint=$(gpg --batch --show-keys --with-colons "$release_key" |
+    awk -F: '$1 == "pub" { primary=1; next } primary && $1 == "fpr" { print $10; exit }')
+  [[ $actual_fingerprint == "$release_fingerprint" ]] || return 1
+
+  if ! pacman-key --finger "$release_fingerprint" >/dev/null 2>&1; then
+    pacman-key --add "$release_key"
+  fi
+  pacman-key --lsign-key "$release_fingerprint"
+
+  if ! awk -v server="$release_server" '
+    /^\[omarchy\][[:space:]]*$/ { inside = 1; blocks++; next }
+    inside && /^\[[^]]+\][[:space:]]*$/ { inside = 0 }
+    inside && NF { entries++ }
+    inside && $0 == "SigLevel = Required DatabaseOptional" { signature = 1 }
+    inside && $0 == "Server = " server { url = 1 }
+    END { exit !(blocks == 1 && entries == 2 && signature && url) }
+  ' "$pacman_conf"; then
+    tmp="${pacman_conf}.omarchy.$$"
+    awk '
+      /^\[omarchy\][[:space:]]*$/ { skip = 1; next }
+      skip && /^\[[^]]+\][[:space:]]*$/ { skip = 0 }
+      !skip { print }
+    ' "$pacman_conf" >"$tmp"
+    cat >>"$tmp" <<EOF
+
+[omarchy]
+SigLevel = Required DatabaseOptional
+Server = $release_server
+EOF
+    chmod --reference="$pacman_conf" "$tmp"
+    chown --reference="$pacman_conf" "$tmp"
+    mv "$tmp" "$pacman_conf"
+    pacman -Sy --noconfirm
+  fi
+fi
+
 if lspci -nn | grep "106b:180[12]" >/dev/null; then
   if ! grep -q '^\[arch-mact2\]' /etc/pacman.conf; then
     cat >> /etc/pacman.conf <<'EOF'

--- a/migrations/1787560726.sh
+++ b/migrations/1787560726.sh
@@ -1,0 +1,6 @@
+echo "Configure the signed Omarchy package repository on Apple Silicon"
+
+omarchy-hw-apple-silicon || exit 0
+
+sudo env OMARCHY_PATH="$OMARCHY_PATH" \
+  bash -euo pipefail -c 'source "$1"' _ "$OMARCHY_PATH/install/hardware/pacman.sh"

--- a/test/shell.d/asahi-package-repository-test.sh
+++ b/test/shell.d/asahi-package-repository-test.sh
@@ -13,6 +13,7 @@ key_file="$test_tmp/omarchy-release.gpg"
 calls="$test_tmp/calls"
 key_state="$test_tmp/key-added"
 leaf="$ROOT/install/hardware/pacman.sh"
+migration="$ROOT/migrations/1787560726.sh"
 mkdir -p "$mock_bin"
 : >"$key_file"
 
@@ -37,6 +38,11 @@ SH
 cat >"$mock_bin/pacman" <<'SH'
 #!/bin/bash
 printf 'pacman:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+cat >"$mock_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+"$@"
 SH
 cat >"$mock_bin/lspci" <<'SH'
 #!/bin/bash
@@ -96,3 +102,32 @@ OMARCHY_PACMAN_CONF="$non_apple_conf" OMARCHY_TEST_APPLE=1 PATH="$mock_bin:$PATH
   bash -euo pipefail -c 'source "$1"' _ "$leaf"
 [[ $(sha256sum "$non_apple_conf") == "$non_apple_hash" ]] || fail "package setup leaves non-Apple systems unchanged"
 pass "Apple package repository remains hardware-scoped"
+
+cat >"$pacman_conf" <<'CONF'
+[options]
+Architecture = aarch64
+
+[omarchy]
+SigLevel = Never
+Server = https://pkgs.omarchy.org/edge/$arch
+CONF
+rm -f "$key_state"
+: >"$calls"
+OMARCHY_PATH="$ROOT" \
+  OMARCHY_PACMAN_CONF="$pacman_conf" \
+  OMARCHY_ASAHI_PACKAGE_KEY_FILE="$key_file" \
+  OMARCHY_TEST_CALLS="$calls" \
+  OMARCHY_TEST_KEY_STATE="$key_state" \
+  OMARCHY_TEST_APPLE=0 \
+  PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null
+grep -Fq 'sudo:env OMARCHY_PATH=' "$calls" || fail "Apple package migration delegates privileged setup through sudo"
+grep -Fxq 'SigLevel = Required DatabaseOptional' "$pacman_conf" || fail "Apple package migration configures the signed repository"
+grep -Fxq "pacman-key:--add $key_file" "$calls" || fail "Apple package migration imports the release key"
+pass "existing Apple Silicon installs receive the signed package repository"
+
+config_hash=$(sha256sum "$pacman_conf")
+OMARCHY_PATH="$ROOT" OMARCHY_TEST_APPLE=1 PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null
+[[ $(sha256sum "$pacman_conf") == "$config_hash" ]] || fail "Apple package migration leaves non-Apple systems unchanged"
+pass "Apple package migration remains hardware-scoped"

--- a/test/shell.d/asahi-package-repository-test.sh
+++ b/test/shell.d/asahi-package-repository-test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+pacman_conf="$test_tmp/pacman.conf"
+key_file="$test_tmp/omarchy-release.gpg"
+calls="$test_tmp/calls"
+key_state="$test_tmp/key-added"
+leaf="$ROOT/install/hardware/pacman.sh"
+mkdir -p "$mock_bin"
+: >"$key_file"
+
+cat >"$mock_bin/omarchy-hw-apple-silicon" <<'SH'
+#!/bin/bash
+exit "${OMARCHY_TEST_APPLE:-0}"
+SH
+cat >"$mock_bin/gpg" <<'SH'
+#!/bin/bash
+printf '%s\n' 'pub:-:255:22:CFF35022CA5B5959:0:0::-:::scESC:::::ed25519:::0:'
+printf '%s\n' 'fpr:::::::::5983B1CA32CB778F4D74D24ECFF35022CA5B5959:'
+SH
+cat >"$mock_bin/pacman-key" <<'SH'
+#!/bin/bash
+printf 'pacman-key:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+if [[ $1 == "--finger" ]]; then
+  [[ -f $OMARCHY_TEST_KEY_STATE ]]
+elif [[ $1 == "--add" ]]; then
+  : >"$OMARCHY_TEST_KEY_STATE"
+fi
+SH
+cat >"$mock_bin/pacman" <<'SH'
+#!/bin/bash
+printf 'pacman:%s\n' "$*" >>"$OMARCHY_TEST_CALLS"
+SH
+cat >"$mock_bin/lspci" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$mock_bin"/*
+
+cat >"$pacman_conf" <<'CONF'
+[options]
+Architecture = aarch64
+
+[asahi-alarm]
+Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
+
+[omarchy]
+SigLevel = Never
+Server = https://pkgs.omarchy.org/edge/$arch
+
+[core]
+Server = http://mirror.archlinuxarm.org/$arch/$repo
+CONF
+
+run_leaf() {
+  OMARCHY_PATH="$ROOT" \
+    OMARCHY_PACMAN_CONF="$pacman_conf" \
+    OMARCHY_ASAHI_PACKAGE_KEY_FILE="$key_file" \
+    OMARCHY_TEST_CALLS="$calls" \
+    OMARCHY_TEST_KEY_STATE="$key_state" \
+    OMARCHY_TEST_APPLE="${1:-0}" \
+    PATH="$mock_bin:$PATH" \
+    bash -euo pipefail -c 'source "$1"' _ "$leaf"
+}
+
+run_leaf 0
+[[ $(grep -Fc '[omarchy]' "$pacman_conf") == 1 ]] || fail "Apple package setup writes one repository block"
+grep -Fxq 'SigLevel = Required DatabaseOptional' "$pacman_conf" || fail "Apple package setup requires signed packages"
+grep -Fxq 'Server = https://github.com/maralcbr/omarchy-pkgs/releases/download/asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24' "$pacman_conf" || fail "Apple package setup uses the immutable release"
+grep -Fq 'asahi-alarm/asahi-alarm' "$pacman_conf" || fail "Apple package setup preserves the Asahi repository"
+grep -Fq 'mirror.archlinuxarm.org' "$pacman_conf" || fail "Apple package setup preserves ALARM repositories"
+! grep -Fq 'pkgs.omarchy.org' "$pacman_conf" || fail "Apple package setup removes the unavailable upstream ARM repository"
+grep -Fxq "pacman-key:--add $key_file" "$calls" || fail "Apple package setup imports the pinned release key"
+grep -Fxq 'pacman-key:--lsign-key 5983B1CA32CB778F4D74D24ECFF35022CA5B5959' "$calls" || fail "Apple package setup trusts the pinned release key"
+grep -Fxq 'pacman:-Sy --noconfirm' "$calls" || fail "Apple package setup refreshes the new repository"
+pass "Apple Silicon receives the signed immutable package repository"
+
+config_hash=$(sha256sum "$pacman_conf")
+sync_count=$(grep -Fc 'pacman:-Sy --noconfirm' "$calls")
+run_leaf 0
+[[ $(sha256sum "$pacman_conf") == "$config_hash" ]] || fail "Apple package setup is idempotent"
+[[ $(grep -Fc 'pacman:-Sy --noconfirm' "$calls") == "$sync_count" ]] || fail "Apple package setup does not resync an unchanged repository"
+pass "Apple package repository setup is idempotent"
+
+non_apple_conf="$test_tmp/non-apple.conf"
+cp "$pacman_conf" "$non_apple_conf"
+non_apple_hash=$(sha256sum "$non_apple_conf")
+OMARCHY_PACMAN_CONF="$non_apple_conf" OMARCHY_TEST_APPLE=1 PATH="$mock_bin:$PATH" \
+  bash -euo pipefail -c 'source "$1"' _ "$leaf"
+[[ $(sha256sum "$non_apple_conf") == "$non_apple_hash" ]] || fail "package setup leaves non-Apple systems unchanged"
+pass "Apple package repository remains hardware-scoped"

--- a/test/shell.d/migrate-asahi-test.sh
+++ b/test/shell.d/migrate-asahi-test.sh
@@ -76,6 +76,7 @@ grep -Fq $'skipped\therdr is unavailable' "$state_dir/1786273938.sh.skipped" || 
 grep -Fq $'skipped\tttfx is unavailable' "$state_dir/1786355450.sh.skipped" || fail "ttfx migration records its repository reason"
 grep -Fq $'skipped\tIntel Mac Broadcom firmware quirk' "$state_dir/1786391100.sh.skipped" || fail "Broadcom migration records its Apple Silicon reason"
 grep -Fq $'skipped\tLimine boot image repair' "$state_dir/1786482992.sh.skipped" || fail "Limine repair migration records its Asahi reason"
+[[ -f $state_dir/1787560726.sh ]] || fail "package repository migration is reviewed to run on Apple Silicon"
 pass "Asahi migration policy blocks unvalidated platform changes"
 
 cat >"$test_root/migrations/9999999999.sh" <<'SH'

--- a/test/vm/asahi-fresh/guest/verify
+++ b/test/vm/asahi-fresh/guest/verify
@@ -22,6 +22,10 @@ grep -Eq '^[[:space:]]*-?auth[[:space:]]+.*pam_gnome_keyring\.so([[:space:]]|$)'
 grep -Eq '^[[:space:]]*-?session[[:space:]]+.*pam_gnome_keyring\.so.*auto_start' /etc/pam.d/sddm || fail "SDDM GNOME Keyring session hook"
 [[ -f /home/omarchy/.local/state/omarchy/done/finalize-user ]] || fail "user finalization marker"
 pacman -Q omarchy-dev omarchy-settings-dev linux-asahi networkmanager iwd rtkit >/dev/null || fail "required packages"
+grep -Fxq '[omarchy]' /etc/pacman.conf || fail "signed Apple Silicon package repository"
+grep -Fxq 'SigLevel = Required DatabaseOptional' /etc/pacman.conf || fail "Apple Silicon package signature policy"
+grep -Fxq 'Server = https://github.com/maralcbr/omarchy-pkgs/releases/download/asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24' /etc/pacman.conf || fail "immutable Apple Silicon package repository"
+pacman-key --finger 5983B1CA32CB778F4D74D24ECFF35022CA5B5959 >/dev/null || fail "Apple Silicon package signing key"
 for unit in NetworkManager.service sddm.service systemd-resolved.service; do
   systemctl is-enabled --quiet "$unit" || fail "$unit enabled"
 done


### PR DESCRIPTION
## Summary
- trust the pinned Omarchy release key and configure the immutable signed aarch64 repository on Apple Silicon
- preserve Asahi/ALARM repositories while replacing only the unavailable upstream Omarchy block
- migrate existing Apple Silicon installs through the reviewed migration policy
- verify fresh-install, migration, idempotency, and hardware-scoping behavior

Closes #10

## Verification
- `OMARCHY_PKGS_PATH=/home/maralc/dev/omarchy-pkgs OMARCHY_ISO_PATH=/home/maralc/dev/omarchy-iso ./test/all` (199 test files passed)
- public `omazed 2.0.1-1` package downloaded from the immutable release and installed into an isolated aarch64 pacman root with `SigLevel = Required`
- release `asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24` reports immutable with 47 signed repository assets