### PR TITLE
Fix Apple Silicon updates with active zram

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -17,7 +17,15 @@ if ! omarchy-update-lock held; then
 fi
 
 trap 'echo ""; echo -e "\033[0;31mSomething went wrong during the update!\n\nPlease review the output above carefully, correct the error, and retry the update.\n\nIf you need assistance, get help from the community at https://omarchy.org/discord\033[0m"' ERR
-trap 'omarchy-update-stay-awake stop' EXIT
+cleanup_update() {
+  local status=$?
+
+  trap - EXIT
+  omarchy-update-stay-awake stop || true
+  exit "$status"
+}
+
+trap cleanup_update EXIT
 
 omarchy-update-requires-free-space
 

--- a/bin/omarchy-update-asahi-bundle
+++ b/bin/omarchy-update-asahi-bundle
@@ -196,11 +196,9 @@ for repository in asahi-alarm core extra alarm aur; do
 done
 grep -RqsE '^[[:space:]]*wifi\.backend[[:space:]]*=[[:space:]]*iwd[[:space:]]*$' "$(root_path /etc/NetworkManager)" ||
   fail "NetworkManager is not configured with the iwd backend"
-if [[ -r $(root_path /proc/swaps) ]] && awk 'NR > 1 { found=1 } END { exit !found }' "$(root_path /proc/swaps)"; then
-  fail "swap or zram is active"
-fi
-[[ ! -r $(root_path /sys/module/zswap/parameters/enabled) ]] ||
-  grep -Eq '^(N|0)$' "$(root_path /sys/module/zswap/parameters/enabled)" || fail "zswap is enabled"
+# Active swap and zram are safe here because bundle updates do not repartition
+# storage, and the archive path audit below rejects zram configuration changes.
+# The fresh installer keeps the stricter swap and zswap storage-boundary gates.
 
 base="${OMARCHY_ASAHI_RELEASE_BASE_URL:-https://github.com/$repo/releases/download/$channel_tag}"
 base=${base%/}

