### PR TITLE
Retire the legacy ChatGPT web launcher

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -120,6 +120,7 @@ asahi_migration_disposition() {
     1787552067.sh) printf 'run\treviewed Apple Silicon audio package repair\n' ;;
     1787552167.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     1787560726.sh) printf 'run\treviewed Apple Silicon package repository setup\n' ;;
+    1787568759.sh) printf 'run\treviewed as architecture-neutral\n' ;;
     1787580187.sh) printf 'run\treviewed architecture-neutral Docker group hardening\n' ;;
     1787618700.sh) printf 'run\treviewed safe Hyprland input-device state migration\n' ;;
     *) return 1 ;;

--- a/default/hypr/bindings/applications.lua
+++ b/default/hypr/bindings/applications.lua
@@ -19,7 +19,9 @@ if o.preinstalled_bindings_enabled() then
   o.bind("SUPER + SHIFT + W", "Omawrite", { launch = "omawrite" })
   o.bind("SUPER + SHIFT + SLASH", "Passwords", { omarchy = "1password" })
 
-  o.bind("SUPER + SHIFT + A", "ChatGPT", { webapp = "https://chatgpt.com" })
+  if o.cmd_present("chatgpt") then
+    o.bind("SUPER + SHIFT + A", "ChatGPT", { launch = "chatgpt" })
+  end
   o.bind("SUPER + SHIFT + ALT + A", "Grok", { webapp = "https://grok.com" })
   o.bind("SUPER + SHIFT + C", "Calendar", { webapp = "https://app.hey.com/calendar/weeks/" })
   o.bind("SUPER + SHIFT + E", "Email", { webapp = "https://app.hey.com" })

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -110,7 +110,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 | `Super + Shift + C`           | Calendar ([HEY](https://hey.com/))  |
 | `Super + Shift + E`           | Email ([HEY](https://hey.com/))  |
 | `Super + Shift + Alt + E`           | New email ([HEY](https://hey.com/))  |
-| `Super + Shift + A`           | AI (ChatGPT)  |
+| `Super + Shift + A`           | AI (ChatGPT desktop)  |
 | `Super + Shift + Alt + A`           | AI (Grok)  |
 | `Super + Shift + G`           | Messenger (Signal)  |
 | `Super + Shift + P`           | Google Photos  |

--- a/manual/17-ai.md
+++ b/manual/17-ai.md
@@ -38,7 +38,7 @@ The watching is on by default. Turn it off under _Trigger > Toggle > Crash Captu
 
 ### Desktop apps
 
-The _Install > AI_ menu also carries a couple of graphical AI apps: the ChatGPT desktop app, and Grok Bot for chatting with xAI's models.
+The _Install > AI_ menu also carries a couple of graphical AI apps: the ChatGPT desktop app, and Grok Bot for chatting with xAI's models. Once ChatGPT is installed, launch it with `Super + Shift + A`.
 
 ### Local LLMs
 

--- a/manual/25-web-apps.md
+++ b/manual/25-web-apps.md
@@ -26,12 +26,6 @@ You can start HEY Email using `Super + Shift + E`, jump straight to composing a 
 
 You can start Basecamp using the application launcher (`Super + Space`)
 
-## ChatGPT
-
-[ChatGPT](https://chatgpt.com) is the most popular AI chat bot in the world.
-
-You can start ChatGPT using `Super + Shift + A`.
-
 ## Grok
 
 [Grok](https://grok.com) is xAI's chat bot.

--- a/migrations/1787568759.sh
+++ b/migrations/1787568759.sh
@@ -1,0 +1,9 @@
+echo "Retire the legacy ChatGPT web app launcher"
+
+desktop_file="$HOME/.local/share/applications/ChatGPT.desktop"
+
+if [[ -f $desktop_file ]] &&
+  grep -Eq '^Exec=omarchy-launch-webapp[[:space:]]+https://chatgpt\.com/?$' "$desktop_file"; then
+  rm -f "$desktop_file"
+  update-desktop-database "$(dirname "$desktop_file")" &>/dev/null || true
+fi

--- a/test/shell.d/chatgpt-webapp-migration-test.sh
+++ b/test/shell.d/chatgpt-webapp-migration-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1787568759.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+stub_bin="$tmpdir/bin"
+calls="$tmpdir/desktop-database-calls"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/update-desktop-database" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$TEST_CALLS"
+SH
+chmod +x "$stub_bin/update-desktop-database"
+
+legacy_home="$tmpdir/legacy-home"
+applications_dir="$legacy_home/.local/share/applications"
+mkdir -p "$applications_dir" "$legacy_home/.config/Codex" "$legacy_home/.cache/Codex"
+cat >"$applications_dir/ChatGPT.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=ChatGPT
+Exec=omarchy-launch-webapp https://chatgpt.com/
+Type=Application
+DESKTOP
+touch "$legacy_home/.config/Codex/preferences" "$legacy_home/.cache/Codex/cache-entry"
+
+HOME="$legacy_home" PATH="$stub_bin:$PATH" TEST_CALLS="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ ! -e $applications_dir/ChatGPT.desktop ]] || fail "migration removes the legacy ChatGPT web app launcher"
+[[ -f $legacy_home/.config/Codex/preferences ]] || fail "migration preserves Codex configuration"
+[[ -f $legacy_home/.cache/Codex/cache-entry ]] || fail "migration preserves Codex cache"
+[[ $(<"$calls") == "$applications_dir" ]] || fail "migration refreshes the desktop application database"
+pass "migration removes only the legacy launcher and preserves Codex state"
+
+HOME="$legacy_home" PATH="$stub_bin:$PATH" TEST_CALLS="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+(( $(wc -l <"$calls") == 1 )) || fail "migration is idempotent"
+pass "migration is idempotent"
+
+custom_home="$tmpdir/custom-home"
+custom_applications_dir="$custom_home/.local/share/applications"
+mkdir -p "$custom_applications_dir"
+cat >"$custom_applications_dir/ChatGPT.desktop" <<'DESKTOP'
+[Desktop Entry]
+Name=My ChatGPT launcher
+Exec=firefox https://chatgpt.com/
+Type=Application
+DESKTOP
+
+HOME="$custom_home" PATH="$stub_bin:$PATH" TEST_CALLS="$calls" \
+  bash -euo pipefail "$migration" >/dev/null
+
+[[ -f $custom_applications_dir/ChatGPT.desktop ]] || fail "migration preserves a custom launcher with the same filename"
+(( $(wc -l <"$calls") == 1 )) || fail "migration does not refresh the database when nothing changed"
+pass "migration preserves unrelated custom launchers"

--- a/test/shell.d/hyprland-binding-conflicts-test.sh
+++ b/test/shell.d/hyprland-binding-conflicts-test.sh
@@ -141,7 +141,8 @@ home="$tmpdir/home"
 stub_bin="$tmpdir/bin"
 mkdir -p "$home" "$stub_bin"
 touch "$stub_bin/voxtype"
-chmod +x "$stub_bin/voxtype"
+touch "$stub_bin/chatgpt"
+chmod +x "$stub_bin/voxtype" "$stub_bin/chatgpt"
 
 bindings=$(PATH="$stub_bin:$PATH" list_bindings "$home")
 [[ -n $bindings ]] || fail "default bindings load for the conflict check"

--- a/test/shell.d/hyprland-default-config-test.sh
+++ b/test/shell.d/hyprland-default-config-test.sh
@@ -25,7 +25,8 @@ hl = {
   bind = function(keys, dispatcher, opts)
     opts = opts or {}
     if opts.description then
-      print(keys .. "\t" .. opts.description)
+      local command = type(dispatcher) == "table" and dispatcher.arg or tostring(dispatcher)
+      print(keys .. "\t" .. opts.description .. "\t" .. command)
     end
   end,
 }
@@ -99,11 +100,26 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 fresh_home="$tmpdir/fresh-home"
-mkdir -p "$fresh_home"
-fresh_output=$(run_application_bindings "$fresh_home")
+chatgpt_bin="$tmpdir/chatgpt-bin"
+mkdir -p "$fresh_home" "$chatgpt_bin"
+touch "$chatgpt_bin/chatgpt"
+fresh_output=$(PATH="$chatgpt_bin:$PATH" run_application_bindings "$fresh_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$fresh_output" || fail "default application bindings include essentials"
-grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$fresh_output" || fail "default application bindings include preinstalled web apps"
+grep -Fxq $'SUPER + SHIFT + A	ChatGPT	uwsm-app -- chatgpt' <<<"$fresh_output" ||
+  fail "installed ChatGPT desktop app receives the default shortcut"
+if grep -Fq 'chatgpt.com' <<<"$fresh_output"; then
+  fail "default application bindings do not launch the legacy ChatGPT web app"
+fi
 pass "default application bindings load from package defaults"
+
+missing_chatgpt_bin="$tmpdir/missing-chatgpt-bin"
+mkdir -p "$missing_chatgpt_bin"
+ln -s "$(command -v lua)" "$missing_chatgpt_bin/lua"
+missing_chatgpt_output=$(PATH="$missing_chatgpt_bin" run_application_bindings "$fresh_home")
+if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$missing_chatgpt_output"; then
+  fail "missing ChatGPT desktop app skips its shortcut"
+fi
+pass "missing ChatGPT desktop app skips its shortcut"
 
 default_output=$(run_omarchy_bindings "$fresh_home")
 grep -Fq $'SUPER + CTRL + SHIFT + code:12\tScreenshot display' <<<"$default_output" ||
@@ -154,7 +170,7 @@ pass "universal clipboard shortcuts share the terminal tag contract"
 removed_home="$tmpdir/removed-home"
 mkdir -p "$removed_home/.local/state/omarchy"
 touch "$removed_home/.local/state/omarchy/preinstalls-removed"
-removed_output=$(run_application_bindings "$removed_home")
+removed_output=$(PATH="$chatgpt_bin:$PATH" run_application_bindings "$removed_home")
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$removed_output" || fail "preinstall removal keeps essential bindings"
 if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$removed_output"; then
   fail "preinstall removal skips preinstalled web app bindings"
@@ -163,7 +179,7 @@ pass "preinstall removal flag skips optional application bindings"
 
 variable_home="$tmpdir/variable-home"
 mkdir -p "$variable_home"
-variable_output=$(run_application_bindings "$variable_home" 'omarchy_preinstalled_bindings = false')
+variable_output=$(PATH="$chatgpt_bin:$PATH" run_application_bindings "$variable_home" 'omarchy_preinstalled_bindings = false')
 grep -Fq $'SUPER + RETURN	Terminal' <<<"$variable_output" || fail "preinstalled binding variable keeps essential bindings"
 if grep -Fq $'SUPER + SHIFT + A	ChatGPT' <<<"$variable_output"; then
   fail "preinstalled binding variable skips optional application bindings"


### PR DESCRIPTION
## Summary
- remove only the stale ChatGPT web-app launcher through a guarded migration
- launch the installed ChatGPT/Codex desktop app from Super+Shift+A
- preserve the desktop package and all Codex configuration/cache
- update manuals and add migration/binding regression coverage

## Validation
- `./test/cli`
- `bash test/shell.d/chatgpt-webapp-migration-test.sh`
- `bash test/shell.d/hyprland-default-config-test.sh`
- `bash test/shell.d/hyprland-binding-conflicts-test.sh`
- `bash test/shell.d/migrate-asahi-test.sh`
- `bash test/shell.d/sddm-keyring-test.sh`