### PR TITLE
Keep Asahi VM release validation current

### DIFF
--- a/test/shell.d/asahi-fresh-install-test.sh
+++ b/test/shell.d/asahi-fresh-install-test.sh
@@ -6,8 +6,11 @@ source "$(dirname "$0")/base-test.sh"
 
 installer="$ROOT/bin/omarchy-install-asahi-fresh"
 wrapper="$ROOT/install-omarchy-mx-mac"
+vm_runner="$ROOT/test/vm/asahi-fresh/run"
+vm_installer="$ROOT/test/vm/asahi-fresh/guest/install"
+vm_launcher="$ROOT/test/vm/asahi-fresh/container/start-vm"
 
-bash -n "$installer" "$wrapper"
+bash -n "$installer" "$wrapper" "$vm_runner" "$vm_installer" "$vm_launcher"
 "$installer" --help 2>&1 | grep -Fq -- '--asahi-packages DIR'
 pass "fresh Asahi installer exposes the verified bundle entrypoint"
 
@@ -79,3 +82,14 @@ if grep -Fq 'v3.8.4' "$installer" "$wrapper"; then
   fail "final fresh installer depends on legacy Omarchy"
 fi
 pass "stable installer enters Quattro directly without Omarchy 3"
+
+grep -Fq 'stable_version=$(<"$root/version")' "$vm_runner" || fail "VM runner reads the candidate stable version"
+grep -Fq 'env OMARCHY_VM_STABLE_VERSION="$stable_version"' "$vm_runner" || fail "VM runner passes the candidate stable version"
+grep -Fq 'grep -Fxq "version=$OMARCHY_VM_STABLE_VERSION"' "$vm_installer" || fail "VM validates the published stable version without a stale hardcode"
+pass "fresh-install VM tracks the candidate stable version"
+
+grep -Fq 'vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}' "$vm_runner" || fail "VM runner keeps the 8 GiB default"
+grep -Fq 'docker exec -e OMARCHY_VM_MEMORY_MB="$vm_memory_mb"' "$vm_runner" || fail "VM runner passes the memory override"
+grep -Fq 'memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}' "$vm_launcher" || fail "VM launcher accepts the memory override"
+grep -Fq -- '-m "$memory_mb"' "$vm_launcher" || fail "QEMU uses the configured guest memory"
+pass "fresh-install VM supports constrained hosts"

--- a/test/vm/asahi-fresh/container/start-vm
+++ b/test/vm/asahi-fresh/container/start-vm
@@ -6,6 +6,7 @@ run=/work/run
 base=/work/cache/archarm-base.qcow2
 code=/usr/share/AAVMF/AAVMF_CODE.fd
 vars_template=/usr/share/AAVMF/AAVMF_VARS.fd
+memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}
 
 rm -rf "$run"
 mkdir -p "$run"
@@ -17,7 +18,7 @@ qemu-system-aarch64 \
   -machine virt,accel=kvm,gic-version=host \
   -cpu host \
   -smp 8 \
-  -m 8192 \
+  -m "$memory_mb" \
   -drive if=pflash,format=raw,readonly=on,file="$code" \
   -drive if=pflash,format=raw,file="$run/AAVMF_VARS.fd" \
   -drive file="$run/disk.qcow2",format=qcow2,if=none,id=drive0,discard=unmap \

--- a/test/vm/asahi-fresh/guest/install
+++ b/test/vm/asahi-fresh/guest/install
@@ -7,6 +7,8 @@ channel=https://github.com/maralcbr/omarchy-pkgs/releases/download/asahi-quattro
 fingerprint=5983B1CA32CB778F4D74D24ECFF35022CA5B5959
 work=/root/omarchy-fresh-vm
 
+[[ ${OMARCHY_VM_STABLE_VERSION:-} =~ ^[0-9]+\.[0-9]+\.[0-9]+-mac\.[0-9]+$ ]]
+
 rm -rf "$work"
 mkdir -p "$work"
 cd "$work"
