### PR TITLE
Test exact ARM package candidates in VM

### DIFF
--- a/test/shell.d/asahi-fresh-install-test.sh
+++ b/test/shell.d/asahi-fresh-install-test.sh
@@ -8,9 +8,11 @@ installer="$ROOT/bin/omarchy-install-asahi-fresh"
 wrapper="$ROOT/install-omarchy-mx-mac"
 vm_runner="$ROOT/test/vm/asahi-fresh/run"
 vm_installer="$ROOT/test/vm/asahi-fresh/guest/install"
+vm_candidate="$ROOT/test/vm/asahi-fresh/guest/candidate-repository"
+vm_verify="$ROOT/test/vm/asahi-fresh/guest/verify"
 vm_launcher="$ROOT/test/vm/asahi-fresh/container/start-vm"
 
-bash -n "$installer" "$wrapper" "$vm_runner" "$vm_installer" "$vm_launcher"
+bash -n "$installer" "$wrapper" "$vm_runner" "$vm_installer" "$vm_candidate" "$vm_verify" "$vm_launcher"
 "$installer" --help 2>&1 | grep -Fq -- '--asahi-packages DIR'
 pass "fresh Asahi installer exposes the verified bundle entrypoint"
 
@@ -98,3 +100,12 @@ grep -Fq 'docker exec -e OMARCHY_VM_MEMORY_MB="$vm_memory_mb"' "$vm_runner" || f
 grep -Fq 'memory_mb=${OMARCHY_VM_MEMORY_MB:-6144}' "$vm_launcher" || fail "VM launcher accepts the memory override"
 grep -Fq -- '-m "$memory_mb"' "$vm_launcher" || fail "QEMU uses the configured guest memory"
 pass "fresh-install VM supports constrained hosts"
+
+grep -Fq 'candidate_tag=${OMARCHY_VM_CANDIDATE_TAG:-}' "$vm_runner" || fail "VM runner accepts an exact package candidate tag"
+grep -Fq 'candidate_sha256=${OMARCHY_VM_CANDIDATE_SHA256:-}' "$vm_runner" || fail "VM runner accepts an exact candidate descriptor checksum"
+grep -Fq 'candidate_fingerprint=${OMARCHY_VM_CANDIDATE_FINGERPRINT:-}' "$vm_runner" || fail "VM runner accepts an exact candidate signing fingerprint"
+grep -Fq 'release_tag=$tag' "$vm_candidate" || fail "VM candidate gate binds the descriptor release tag"
+grep -Fq 'valid_fingerprint == "${signing_fingerprint^^}"' "$vm_candidate" || fail "VM candidate gate binds the descriptor signature"
+grep -Fq 'pacman -Syu --needed --noconfirm "${packages[@]}"' "$vm_candidate" || fail "VM candidate gate installs all descriptor packages"
+grep -Fq 'candidate package version: $package' "$vm_verify" || fail "VM verifies candidate versions after reboot"
+pass "fresh-install VM can consume an exact signed package candidate"

--- a/test/vm/asahi-fresh/README.md
+++ b/test/vm/asahi-fresh/README.md
@@ -37,3 +37,18 @@ after the reboot checks. Each transaction gets a separate log under
 `test-runs/run/optional-package-logs/`. This validates package installation and
 post-install hooks in a disposable system, but it does not automate application
 login, GUI interaction, or hardware behavior.
+
+To run the full lifecycle after installing an exact immutable package candidate,
+provide its trusted identity explicitly:
+
+```bash
+OMARCHY_VM_CANDIDATE_TAG=asahi-packages-candidate-<40-hex-commit> \
+OMARCHY_VM_CANDIDATE_SHA256=<64-hex-descriptor-checksum> \
+OMARCHY_VM_CANDIDATE_FINGERPRINT=<40-hex-signing-subkey> \
+test/vm/asahi-fresh/run
+```
+
+This opt-in path verifies the signed descriptor inside the guest, installs all
+21 candidate packages through the exact release repository, and checks their
+versions again after the full install and reboot. It does not alter the stable
+repository pin used by the production installer or the default VM path.

