### PR TITLE
Accept numbered Mac release bundles

### DIFF
--- a/bin/omarchy-upgrade-to-quattro
+++ b/bin/omarchy-upgrade-to-quattro
@@ -295,7 +295,7 @@ validate_asahi_packages() {
   version=$(bsdtar -xOf "${asahi_package_archives[2]}" usr/share/omarchy/version 2>/dev/null || \
     bsdtar -xOf "${asahi_package_archives[2]}" ./usr/share/omarchy/version 2>/dev/null) || \
     fail "omarchy-dev does not package /usr/share/omarchy/version. No changes were made."
-  grep -Fq -- '-mac.dev' <<<"$version" || fail "omarchy-dev is not an Omarchy Mac dev build. No changes were made."
+  [[ $version =~ -mac\.(dev|[0-9]+)$ ]] || fail "omarchy-dev is not an Omarchy Mac release build. No changes were made."
 }
 
 if (( asahi_mode )); then

--- a/test/shell.d/upgrade-to-quattro-test.sh
+++ b/test/shell.d/upgrade-to-quattro-test.sh
@@ -76,8 +76,9 @@ grep -Fq 'packages were built from different source bundles' "$upgrade_to_quattr
 grep -Fq 'omarchy-usb-autosuspend\.conf' "$upgrade_to_quattro"
 grep -Fq 'systemd/oomd\.conf\.d' "$upgrade_to_quattro"
 grep -Fq 'systemd/zram-generator\.conf\.d' "$upgrade_to_quattro"
-grep -Fq "grep -Fq -- '-mac.dev'" "$upgrade_to_quattro"
-pass "Omarchy 4 upgrade preflights local package identity, architecture, contents, dependencies, and Mac version"
+grep -Fq '[[ $version =~ -mac\.(dev|[0-9]+)$ ]]' "$upgrade_to_quattro"
+grep -Fq 'is not an Omarchy Mac release build' "$upgrade_to_quattro"
+pass "Omarchy 4 upgrade accepts signed development and numbered Mac release builds"
 
 grep -Fq 'create_asahi_system_backup' "$upgrade_to_quattro"
 grep -Fq '/var/lib/omarchy/backups/quattro-$backup_suffix' "$upgrade_to_quattro"


### PR DESCRIPTION
Allows the signed Quattro migration path to accept both development and numbered Mac product versions. This fixes package-managed 4.0.1 bundles being rejected before mutation when a legacy user checkout still needs transition.\n\nValidated with the focused upgrade test and the full CLI suite.