### PR TITLE
Discover immutable Asahi channels dynamically

### DIFF
--- a/bin/omarchy-update-asahi-bundle
+++ b/bin/omarchy-update-asahi-bundle
@@ -50,7 +50,7 @@ compatible=$(tr '\0' '\n' <"$(root_path /proc/device-tree/compatible)" 2>/dev/nu
 [[ $(uname -m) == "aarch64" ]] || fail "only aarch64 is supported"
 grep -q '^apple,' <<<"$compatible" || fail "Apple Silicon device tree not found"
 
-for command in bsdtar curl gpg sha256sum vercmp; do
+for command in bsdtar curl gpg jq sha256sum vercmp; do
   omarchy-cmd-present "$command" || fail "$command is required"
 done
 
@@ -83,7 +83,17 @@ if [[ -n ${OMARCHY_ASAHI_CHANNEL_URL:-} ]]; then
   channel_url=$OMARCHY_ASAHI_CHANNEL_URL
   channel_signature_url="${OMARCHY_ASAHI_CHANNEL_SIGNATURE_URL:-$channel_url.sig}"
 else
-  tag=asahi-quattro-channel
+  releases_api_url="${OMARCHY_ASAHI_RELEASES_API_URL:-https://api.github.com/repos/$repo/releases?per_page=100}"
+  download "$releases_api_url" "$workdir/releases.json"
+  tag=$(jq -er '
+    [
+      .[]
+      | select(.draft == false and .prerelease == false)
+      | select(.tag_name | test("^asahi-quattro-channel-[1-9][0-9]*$"))
+      | { tag: .tag_name, sequence: (.tag_name | sub("^asahi-quattro-channel-"; "") | tonumber) }
+    ]
+    | max_by(.sequence).tag
+  ' "$workdir/releases.json") || fail "could not discover the signed Apple Silicon release channel"
   base="https://github.com/$repo/releases/download/$tag"
   channel_url="$base/asahi-quattro-channel"
   channel_signature_url="$channel_url.sig"

--- a/test/shell.d/asahi-bundle-update-test.sh
+++ b/test/shell.d/asahi-bundle-update-test.sh
@@ -64,7 +64,11 @@ while (($#)); do
   esac
 done
 [[ -z ${TEST_CURL_LOG:-} ]] || printf '%s\n' "$url" >>"$TEST_CURL_LOG"
-cp "$TEST_ASSETS/${url##*/}" "$output"
+if [[ $url == */releases\?per_page=100 ]]; then
+  cp "$TEST_ASSETS/releases.json" "$output"
+else
+  cp "$TEST_ASSETS/${url##*/}" "$output"
+fi
 SH
 cat >"$stub_bin/gpg" <<'SH'
 #!/bin/bash
@@ -79,7 +83,7 @@ echo '[GNUPG:] VALIDSIG 5983B1CA32CB778F4D74D24ECFF35022CA5B5959 2026-01-01 0 4 
 SH
 cat >"$stub_bin/jq" <<'SH'
 #!/bin/bash
-exit 1
+echo asahi-quattro-channel-22
 SH
 cat >"$stub_bin/bsdtar" <<'SH'
 #!/bin/bash
@@ -101,6 +105,29 @@ run_check() {
     PATH="$stub_bin:$PATH" \
     "$updater" --check
 }
+
+run_discovery_check() {
+  TEST_ASSETS="$assets" \
+    TEST_CURL_LOG="$test_tmp/discovery-curl.log" \
+    OMARCHY_ASAHI_TESTING=1 \
+    OMARCHY_ASAHI_ROOT="$test_tmp/root" \
+    OMARCHY_ASAHI_BUNDLE_STATE="$state" \
+    OMARCHY_ASAHI_KEY_FILE="$test_tmp/omarchy-release.gpg" \
+    OMARCHY_ASAHI_RELEASES_API_URL="https://api.github.test/repos/example/releases?per_page=100" \
+    PATH="$stub_bin:$PATH" \
+    "$updater" --check
+}
+
+printf '%s\n' \
+  '[{"draft":false,"prerelease":false,"tag_name":"asahi-quattro-channel-22"}]' \
+  >"$assets/releases.json"
+write_channel 2 "$source_commit"
+run_discovery_check >"$test_tmp/discovery.out"
+grep -Fxq 'https://api.github.test/repos/example/releases?per_page=100' "$test_tmp/discovery-curl.log" ||
+  fail "versioned channel discovery reads the GitHub releases API"
+grep -Fxq 'https://github.com/maralcbr/omarchy-pkgs/releases/download/asahi-quattro-channel-22/asahi-quattro-channel' "$test_tmp/discovery-curl.log" ||
+  fail "versioned channel discovery downloads the selected signed pointer"
+pass "immutable versioned Asahi channels are discovered dynamically"
 
 write_channel 2 "$source_commit"
 run_check >"$test_tmp/available.out"


### PR DESCRIPTION
Replace the permanently frozen constant channel URL with discovery of the highest immutable versioned channel release. The signed pointer and monotonic sequence remain authoritative. Includes a focused regression test for API discovery and signed pointer download.