--- a/test/vm/asahi-fresh/guest/candidate-repository
+++ b/test/vm/asahi-fresh/guest/candidate-repository
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+tag=${OMARCHY_VM_CANDIDATE_TAG:?Missing exact candidate tag}
+descriptor_sha256=${OMARCHY_VM_CANDIDATE_SHA256:?Missing exact candidate descriptor checksum}
+signing_fingerprint=${OMARCHY_VM_CANDIDATE_FINGERPRINT:?Missing exact candidate signing fingerprint}
+key_file=/root/omarchy-arm-repository.asc
+repository_url="https://github.com/maralcbr/omarchy-pkgs/releases/download/$tag"
+work=/root/omarchy-package-candidate
+
+[[ $tag =~ ^asahi-packages-candidate-[0-9a-f]{40}$ ]]
+[[ $descriptor_sha256 =~ ^[0-9a-fA-F]{64}$ ]]
+[[ $signing_fingerprint =~ ^[0-9a-fA-F]{40}$ ]]
+[[ -r $key_file ]]
+
+rm -rf "$work"
+mkdir -m 0700 "$work"
+curl --fail --location --connect-timeout 15 --max-time 300 --retry 3 --retry-all-errors \
+  "$repository_url/CANDIDATE" --output "$work/CANDIDATE"
+curl --fail --location --connect-timeout 15 --max-time 300 --retry 3 --retry-all-errors \
+  "$repository_url/CANDIDATE.sig" --output "$work/CANDIDATE.sig"
+[[ $(sha256sum "$work/CANDIDATE" | cut -d' ' -f1) == "${descriptor_sha256,,}" ]]
+grep -Fxq 'format=1' "$work/CANDIDATE"
+grep -Fxq 'channel=candidate' "$work/CANDIDATE"
+grep -Fxq "release_tag=$tag" "$work/CANDIDATE"
+grep -Fxq "source_commit=${tag#asahi-packages-candidate-}" "$work/CANDIDATE"
+grep -Fxq "signing_fingerprint=${signing_fingerprint^^}" "$work/CANDIDATE"
+grep -Fxq 'package_count=21' "$work/CANDIDATE"
+(( $(grep -c '^package=' "$work/CANDIDATE") == 21 ))
+
+export GNUPGHOME=$work/gnupg
+mkdir -m 0700 "$GNUPGHOME"
+gpg --batch --import "$key_file" >/dev/null 2>&1
+signature_status=$(gpg --batch --status-fd 1 --verify "$work/CANDIDATE.sig" "$work/CANDIDATE" 2>/dev/null)
+valid_fingerprint=$(awk '$2 == "VALIDSIG" { print $3; exit }' <<<"$signature_status")
+[[ $valid_fingerprint == "${signing_fingerprint^^}" ]]
+primary_fingerprint=$(gpg --batch --show-keys --with-colons "$key_file" |
+  awk -F: '$1 == "pub" { primary=1; next } primary && $1 == "fpr" { print $10; exit }')
+[[ $primary_fingerprint =~ ^[A-F0-9]{40}$ ]]
+
+pacman-key --add "$key_file"
+pacman-key --lsign-key "$primary_fingerprint"
+
+awk '
+  /^\[omarchy\]$/ { skip=1; next }
+  skip && /^\[[^]]+\]$/ { skip=0 }
+  !skip { print }
+' /etc/pacman.conf >"$work/pacman.conf.without-omarchy"
+{
+  printf '%s\n' '[omarchy]'
+  printf '%s\n' 'SigLevel = Required DatabaseOptional'
+  printf 'Server = %s\n\n' "$repository_url"
+  cat "$work/pacman.conf.without-omarchy"
+} >"$work/pacman.conf"
+install -m 0644 "$work/pacman.conf" /etc/pacman.conf
+
+packages=()
+while IFS='|' read -r _ package version _ _ _ _ _; do
+  [[ $package =~ ^[a-z0-9@._+-]+$ && -n $version ]]
+  packages+=("$package")
+done < <(sed -n 's/^package=//p' "$work/CANDIDATE")
+(( ${#packages[@]} == 21 ))
+(( $(printf '%s\n' "${packages[@]}" | sort -u | wc -l) == 21 ))
+
+pacman -Syu --needed --noconfirm "${packages[@]}"
+while IFS='|' read -r _ package version _ _ _ _ _; do
+  [[ $(pacman -Q "$package" | cut -d' ' -f2) == "$version" ]]
+done < <(sed -n 's/^package=//p' "$work/CANDIDATE")
+
+install -Dm644 "$work/CANDIDATE" /var/lib/omarchy/vm-package-candidate
+printf '%s\n' "$descriptor_sha256" | install -Dm644 /dev/stdin /var/lib/omarchy/vm-package-candidate.sha256
+printf '%s\n' "$primary_fingerprint" | install -Dm644 /dev/stdin /var/lib/omarchy/vm-package-candidate-primary-fingerprint
+echo "Installed exact signed package candidate $tag"

--- a/test/vm/asahi-fresh/guest/verify
+++ b/test/vm/asahi-fresh/guest/verify
@@ -26,6 +26,20 @@ grep -Fxq '[omarchy]' /etc/pacman.conf || fail "signed Apple Silicon package rep
 grep -Fxq 'SigLevel = Required DatabaseOptional' /etc/pacman.conf || fail "Apple Silicon package signature policy"
 grep -Fxq 'Server = https://github.com/maralcbr/omarchy-pkgs/releases/download/asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24' /etc/pacman.conf || fail "immutable Apple Silicon package repository"
 pacman-key --finger 5983B1CA32CB778F4D74D24ECFF35022CA5B5959 >/dev/null || fail "Apple Silicon package signing key"
+if [[ -f /var/lib/omarchy/vm-package-candidate ]]; then
+  candidate=/var/lib/omarchy/vm-package-candidate
+  candidate_sha256=$(< /var/lib/omarchy/vm-package-candidate.sha256)
+  candidate_primary_fingerprint=$(< /var/lib/omarchy/vm-package-candidate-primary-fingerprint)
+  [[ $(sha256sum "$candidate" | cut -d' ' -f1) == "${candidate_sha256,,}" ]] || fail "candidate descriptor checksum"
+  grep -Fxq 'channel=candidate' "$candidate" || fail "candidate channel"
+  grep -Eq '^release_tag=asahi-packages-candidate-[0-9a-f]{40}$' "$candidate" || fail "candidate release tag"
+  grep -Fxq 'package_count=21' "$candidate" || fail "candidate package count"
+  (( $(grep -c '^package=' "$candidate") == 21 )) || fail "candidate package inventory"
+  pacman-key --finger "$candidate_primary_fingerprint" >/dev/null || fail "candidate signing certificate"
+  while IFS='|' read -r _ package version _ _ _ _ _; do
+    [[ $(pacman -Q "$package" | cut -d' ' -f2) == "$version" ]] || fail "candidate package version: $package"
+  done < <(sed -n 's/^package=//p' "$candidate")
+fi
 for unit in NetworkManager.service sddm.service systemd-resolved.service; do
   systemctl is-enabled --quiet "$unit" || fail "$unit enabled"
 done

--- a/test/vm/asahi-fresh/run
+++ b/test/vm/asahi-fresh/run
@@ -13,11 +13,34 @@ keep=0
 rebuild=0
 optional_packages=0
 vm_memory_mb=${OMARCHY_VM_MEMORY_MB:-6144}
+candidate_tag=${OMARCHY_VM_CANDIDATE_TAG:-}
+candidate_sha256=${OMARCHY_VM_CANDIDATE_SHA256:-}
+candidate_fingerprint=${OMARCHY_VM_CANDIDATE_FINGERPRINT:-}
+candidate_key=${OMARCHY_VM_CANDIDATE_KEY_FILE:-$root/default/omarchy-arm-repository.asc}
 
 [[ $vm_memory_mb =~ ^[1-9][0-9]*$ ]] || {
   echo "OMARCHY_VM_MEMORY_MB must be a positive integer" >&2
   exit 1
 }
+
+if [[ -n $candidate_tag || -n $candidate_sha256 || -n $candidate_fingerprint ]]; then
+  [[ $candidate_tag =~ ^asahi-packages-candidate-[0-9a-f]{40}$ ]] || {
+    echo "OMARCHY_VM_CANDIDATE_TAG must identify an exact candidate commit" >&2
+    exit 1
+  }
+  [[ $candidate_sha256 =~ ^[0-9a-fA-F]{64}$ ]] || {
+    echo "OMARCHY_VM_CANDIDATE_SHA256 must be an exact descriptor checksum" >&2
+    exit 1
+  }
+  [[ $candidate_fingerprint =~ ^[0-9a-fA-F]{40}$ ]] || {
+    echo "OMARCHY_VM_CANDIDATE_FINGERPRINT must be an exact signing fingerprint" >&2
+    exit 1
+  }
+  [[ -r $candidate_key ]] || {
+    echo "OMARCHY_VM_CANDIDATE_KEY_FILE is not readable" >&2
+    exit 1
+  }
+fi
 
 while (($#)); do
   case "$1" in
@@ -103,6 +126,16 @@ wait_for_reboot() {
 }
 
 wait_for_ssh || { tail -200 "$state/run/serial.log"; exit 1; }
+if [[ -n $candidate_tag ]]; then
+  scp "${scp_args[@]}" "$candidate_key" root@127.0.0.1:/root/omarchy-arm-repository.asc
+  scp "${scp_args[@]}" "$harness/guest/candidate-repository" root@127.0.0.1:/root/omarchy-vm-candidate-repository
+  ssh "${ssh_args[@]}" root@127.0.0.1 env \
+    OMARCHY_VM_CANDIDATE_TAG="$candidate_tag" \
+    OMARCHY_VM_CANDIDATE_SHA256="$candidate_sha256" \
+    OMARCHY_VM_CANDIDATE_FINGERPRINT="$candidate_fingerprint" \
+    bash /root/omarchy-vm-candidate-repository |
+    tee "$state/run/candidate-repository.log"
+fi
 scp "${scp_args[@]}" "$root/bin/omarchy-install-asahi-fresh" root@127.0.0.1:/root/omarchy-install-asahi-fresh.candidate
 scp "${scp_args[@]}" "$root/bin/omarchy-update-asahi-bundle" root@127.0.0.1:/root/omarchy-update-asahi-bundle.candidate
 scp "${scp_args[@]}" "$harness/guest/install" root@127.0.0.1:/root/omarchy-vm-install


### PR DESCRIPTION
## Summary
- add opt-in exact candidate tag, descriptor digest, and signing fingerprint inputs to the disposable aarch64 VM harness
- verify and install all 21 signed candidate packages inside the guest
- recheck exact candidate versions after the full fresh install and reboot
- keep the production stable repository pin and default VM path unchanged

## Verification
- full 6 GiB native aarch64 Docker/KVM fresh-system run passed
- exact signed candidate and all 21 package versions passed before and after reboot
- interruption recovery and completed-installer rerun rejection passed
- `./test/shell.d/asahi-fresh-install-test.sh`
- `./test/shell.d/asahi-package-candidate-test.sh`
- `git diff --check`