--- a/bin/omarchy-update-stay-awake
+++ b/bin/omarchy-update-stay-awake
@@ -70,8 +70,21 @@ stop() {
       current_start_time=$(process_start_time "$inhibit_pid" 2>/dev/null || true)
       if [[ $current_start_time == "$recorded_start_time" ]] &&
         [[ $(process_state "$inhibit_pid" 2>/dev/null || true) != "Z" ]]; then
-        echo "Failed to stop the Omarchy update sleep inhibitor." >&2
-        return 1
+        kill -KILL "$inhibit_pid" >/dev/null 2>&1 || true
+
+        for (( attempt = 0; attempt < 50; attempt++ )); do
+          current_start_time=$(process_start_time "$inhibit_pid" 2>/dev/null || true)
+          [[ $current_start_time == "$recorded_start_time" ]] || break
+          [[ $(process_state "$inhibit_pid" 2>/dev/null || true) != "Z" ]] || break
+          sleep 0.02
+        done
+
+        current_start_time=$(process_start_time "$inhibit_pid" 2>/dev/null || true)
+        if [[ $current_start_time == "$recorded_start_time" ]] &&
+          [[ $(process_state "$inhibit_pid" 2>/dev/null || true) != "Z" ]]; then
+          echo "Failed to stop the Omarchy update sleep inhibitor." >&2
+          return 1
+        fi
       fi
     fi
     rm -f "$inhibit_pid_file"

--- a/test/shell.d/asahi-bundle-update-test.sh
+++ b/test/shell.d/asahi-bundle-update-test.sh
@@ -8,6 +8,12 @@ updater="$ROOT/bin/omarchy-update-asahi-bundle"
 grep -Fq 'manifest_format == "2"' "$updater" || fail "Asahi updater consumes manifest format 2"
 grep -Fq 'package=*)' "$updater" || fail "Asahi updater consumes canonical package records"
 grep -Fq 'channel=*) channel_name=' "$updater" || fail "Asahi updater validates the signed channel name"
+if grep -Eq '/proc/swaps|/sys/module/zswap' "$updater"; then
+  fail "Asahi bundle updates do not reject Omarchy's active zram configuration"
+fi
+grep -Fq '/sys/module/zswap/parameters/enabled' "$ROOT/bin/omarchy-install-asahi-fresh" ||
+  fail "fresh Asahi installs retain the zswap safety gate"
+pass "runtime zram is allowed only outside the fresh-install storage boundary"
 
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT

--- a/test/shell.d/update-lock-test.sh
+++ b/test/shell.d/update-lock-test.sh
@@ -195,3 +195,20 @@ kill -0 "$unrelated_pid" 2>/dev/null ||
 kill "$unrelated_pid"
 wait "$unrelated_pid" 2>/dev/null || true
 pass "stale inhibitor state does not terminate a reused PID"
+
+# An update-owned inhibitor that ignores TERM is forcibly reaped after the
+# bounded graceful shutdown period. This must not leave stale cleanup state.
+write_stub systemd-inhibit 'exec bash -c '\''trap "" TERM; while :; do :; done'\'''
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" start
+inhibit_pid_file="$stay_awake_helper_state/inhibit-pid"
+for _ in {1..100}; do
+  [[ -s $inhibit_pid_file ]] && break
+  sleep 0.01
+done
+[[ -s $inhibit_pid_file ]] || fail "TERM-resistant inhibitor records its ownership"
+read -r stubborn_pid _ <"$inhibit_pid_file"
+
+run_with_lock_env "$ROOT/bin/omarchy-update-stay-awake" stop
+kill -0 "$stubborn_pid" 2>/dev/null && fail "TERM-resistant update inhibitor is stopped"
+[[ ! -e $inhibit_pid_file ]] || fail "stopped inhibitor does not leave stale cleanup state"
+pass "TERM-resistant update inhibitor is forcibly cleaned up"

--- a/test/shell.d/update-sequence-test.sh
+++ b/test/shell.d/update-sequence-test.sh
@@ -36,7 +36,10 @@ for step in "${steps[@]}"; do
   cat >"$stub_bin/$step" <<'STUB'
 #!/bin/bash
 printf '%s unattended=%s\n' "${0##*/}" "${OMARCHY_UPDATE_UNATTENDED:-}" >>"$STEP_LOG"
-[[ ${FAILING_STEP:-} != "${0##*/}" ]] || exit 1
+if [[ ${CLEANUP_FAIL:-0} == "1" && ${0##*/} == "omarchy-update-stay-awake" && ${1:-} == "stop" ]]; then
+  exit 7
+fi
+[[ ${FAILING_STEP:-} != "${0##*/}" ]] || exit 42
 STUB
   chmod +x "$stub_bin/$step"
 done
@@ -53,6 +56,7 @@ run_update() {
   : >"$test_tmp/steps"
   STEP_LOG="$test_tmp/steps" \
     FAILING_STEP="${FAILING_STEP:-}" \
+    CLEANUP_FAIL="${CLEANUP_FAIL:-0}" \
     OMARCHY_UPDATE_LOGGED=1 \
     PATH="$stub_bin:$PATH" \
     bash "$ROOT/bin/omarchy-update" "$@" >"$test_tmp/out" 2>"$test_tmp/err"
@@ -112,3 +116,11 @@ for step in omarchy-migrate omarchy-hook omarchy-update-aur-pkgs omarchy-update-
   fi
 done
 pass "a blocked package upgrade stops the update before it migrates"
+
+set +e
+FAILING_STEP=omarchy-update-system-pkgs CLEANUP_FAIL=1 run_update -y
+update_status=$?
+set -e
+[[ $update_status -eq 42 ]] ||
+  fail "cleanup failure replaces the original update status" "expected 42, got $update_status"
+pass "cleanup failure preserves the original update status"


### PR DESCRIPTION
## Summary
- allow signed Apple Silicon bundle updates while the normal Omarchy zram device is active
- keep the fresh-installer swap and zswap storage guards intact
- forcibly clean up update-owned inhibitors that ignore TERM
- preserve the original updater exit status if cleanup also fails

## Validation
- focused Asahi bundle, fresh-install, update lock, and update sequence tests pass
- CLI suite passes
- broad shell suite was run; unrelated Node-runtime-dependent tests fail in the current host environment before this patch and focused updater tests remain green

## Safety
- no active installation update, zram change, reboot, or ISO worktree modification was performed