### PR TITLE
Add Phase 2 package candidate verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ guidance does not drift from the router.
 
 # Git
 
-- Do not use `codex` or `Codex` in branch names or source-code comments.
+- Do not use `codex` or `Codex` in branch names or comments of any kind.
 - Commits should be atomic: include only one coherent change or fix, and do not mix unrelated work.
 - Commit messages should be succinct and describe the change being made.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ guidance does not drift from the router.
 
 # Git
 
+- Do not use `codex` or `Codex` in branch names or source-code comments.
 - Commits should be atomic: include only one coherent change or fix, and do not mix unrelated work.
 - Commit messages should be succinct and describe the change being made.
 

--- a/bin/omarchy-pkg-repository-verify-candidate
+++ b/bin/omarchy-pkg-repository-verify-candidate
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# omarchy:summary=Verify an offline Apple Silicon package candidate
+# omarchy:args=DIRECTORY RELEASE_TAG DESCRIPTOR_SHA256 SIGNING_FINGERPRINT KEY_FILE
+# omarchy:hidden=true
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: omarchy-pkg-repository-verify-candidate DIRECTORY RELEASE_TAG DESCRIPTOR_SHA256 SIGNING_FINGERPRINT KEY_FILE" >&2
+  exit 64
+}
+
+(( $# == 5 )) || usage
+
+repository=$1
+expected_tag=$2
+expected_descriptor_sha256=${3,,}
+expected_signing_fingerprint=${4^^}
+key_file=$5
+
+fail() {
+  echo "Apple Silicon package candidate: $*" >&2
+  exit 2
+}
+
+[[ -d $repository ]] || fail "repository directory does not exist"
+[[ $expected_tag =~ ^asahi-packages-candidate-[0-9a-f]{40}$ ]] || fail "invalid release tag"
+[[ $expected_descriptor_sha256 =~ ^[0-9a-f]{64}$ ]] || fail "invalid descriptor checksum"
+[[ $expected_signing_fingerprint =~ ^[A-F0-9]{40}$ ]] || fail "invalid signing fingerprint"
+[[ -r $key_file ]] || fail "signing certificate is not readable"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+gnupg_dir=$workdir/gnupg
+mkdir -m 0700 "$gnupg_dir"
+gpg --batch --homedir "$gnupg_dir" --import "$key_file" >/dev/null 2>&1 ||
+  fail "could not import the signing certificate"
+
+key_kind=$(gpg --batch --homedir "$gnupg_dir" --with-colons --list-keys |
+  awk -F: -v wanted="$expected_signing_fingerprint" '
+    $1 == "pub" || $1 == "sub" { kind=$1; next }
+    $1 == "fpr" && $10 == wanted { print kind; exit }
+  ')
+[[ $key_kind == "sub" ]] || fail "configured signing fingerprint is not a public subkey"
+
+verify_signature() {
+  local file=$1 signature=$2 status
+  [[ -s $file && -s $signature ]] || fail "missing signed asset ${file##*/}"
+  status=$(gpg --batch --homedir "$gnupg_dir" --status-fd 1 --verify "$signature" "$file" 2>/dev/null) ||
+    fail "signature verification failed for ${file##*/}"
+  awk -v expected="$expected_signing_fingerprint" '
+    $2 == "VALIDSIG" && $3 == expected { valid=1 }
+    END { exit !valid }
+  ' <<<"$status" || fail "${file##*/} was not signed by the configured subkey"
+}
+
+descriptor=$repository/CANDIDATE
+descriptor_signature=$repository/CANDIDATE.sig
+[[ -s $descriptor ]] || fail "candidate descriptor is missing"
+[[ $(sha256sum "$descriptor" | cut -d' ' -f1) == $expected_descriptor_sha256 ]] ||
+  fail "candidate descriptor checksum does not match"
+verify_signature "$descriptor" "$descriptor_signature"
+
+format="" channel="" release_tag="" source_commit="" workflow_run="" runner_arch=""
+signing_fingerprint="" package_count=""
+declare -A package_names=() package_files=() described_files=() described_assets=()
+declare -A seen_headers=()
+package_records=0
+asset_records=0
+
+set_header() {
+  local name=$1 value=$2
+  [[ -z ${seen_headers[$name]:-} ]] || fail "duplicate candidate descriptor header: $name"
+  printf -v "$name" '%s' "$value"
+  seen_headers[$name]=1
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    format=*) set_header format "${line#format=}" ;;
+    channel=*) set_header channel "${line#channel=}" ;;
+    release_tag=*) set_header release_tag "${line#release_tag=}" ;;
+    source_commit=*) set_header source_commit "${line#source_commit=}" ;;
+    workflow_run=*) set_header workflow_run "${line#workflow_run=}" ;;
+    runner_arch=*) set_header runner_arch "${line#runner_arch=}" ;;
+    signing_fingerprint=*) set_header signing_fingerprint "${line#signing_fingerprint=}" ;;
+    package_count=*) set_header package_count "${line#package_count=}" ;;
+    package=*)
+      record=${line#package=}
+      IFS='|' read -r index package version architecture filename archive_sha signature_filename signature_sha extra <<<"$record"
+      [[ -z $extra && $index =~ ^[1-9][0-9]*$ ]] || fail "invalid package record index"
+      (( index == package_records + 1 )) || fail "invalid package record index"
+      [[ $package =~ ^[a-z0-9@._+-]+$ && -n $version ]] || fail "invalid package record"
+      [[ $architecture == "aarch64" || $architecture == "any" ]] || fail "invalid package architecture"
+      [[ $filename =~ ^[A-Za-z0-9._+@-]+\.pkg\.tar\.[A-Za-z0-9.]+$ ]] || fail "unsafe package filename"
+      [[ $signature_filename == $filename.sig ]] || fail "invalid package signature filename"
+      [[ $archive_sha =~ ^[0-9a-f]{64}$ && $signature_sha =~ ^[0-9a-f]{64}$ ]] || fail "invalid package checksum"
+      [[ -z ${package_names[$package]:-} && -z ${package_files[$filename]:-} ]] || fail "duplicate package record"
+      package_names[$package]=1
+      package_files[$filename]=1
+      described_files[$filename]=1
+      described_files[$signature_filename]=1
+      archive=$repository/$filename
+      signature=$repository/$signature_filename
+      [[ $(sha256sum "$archive" | cut -d' ' -f1) == $archive_sha ]] || fail "package checksum mismatch: $filename"
+      [[ $(sha256sum "$signature" | cut -d' ' -f1) == $signature_sha ]] || fail "package signature checksum mismatch: $filename"
+      verify_signature "$archive" "$signature"
+      metadata=$(bsdtar -xOf "$archive" .PKGINFO) || fail "could not read package metadata: $filename"
+      [[ $(sed -n 's/^pkgname = //p' <<<"$metadata") == $package ]] || fail "package name mismatch: $filename"
+      [[ $(sed -n 's/^pkgver = //p' <<<"$metadata") == $version ]] || fail "package version mismatch: $filename"
+      [[ $(sed -n 's/^arch = //p' <<<"$metadata") == $architecture ]] || fail "package architecture mismatch: $filename"
+      ((package_records += 1))
+      ;;
+    asset=*)
+      record=${line#asset=}
+      IFS='|' read -r filename asset_sha extra <<<"$record"
+      [[ -z $extra && $filename =~ ^[A-Za-z0-9._-]+$ && $asset_sha =~ ^[0-9a-f]{64}$ ]] || fail "invalid asset record"
+      [[ -z ${described_assets[$filename]:-} ]] || fail "duplicate asset record"
+      described_assets[$filename]=1
+      described_files[$filename]=1
+      [[ -s $repository/$filename ]] || fail "missing repository asset: $filename"
+      [[ $(sha256sum "$repository/$filename" | cut -d' ' -f1) == $asset_sha ]] || fail "asset checksum mismatch: $filename"
+      ((asset_records += 1))
+      ;;
+    "") ;;
+    *) fail "unknown candidate descriptor entry"
+  esac
+done <"$descriptor"
+
+[[ $format == "1" && $channel == "candidate" ]] || fail "unsupported candidate descriptor"
+[[ $release_tag == $expected_tag ]] || fail "release tag does not match the candidate descriptor"
+[[ $source_commit == ${expected_tag#asahi-packages-candidate-} ]] || fail "source commit does not match the release tag"
+[[ $workflow_run =~ ^[1-9][0-9]*$ && $runner_arch == "aarch64" ]] || fail "invalid build identity"
+[[ $signing_fingerprint == $expected_signing_fingerprint ]] || fail "signing fingerprint does not match the descriptor"
+[[ $package_count == "21" && $package_records == 21 ]] || fail "candidate does not contain exactly 21 packages"
+
+required_assets=(
+  omarchy.db
+  omarchy.db.sig
+  omarchy.files
+  omarchy.files.sig
+  transaction-clean.log
+  transaction-upgrade.log
+  transaction-repositories.sha256
+)
+(( asset_records == ${#required_assets[@]} )) || fail "candidate repository asset count is incorrect"
+for asset in "${required_assets[@]}"; do
+  [[ -n ${described_assets[$asset]:-} ]] || fail "candidate descriptor is missing $asset"
+done
+verify_signature "$repository/omarchy.db" "$repository/omarchy.db.sig"
+verify_signature "$repository/omarchy.files" "$repository/omarchy.files.sig"
+
+described_files[CANDIDATE]=1
+described_files[CANDIDATE.sig]=1
+described_files[SHA256SUMS]=1
+while IFS= read -r -d '' file; do
+  filename=${file##*/}
+  [[ -n ${described_files[$filename]:-} ]] || fail "unexpected release asset: $filename"
+done < <(find "$repository" -maxdepth 1 -type f -print0)
+(( $(find "$repository" -maxdepth 1 -type f | wc -l) == ${#described_files[@]} )) ||
+  fail "release asset inventory is incomplete"
+
+(
+  cd "$repository"
+  sha256sum --check --strict SHA256SUMS >/dev/null
+) || fail "SHA256SUMS verification failed"
+
+echo "Verified Apple Silicon package candidate $expected_tag ($expected_descriptor_sha256)"

--- a/docs/apple-silicon-integration-roadmap.md
+++ b/docs/apple-silicon-integration-roadmap.md
@@ -215,9 +215,10 @@ but they do not carry implied approval, schedule, or support promises.
 ## Research basis
 
 - [Detailed Phase 1 plan](apple-silicon-phase-1-plan.md)
+- [Detailed Phase 2 plan](apple-silicon-phase-2-plan.md)
 - [`omarchy-iso` generic aarch64 plan](https://github.com/omacom-io/omarchy-iso/blob/quattro/plans/aarch64-support.md)
 - [Asahi distribution guidelines](https://asahilinux.org/docs/alt/policy/)
 - [Asahi boot process](https://asahilinux.org/docs/alt/boot-process-guide/)
 - [Asahi feature support](https://asahilinux.org/docs/platform/feature-support/overview/)
 
-Research snapshot: 2026-08-23.
+Research snapshot: 2026-08-24.

--- a/docs/apple-silicon-phase-2-plan.md
+++ b/docs/apple-silicon-phase-2-plan.md
@@ -243,6 +243,34 @@ release validation, but it must not create GitHub Secrets, publish a release,
 delete an old candidate, or promote a stable snapshot. Those are explicit
 operator actions after review.
 
+## Implementation status
+
+The safe, non-publishing implementation slice is now present on the Phase 2
+branches:
+
+- `maralcbr/omarchy-pkgs` builds all 12 reviewed sources as a native ARM
+  matrix, assembles the complete 21-package repository, and exercises signed
+  clean-install and previous-snapshot upgrade transactions in disposable
+  containers;
+- production publication validates that the imported credential is a dedicated
+  secret signing subkey, rejects the personal release fingerprint, and forces
+  the exact subkey selector;
+- this fork can verify a downloaded candidate offline against its exact tag,
+  descriptor digest, public signing-subkey fingerprint, signatures, checksums,
+  package count, and closed asset inventory without changing pacman state;
+- promotion and retention are implemented as dry-run-first operator tools;
+  promotion requires a matching acceptance record and verifies byte identity,
+  while retention preserves stable releases and defaults to keeping uncertain
+  candidates; and
+- the local host now has QEMU aarch64 support and usable KVM acceleration. The
+  fresh-system VM defaults to 6 GiB, but the full VM and hardware gates remain
+  intentionally pending until an immutable candidate exists.
+
+No candidate or stable release has been published, no GitHub signing secret has
+been created, and the installer continues to use the existing stable snapshot.
+Those boundaries keep this work isolated from both the active Omarchy session
+and current online installers.
+
 ## Research basis
 
 - [Six-phase integration roadmap](apple-silicon-integration-roadmap.md)

--- a/docs/apple-silicon-phase-2-plan.md
+++ b/docs/apple-silicon-phase-2-plan.md
@@ -1,0 +1,256 @@
+# Apple Silicon Integration — Phase 2 Package Publication Plan
+
+> **Decision:** Phase 2 uses the existing public
+> [`maralcbr/omarchy-pkgs`](https://github.com/maralcbr/omarchy-pkgs)
+> repository to build and publish immutable ARM package candidates. Candidates
+> are public GitHub prereleases. Promotion copies the exact accepted assets into
+> a stable snapshot without rebuilding them.
+
+This is a downstream package-publication and qualification system. It does not
+claim official Omarchy media, upstream package ownership, or supported Apple
+hardware.
+
+## Outcome
+
+Phase 2 replaces the current one-off 21-package snapshot with a repeatable,
+auditable path:
+
+1. build all 21 repository packages on native GitHub-hosted ARM runners;
+2. sign every package and the repository metadata with a dedicated ARM
+   repository signing subkey;
+3. publish an immutable public candidate prerelease;
+4. make this fork consume that exact release tag and descriptor digest;
+5. prove dependency resolution and clean installation and upgrade transactions;
+6. run fresh-system VM and physical Apple Silicon acceptance locally; and
+7. promote the exact accepted release assets without rebuilding.
+
+The current x86-64 path and the externally owned Asahi kernel, firmware, device
+trees, and boot policy remain out of scope.
+
+## Verified starting position
+
+The implementation begins with working evidence rather than a blank pipeline:
+
+- `maralcbr/omarchy-pkgs` is public and the repository owner has admin access.
+- The repository already contains the 12 ARM package sources that produce the
+  current 21-package repository, transaction checks, release helpers, and an
+  ARM GitHub Actions workflow.
+- The current workflow builds all sources in one `ubuntu-24.04-arm` workspace,
+  signs with the personal release key, and publishes a normal immutable release.
+  Phase 2 must split those builds, replace the signing credential, and publish
+  candidates as prereleases.
+- The immutable release
+  `asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24` contains all 21
+  packages, detached signatures, `omarchy.db`/`omarchy.files`, and 50 assets.
+  It is about 260 MB; the largest asset is about 165 MB.
+- This fork currently pins that release tag and enforces signed packages with
+  `SigLevel = Required DatabaseOptional`.
+- Standard GitHub Actions use in this public repository currently has no paid
+  minutes requirement. Durable packages belong in GitHub Release assets, not
+  temporary Actions artifacts.
+- A GitHub `ubuntu-24.04-arm` runner is approximately 4 CPU, 16 GB RAM, and
+  14 GB SSD. The build must therefore use per-source matrix jobs instead of one
+  workspace containing every build.
+- The local Apple M1 Pro has 10 cores, 15 GiB RAM, and sufficient disk for the
+  existing 96 GiB sparse VM image. With no swap, the VM should use about 6 GiB;
+  an 8 GiB guest leaves too little host headroom.
+- Docker CLI availability inside Codex does not prove host daemon readiness.
+  `qemu-system-aarch64` is not currently visible and `/dev/kvm` is not exposed
+  in the sandbox. QEMU/KVM must be verified or prepared on the host before the
+  full-VM gate.
+
+## Fixed decisions
+
+- **Repository:** publish candidates and stable snapshots in
+  `maralcbr/omarchy-pkgs`.
+- **Candidate visibility:** use public GitHub prereleases.
+- **Build topology:** one native ARM matrix job per package source, followed by
+  an assembly/check job for the complete 21-package repository.
+- **CI responsibility:** build packages; validate artifact architecture and
+  completeness; generate and sign repository metadata; publish the immutable
+  candidate; read it back; and run repository, dependency, clean-install, and
+  upgrade transaction checks.
+- **Local responsibility:** fresh-system VM validation and physical Apple
+  Silicon hardware acceptance.
+- **Signing:** store only a dedicated ARM repository signing subkey and its
+  passphrase in GitHub Actions Secrets. Keep the personal master key out of
+  Actions. Pin the public fingerprint as protected repository/environment
+  configuration and force GnuPG to use that exact subkey.
+- **Promotion:** download and verify the accepted candidate, then upload those
+  exact bytes to the stable snapshot. Never invoke a build during promotion.
+- **Coverage:** the gate is the complete current set of 21 packages. A partial
+  repository cannot be published or promoted.
+- **Retention:** retain promoted stable snapshots indefinitely; retain at least
+  the newest two unpromoted candidates and every unpromoted candidate younger
+  than 14 days; retain failed candidates for 7 days unless linked to an
+  unresolved defect; retain temporary Actions artifacts for 1 day.
+
+## Candidate contract
+
+Every candidate is identified by both an immutable Git tag and the SHA-256 of a
+small signed release descriptor. The descriptor records at least:
+
+- schema version, candidate tag, and source commit;
+- package source revisions and the expected package count (`21`);
+- each package filename, architecture, version, SHA-256, and signature filename;
+- the repository database/files filenames and SHA-256 values;
+- the exact signing subkey fingerprint;
+- the build workflow run and native runner architecture; and
+- the repository inputs used by dependency resolution.
+
+The descriptor and its detached signature are release assets and are included
+in `SHA256SUMS`. After publication, CI downloads the public assets, verifies the
+descriptor digest and signature, compares the complete asset inventory, and
+performs tests from the downloaded copy. Local acceptance records the candidate
+tag and descriptor digest, not merely a branch or commit.
+
+The fork must reject a candidate when the tag, descriptor digest, signer,
+package count, package checksum, or repository metadata checksum differs. The
+existing stable pin remains the default until a candidate passes every gate.
+
+## Implementation sequence
+
+Code review, candidate publication, local acceptance, and stable promotion are
+separate authority boundaries. Merging workflow support does not publish or
+promote a release.
+
+### P2-PR1 — Candidate build topology and inventory
+
+**Repository:** `maralcbr/omarchy-pkgs`.
+
+- Generate the matrix from the checked-in package-source inventory.
+- Build one source per native ARM job and upload only its package archives as a
+  one-day temporary artifact.
+- Fan the artifacts into a clean assembly job and require exactly the checked-in
+  list of 21 package names, with no duplicates or unexpected archives.
+- Reject non-`aarch64`/`any` artifacts and preserve `.PKGINFO`, `.BUILDINFO`,
+  source revision, build log, and checksums as evidence.
+- Generate an unsigned repository only for pre-publication dependency and
+  transaction checks; signing happens in the protected publication job.
+
+**Gate:** all 21 packages build independently and the assembled repository
+passes completeness, architecture, dependency-resolution, and clean-transaction
+tests. Existing package-reuse and manifest tests remain green.
+
+### P2-PR2 — Dedicated signing and immutable candidate prerelease
+
+**Repository:** `maralcbr/omarchy-pkgs`.
+
+- Replace the personal release-key secret with a dedicated ARM repository
+  signing-subkey secret and passphrase.
+- Require the configured fingerprint, verify that the imported secret material
+  can sign as that exact subkey, and use the `fingerprint!` GnuPG selector.
+- Sign all 21 packages plus `omarchy.db` and `omarchy.files` metadata.
+- Produce and sign the candidate descriptor and `SHA256SUMS`.
+- Publish `asahi-packages-candidate-<source-commit>` as an immutable public
+  GitHub prerelease, then verify the public readback independently.
+- Set every temporary artifact retention period to one day.
+
+**Gate:** a dry run succeeds without a publishing credential; the protected
+publish job refuses the personal master fingerprint, incomplete secret
+material, a partial repository, an existing tag, or a mismatched public
+readback. No candidate is published while implementing or reviewing the PR.
+
+### P2-PR3 — Exact candidate consumption and CI lifecycle tests
+
+**Repositories:** this fork and `maralcbr/omarchy-pkgs`.
+
+- Add an explicit candidate input consisting of release tag plus descriptor
+  SHA-256. Do not silently follow `latest`, a branch, or a mutable URL.
+- Verify the descriptor signature and dedicated subkey fingerprint before
+  changing pacman configuration.
+- Configure the release-asset repository only after descriptor and complete
+  asset validation; keep `SigLevel = Required DatabaseOptional` or stronger.
+- Run dependency resolution, a clean installation of the full required
+  transaction, an upgrade from the previous accepted snapshot, and a no-op
+  second upgrade against assets downloaded from the public prerelease.
+- Confirm that PC boot packages are not introduced and approved Asahi
+  repositories are preserved.
+
+**Gate:** CI proves install and upgrade from the exact public candidate and the
+fork records the tag, descriptor digest, and signer as reviewable inputs.
+
+### P2-PR4 — Local fresh-system and hardware acceptance
+
+**Execution host:** the local Apple Silicon machine.
+
+- Verify host-side QEMU availability and the usable acceleration path outside
+  the Codex sandbox. If KVM is unavailable on the host, record the slower TCG
+  path rather than treating sandbox isolation as a hardware failure.
+- Use an approximately 6 GiB aarch64 guest and close memory-heavy applications
+  before running it.
+- Install a fresh system from the exact candidate tag/digest, reboot, update
+  from the previous accepted snapshot, and capture package/signature evidence.
+- On physical hardware, exercise boot, display/GPU, input, networking, audio,
+  suspend/resume, shutdown, and recovery expectations already defined by the
+  Apple Silicon roadmap.
+- Store a signed acceptance record containing candidate identity, machine
+  identity, test versions, results, known defects, and evidence locations.
+
+**Gate:** both VM and hardware acceptance pass with no unresolved release-
+blocking defect. Container checks alone cannot satisfy this gate.
+
+### P2-PR5 — Byte-identical promotion and retention
+
+**Repository:** `maralcbr/omarchy-pkgs`; protected manual environment.
+
+- Require the accepted candidate tag, descriptor digest, and local acceptance
+  record as promotion inputs.
+- Download assets from the public candidate, verify all signatures and
+  checksums, and compare their inventory with the signed descriptor.
+- Create the stable snapshot by uploading the same bytes. The promotion job has
+  no checkout, compiler, package builder, or rebuild step.
+- Read the stable assets back and prove that each byte hash matches the
+  candidate before marking the release promoted.
+- Apply retention conservatively: stable snapshots are never deleted; keep the
+  newest two unpromoted candidates even when older than 14 days, and keep all
+  unpromoted candidates younger than 14 days; keep failed candidates for at
+  least 7 days and indefinitely while an unresolved defect references them.
+  Default to retention when defect status cannot be determined.
+
+**Gate:** the stable descriptor and every stable package/database asset have
+the same SHA-256 as the accepted candidate, and a final clean install and
+upgrade read only stable release assets.
+
+## Phase 2 completion gate
+
+Phase 2 is complete only when:
+
+- all 21 package outputs are built and checked in isolated native ARM matrix
+  jobs;
+- the dedicated ARM signing subkey is the only private signing material
+  available to Actions and its public fingerprint is pinned;
+- an immutable public candidate passes independent public readback;
+- this fork consumes the exact candidate tag and descriptor digest;
+- clean dependency, install, and upgrade transactions pass against downloaded
+  public assets;
+- fresh-system VM and physical Apple Silicon acceptance pass locally;
+- promotion copies the accepted bytes without rebuilding and stable readback
+  proves byte identity;
+- the retention policy is automated, conservative on uncertainty, and covered
+  by dry-run tests; and
+- no user-facing text expands the result into an official upstream or supported
+  Apple hardware claim.
+
+Any failed item leaves Phase 2 open. A local package build, a container install,
+or a candidate prerelease alone is not sufficient.
+
+## Immediate implementation boundary
+
+The first safe implementation slice is P2-PR1 plus the non-secret scaffolding
+of P2-PR2. It may change and test workflow code, descriptor generation, and
+release validation, but it must not create GitHub Secrets, publish a release,
+delete an old candidate, or promote a stable snapshot. Those are explicit
+operator actions after review.
+
+## Research basis
+
+- [Six-phase integration roadmap](apple-silicon-integration-roadmap.md)
+- [Detailed Phase 1 plan](apple-silicon-phase-1-plan.md)
+- [`maralcbr/omarchy-pkgs`](https://github.com/maralcbr/omarchy-pkgs)
+- [GitHub hosted runners](https://docs.github.com/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners)
+- [GitHub release management](https://docs.github.com/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+- [Asahi distribution guidelines](https://asahilinux.org/docs/alt/policy/)
+- [MX signed repository evidence](releases/v4.0.0-mac.15.md)
+
+Verified decision and environment snapshot: 2026-08-24.

--- a/test/shell.d/asahi-fresh-install-test.sh
+++ b/test/shell.d/asahi-fresh-install-test.sh
@@ -93,8 +93,8 @@ grep -Fq 'env OMARCHY_VM_STABLE_VERSION="$stable_version"' "$vm_runner" || fail 
 grep -Fq 'grep -Fxq "version=$OMARCHY_VM_STABLE_VERSION"' "$vm_installer" || fail "VM validates the published stable version without a stale hardcode"
 pass "fresh-install VM tracks the candidate stable version"
 
-grep -Fq 'vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}' "$vm_runner" || fail "VM runner keeps the 8 GiB default"
+grep -Fq 'vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-6144}' "$vm_runner" || fail "VM runner keeps the 6 GiB default"
 grep -Fq 'docker exec -e OMARCHY_VM_MEMORY_MB="$vm_memory_mb"' "$vm_runner" || fail "VM runner passes the memory override"
-grep -Fq 'memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}' "$vm_launcher" || fail "VM launcher accepts the memory override"
+grep -Fq 'memory_mb=${OMARCHY_VM_MEMORY_MB:-6144}' "$vm_launcher" || fail "VM launcher accepts the memory override"
 grep -Fq -- '-m "$memory_mb"' "$vm_launcher" || fail "QEMU uses the configured guest memory"
 pass "fresh-install VM supports constrained hosts"

--- a/test/shell.d/asahi-package-candidate-test.sh
+++ b/test/shell.d/asahi-package-candidate-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+repository=$test_tmp/repository
+export GNUPGHOME=$test_tmp/gnupg
+mkdir "$repository"
+mkdir -m 0700 "$GNUPGHOME"
+
+passphrase=phase-2-candidate-test
+commit=1111111111111111111111111111111111111111
+tag=asahi-packages-candidate-$commit
+
+gpg --batch --pinentry-mode loopback --passphrase "$passphrase" \
+  --quick-generate-key 'Candidate Fixture <candidate@example.invalid>' ed25519 cert 1d >/dev/null 2>&1
+primary_fingerprint=$(gpg --batch --list-secret-keys --with-colons |
+  awk -F: '$1 == "sec" { primary=1; next } primary && $1 == "fpr" { print $10; exit }')
+gpg --batch --pinentry-mode loopback --passphrase "$passphrase" \
+  --quick-add-key "$primary_fingerprint" ed25519 sign 1d >/dev/null 2>&1
+signing_fingerprint=$(gpg --batch --list-secret-keys --with-colons |
+  awk -F: '$1 == "ssb" { subkey=1; next } subkey && $1 == "fpr" { print $10; exit }')
+gpg --batch --export "$primary_fingerprint" >"$test_tmp/candidate.gpg"
+
+sign() {
+  gpg --batch --yes --pinentry-mode loopback --passphrase "$passphrase" \
+    --local-user "$signing_fingerprint!" --detach-sign "$1"
+}
+
+for number in $(seq -w 1 21); do
+  package=phase-two-package-$number
+  metadata=$test_tmp/.PKGINFO
+  printf 'pkgname = %s\npkgver = 1.2.%s-1\narch = aarch64\n' "$package" "$number" >"$metadata"
+  archive=$repository/$package-1.2.$number-1-aarch64.pkg.tar.zst
+  bsdtar -cf "$archive" -C "$test_tmp" .PKGINFO
+  sign "$archive"
+done
+
+for asset in omarchy.db omarchy.files transaction-clean.log transaction-upgrade.log transaction-repositories.sha256; do
+  printf '%s fixture\n' "$asset" >"$repository/$asset"
+done
+sign "$repository/omarchy.db"
+sign "$repository/omarchy.files"
+
+{
+  printf 'format=1\n'
+  printf 'channel=candidate\n'
+  printf 'release_tag=%s\n' "$tag"
+  printf 'source_commit=%s\n' "$commit"
+  printf 'workflow_run=42\n'
+  printf 'runner_arch=aarch64\n'
+  printf 'signing_fingerprint=%s\n' "$signing_fingerprint"
+  printf 'package_count=21\n'
+  index=0
+  for archive in "$repository"/*.pkg.tar.zst; do
+    ((index += 1))
+    metadata=$(bsdtar -xOf "$archive" .PKGINFO)
+    package=$(sed -n 's/^pkgname = //p' <<<"$metadata")
+    version=$(sed -n 's/^pkgver = //p' <<<"$metadata")
+    filename=${archive##*/}
+    printf 'package=%s|%s|%s|aarch64|%s|%s|%s.sig|%s\n' \
+      "$index" "$package" "$version" "$filename" \
+      "$(sha256sum "$archive" | cut -d' ' -f1)" "$filename" \
+      "$(sha256sum "$archive.sig" | cut -d' ' -f1)"
+  done
+  for asset in omarchy.db omarchy.db.sig omarchy.files omarchy.files.sig transaction-clean.log transaction-upgrade.log transaction-repositories.sha256; do
+    printf 'asset=%s|%s\n' "$asset" "$(sha256sum "$repository/$asset" | cut -d' ' -f1)"
+  done
+} >"$repository/CANDIDATE"
+sign "$repository/CANDIDATE"
+(
+  cd "$repository"
+  sha256sum -- * >SHA256SUMS
+)
+descriptor_sha256=$(sha256sum "$repository/CANDIDATE" | cut -d' ' -f1)
+
+"$ROOT/bin/omarchy-pkg-repository-verify-candidate" \
+  "$repository" "$tag" "$descriptor_sha256" "$signing_fingerprint" "$test_tmp/candidate.gpg" >/dev/null
+pass "exact signed package candidate is accepted"
+
+if "$ROOT/bin/omarchy-pkg-repository-verify-candidate" \
+  "$repository" "$tag" "$(printf '0%.0s' {1..64})" "$signing_fingerprint" "$test_tmp/candidate.gpg" >/dev/null 2>&1; then
+  fail "candidate verifier accepted the wrong descriptor digest"
+fi
+pass "candidate descriptor digest is pinned"
+
+if "$ROOT/bin/omarchy-pkg-repository-verify-candidate" \
+  "$repository" "$tag" "$descriptor_sha256" "$primary_fingerprint" "$test_tmp/candidate.gpg" >/dev/null 2>&1; then
+  fail "candidate verifier accepted the primary fingerprint"
+fi
+pass "candidate signer must be the exact signing subkey"
+
+printf 'unexpected\n' >"$repository/unexpected"
+if "$ROOT/bin/omarchy-pkg-repository-verify-candidate" \
+  "$repository" "$tag" "$descriptor_sha256" "$signing_fingerprint" "$test_tmp/candidate.gpg" >/dev/null 2>&1; then
+  fail "candidate verifier accepted an unexpected release asset"
+fi
+pass "candidate release asset inventory is closed"

--- a/test/vm/asahi-fresh/README.md
+++ b/test/vm/asahi-fresh/README.md
@@ -23,7 +23,9 @@ Run:
 test/vm/asahi-fresh/run
 ```
 
-The guest uses 8 vCPUs, 8 GiB RAM, and a 96 GiB sparse disk.
+The guest uses 8 vCPUs, 6 GiB RAM, and a 96 GiB sparse disk. Set
+`OMARCHY_VM_MEMORY_MB` explicitly when a different disposable-guest limit is
+required.
 
 Use `--rebuild-base` to discard the cached Arch Linux ARM base and `--keep` to
 retain the VM container after a run. State and failure artifacts are written to

--- a/test/vm/asahi-fresh/container/start-vm
+++ b/test/vm/asahi-fresh/container/start-vm
@@ -6,7 +6,7 @@ run=/work/run
 base=/work/cache/archarm-base.qcow2
 code=/usr/share/AAVMF/AAVMF_CODE.fd
 vars_template=/usr/share/AAVMF/AAVMF_VARS.fd
-memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}
+memory_mb=${OMARCHY_VM_MEMORY_MB:-6144}
 
 rm -rf "$run"
 mkdir -p "$run"

--- a/test/vm/asahi-fresh/run
+++ b/test/vm/asahi-fresh/run
@@ -12,7 +12,7 @@ vnc_port=${OMARCHY_VM_VNC_PORT:-25900}
 keep=0
 rebuild=0
 optional_packages=0
-vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-8192}
+vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-6144}
 
 [[ $vm_memory_mb =~ ^[1-9][0-9]*$ ]] || {
   echo "OMARCHY_VM_MEMORY_MB must be a positive integer" >&2


### PR DESCRIPTION
Adds the non-publishing Phase 2 foundation:

- exact offline verification for immutable 21-package candidates
- 6 GiB default for disposable Apple Silicon VM acceptance
- Phase 2 publication and safety-boundary documentation

The current installer release tag, signing key, and pacman configuration are unchanged.