### PR TITLE
Fix Apple Silicon display backlight selection

### DIFF
--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -7,11 +7,11 @@ backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
 
 # Start with the first possible output, then refine to the most likely given an order heuristic.
 # Glob the candidates in the loop list: [[ ]] does not do pathname expansion.
-# The Touch Bar on T2 Macs registers a backlight that never drives the display panel.
-device="$(ls -1 "$backlight_path" 2>/dev/null | grep -vx appletb_backlight | head -n1)"
+# Touch Bars register backlights that never drive the built-in display panel.
+device="$(ls -1 "$backlight_path" 2>/dev/null | grep -Evx 'appletb_backlight|display-pipe|228600000\.dsi\.0' | head -n1)"
 # gmux comes first: apple-gmux only registers when the kernel has already picked it, and on
 # dual-GPU Macs the GPU's own PWM stops driving the panel once that GPU suspends.
-for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
+for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/apple-panel-bl "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
   if [[ -e $candidate ]]; then
     device="${candidate##*/}"
     break

--- a/test/shell.d/hw-display-test.sh
+++ b/test/shell.d/hw-display-test.sh
@@ -46,11 +46,18 @@ device=$(hw_display)
 [[ $device == "gmux_backlight" ]] || fail "a T2 Mac uses gmux instead of the Touch Bar" "actual: $device"
 pass "a T2 Mac uses gmux instead of the Touch Bar"
 
-write_backlights appletb_backlight
-if hw_display >/dev/null 2>&1; then
-  fail "the Touch Bar is never used as the display backlight"
-fi
-pass "the Touch Bar is never used as the display backlight"
+write_backlights 228600000.dsi.0 apple-panel-bl
+device=$(hw_display)
+[[ $device == "apple-panel-bl" ]] || fail "Apple Silicon uses the Retina panel instead of the Touch Bar" "actual: $device"
+pass "Apple Silicon uses the Retina panel instead of the Touch Bar"
+
+for touch_bar in appletb_backlight display-pipe 228600000.dsi.0; do
+  write_backlights "$touch_bar"
+  if hw_display >/dev/null 2>&1; then
+    fail "a Touch Bar is never used as the display backlight" "actual: $touch_bar"
+  fi
+done
+pass "Touch Bars are never used as the display backlight"
 
 write_backlights acpi_video0 amdgpu_bl0 appletb_backlight gmux_backlight intel_backlight
 device=$(hw_display)


### PR DESCRIPTION
## Summary
- prioritize `apple-panel-bl` as the built-in display on Apple Silicon
- exclude the `228600000.dsi.0`, `display-pipe`, and `appletb_backlight` Touch Bar devices from the generic fallback
- add regression coverage for Apple Silicon and every known Touch Bar backlight name

## Problem
On a 13-inch M1 MacBook Pro (`apple,j293`), `/sys/class/backlight` exposes both:

- `apple-panel-bl` — built-in Retina display, driven by `apple-dcp`
- `228600000.dsi.0` — Touch Bar, driven by `panel-summit`

The alphabetical fallback selected `228600000.dsi.0`, so the display brightness keys adjusted the Touch Bar instead of the Retina panel. Asahi's `tiny-dfr` uses the same device classification: https://github.com/AsahiLinux/tiny-dfr/blob/master/src/backlight.rs

## Hardware validation
- before the fix, `omarchy-hw-display` returned `228600000.dsi.0`
- with this branch, `./bin/omarchy-hw-display` returns `apple-panel-bl`
- changing `apple-panel-bl` moved the Retina panel's raw brightness from 140 to 145; the original value was restored afterward

## Verification
- `./test/shell.d/hw-display-test.sh`
- `./test/shell` — all 202 test files passed
- `git diff --check`