### PR TITLE
Restore ARM Node bundle selection for 4.0.1

### DIFF
--- a/install/user/mise-work.sh
+++ b/install/user/mise-work.sh
@@ -13,13 +13,22 @@ mise trust ~/Work/.mise.toml
 # /opt/packages in the ISO chroot, or from the copy staged in provisioning state when
 # omarchy-provision-owner finalizes the user at first boot.
 case ${OMARCHY_SETUP_CONTEXT:-runtime} in
-  iso-chroot) NODE_PACKAGE_DIR=/opt/packages ;;
-  provision-owner) NODE_PACKAGE_DIR=/var/lib/omarchy/provisioning/packages ;;
+  iso-chroot) NODE_PACKAGE_DIR=${OMARCHY_NODE_PACKAGE_DIR:-/opt/packages} ;;
+  provision-owner) NODE_PACKAGE_DIR=${OMARCHY_NODE_PACKAGE_DIR:-/var/lib/omarchy/provisioning/packages} ;;
   *) NODE_PACKAGE_DIR="" ;;
 esac
 
 if [[ -n $NODE_PACKAGE_DIR ]]; then
-  NODE_TARBALL=$(find "$NODE_PACKAGE_DIR" -name "node-v*-linux-x64.tar.gz" -type f 2>/dev/null | head -n1)
+  case $(uname -m) in
+    aarch64|arm64) NODE_ARCH=arm64 ;;
+    x86_64) NODE_ARCH=x64 ;;
+    *)
+      echo "Error: unsupported Node.js architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  NODE_TARBALL=$(find "$NODE_PACKAGE_DIR" -name "node-v*-linux-$NODE_ARCH.tar.gz" -type f 2>/dev/null | head -n1)
   if [[ -z $NODE_TARBALL ]]; then
     if [[ ${OMARCHY_SETUP_CONTEXT:-} == "provision-owner" ]]; then
       # A factory snapshot predating the bundled tarball may not have it staged.
@@ -31,7 +40,9 @@ if [[ -n $NODE_PACKAGE_DIR ]]; then
       exit 1
     fi
   else
-    NODE_VERSION=$(basename "$NODE_TARBALL" | sed 's/node-v\(.*\)-linux-x64.tar.gz/\1/')
+    NODE_VERSION=$(basename "$NODE_TARBALL")
+    NODE_VERSION=${NODE_VERSION#node-v}
+    NODE_VERSION=${NODE_VERSION%-linux-$NODE_ARCH.tar.gz}
     NODE_INSTALL_DIR="$HOME/.local/share/mise/installs/node/$NODE_VERSION"
 
     mkdir -p "$NODE_INSTALL_DIR"

--- a/test/shell.d/mise-work-architecture-test.sh
+++ b/test/shell.d/mise-work-architecture-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+source "$(dirname "$0")/base-test.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/packages"
+
+cat >"$tmp/bin/uname" <<'SH'
+#!/bin/bash
+printf '%s\n' "$TEST_UNAME"
+SH
+
+cat >"$tmp/bin/mise" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$MISE_TEST_LOG"
+SH
+
+chmod +x "$tmp/bin/uname" "$tmp/bin/mise"
+
+run_arch_case() {
+  local machine="$1" archive_arch="$2" version="$3"
+  local home="$tmp/home-$machine" payload="$tmp/payload-$machine"
+  local archive="$tmp/packages/node-v$version-linux-$archive_arch.tar.gz"
+  local log="$tmp/mise-$machine.log"
+
+  mkdir -p "$home" "$payload/node-v$version-linux-$archive_arch/bin"
+  printf '%s\n' "$machine" >"$payload/node-v$version-linux-$archive_arch/bin/node-marker"
+  tar -C "$payload" -czf "$archive" "node-v$version-linux-$archive_arch"
+
+  HOME="$home" \
+    PATH="$tmp/bin:$PATH" \
+    TEST_UNAME="$machine" \
+    MISE_TEST_LOG="$log" \
+    OMARCHY_SETUP_CONTEXT=iso-chroot \
+    OMARCHY_NODE_PACKAGE_DIR="$tmp/packages" \
+    bash -eE -c 'source "$1"' bash "$ROOT/install/user/mise-work.sh"
+
+  grep -Fxq "$machine" "$home/.local/share/mise/installs/node/$version/bin/node-marker" ||
+    fail "$machine installs the matching bundled Node archive"
+  grep -Fxq "use -g node@$version" "$log" ||
+    fail "$machine activates the matching bundled Node version"
+  pass "$machine uses the $archive_arch Node bundle"
+}
+
+run_arch_case aarch64 arm64 26.7.0
+run_arch_case x86_64 x64 24.0.0


### PR DESCRIPTION
Restores the already-reviewed host-architecture Node bundle selection that was omitted by the upstream 4.0.1 synchronization. This is required by the signed ARM runtime assembly gate.\n\nValidation: `./test/all` with isolated HOME and package/ISO checkouts: all 219 test files passed.