@@ -24,7 +26,7 @@ curl --fail --location --connect-timeout 15 --max-time 300 --retry 3 --retry-all
 [[ $(gpg --show-keys --with-colons omarchy-release.gpg | awk -F: '$1 == "fpr" { print $10; exit }') == "$fingerprint" ]]
 gpgv --keyring ./omarchy-release.gpg install-omarchy-mx-mac.sig install-omarchy-mx-mac
 gpgv --keyring ./omarchy-release.gpg omarchy-mx-mac-release.sig omarchy-mx-mac-release
-grep -Fxq 'version=4.0.0-mac.13' omarchy-mx-mac-release
+grep -Fxq "version=$OMARCHY_VM_STABLE_VERSION" omarchy-mx-mac-release
 
 curl --fail --location --connect-timeout 15 --max-time 300 --retry 3 --retry-all-errors -o install-asahi-quattro "$channel/install-asahi-quattro"
 curl --fail --location --connect-timeout 15 --max-time 300 --retry 3 --retry-all-errors -o install-asahi-quattro.sig "$channel/install-asahi-quattro.sig"

--- a/test/vm/asahi-fresh/run
+++ b/test/vm/asahi-fresh/run
@@ -12,6 +12,12 @@ vnc_port=${OMARCHY_VM_VNC_PORT:-25900}
 keep=0
 rebuild=0
 optional_packages=0
+vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}
+
+[[ $vm_memory_mb =~ ^[1-9][0-9]*$ ]] || {
+  echo "OMARCHY_VM_MEMORY_MB must be a positive integer" >&2
+  exit 1
+}
 
 while (($#)); do
   case "$1" in
@@ -52,7 +58,8 @@ docker run -d \
   "$image" sleep infinity >/dev/null
 
 docker exec "$container" /usr/local/lib/omarchy-asahi-vm/build-base
-docker exec "$container" /usr/local/lib/omarchy-asahi-vm/start-vm
+docker exec -e OMARCHY_VM_MEMORY_MB="$vm_memory_mb" \
+  "$container" /usr/local/lib/omarchy-asahi-vm/start-vm
 docker exec "$container" chown -R "$(id -u):$(id -g)" /work/run
 
 ssh_args=(
@@ -99,7 +106,10 @@ wait_for_ssh || { tail -200 "$state/run/serial.log"; exit 1; }
 scp "${scp_args[@]}" "$root/bin/omarchy-install-asahi-fresh" root@127.0.0.1:/root/omarchy-install-asahi-fresh.candidate
 scp "${scp_args[@]}" "$root/bin/omarchy-update-asahi-bundle" root@127.0.0.1:/root/omarchy-update-asahi-bundle.candidate
 scp "${scp_args[@]}" "$harness/guest/install" root@127.0.0.1:/root/omarchy-vm-install
-ssh -tt "${ssh_args[@]}" root@127.0.0.1 bash /root/omarchy-vm-install | tee "$state/run/install.log" || exit 1
+stable_version=$(<"$root/version")
+ssh -tt "${ssh_args[@]}" root@127.0.0.1 \
+  env OMARCHY_VM_STABLE_VERSION="$stable_version" bash /root/omarchy-vm-install |
+  tee "$state/run/install.log" || exit 1
 
 boot_id=$(ssh "${ssh_args[@]}" root@127.0.0.1 cat /proc/sys/kernel/random/boot_id)
 ssh "${ssh_args[@]}" root@127.0.0.1 systemctl reboot --no-block || true


### PR DESCRIPTION
## Summary
- derive the VM expected stable version from the candidate source instead of a stale `mac.13` literal
- allow constrained hosts to override the disposable guest memory while retaining the 8 GiB default
- cover version and memory propagation in the focused shell test

## Verification
- `bash test/shell.d/asahi-fresh-install-test.sh`
- invalid `OMARCHY_VM_MEMORY_MB` rejection
- `OMARCHY_VM_MEMORY_MB=6144 test/vm/asahi-fresh/run` against published `v4.0.0-mac.15`
- full VM path passed package installation, interruption recovery, reboot verification, and rerun rejection