### PR TITLE
Harden release and GitHub governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Suggestion
-    url: https://github.com/basecamp/omarchy/discussions/categories/suggestions
-    about: Suggest a new feature, change to existing feature, or other ideas in Discussions.
+    url: https://github.com/maralcbr/omarchy-mx-mac/discussions/categories/ideas
+    about: Suggest an Apple Silicon feature or project-specific change in this repository.
   - name: Support
-    url: https://omarchy.org/discord
-    about: Need help? Join our Discord community for support with any issues. GitHub issues should be used for verified bugs only.
+    url: https://github.com/maralcbr/omarchy-mx-mac/discussions/categories/q-a
+    about: Ask for Omarchy MX Mac help in this repository. Use GitHub issues for verified bugs.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,18 @@ jobs:
           RELEASE_SEQUENCE: ${{ inputs.sequence }}
         run: |
           mkdir -p /tmp/current-release
-          if gh release download --pattern 'omarchy-mx-mac-release*' --dir /tmp/current-release 2>/dev/null; then
-            status=$(gpg --batch --status-fd 1 --verify \
-              /tmp/current-release/omarchy-mx-mac-release.sig \
-              /tmp/current-release/omarchy-mx-mac-release 2>/dev/null)
-            signer=$(awk '$1 == "[GNUPG:]" && $2 == "VALIDSIG" { print $NF; exit }' <<<"$status")
-            [[ $signer == 5983B1CA32CB778F4D74D24ECFF35022CA5B5959 ]]
-            current_sequence=$(sed -n 's/^sequence=//p' /tmp/current-release/omarchy-mx-mac-release)
-            [[ $current_sequence =~ ^[1-9][0-9]*$ ]]
-            (( RELEASE_SEQUENCE > current_sequence ))
-          fi
+          previous_tag=$(scripts/find-previous-stable-release "$GITHUB_REPOSITORY")
+          gh release download "$previous_tag" \
+            --pattern 'omarchy-mx-mac-release*' \
+            --dir /tmp/current-release
+          status=$(gpg --batch --status-fd 1 --verify \
+            /tmp/current-release/omarchy-mx-mac-release.sig \
+            /tmp/current-release/omarchy-mx-mac-release 2>/dev/null)
+          signer=$(awk '$1 == "[GNUPG:]" && $2 == "VALIDSIG" { print $NF; exit }' <<<"$status")
+          [[ $signer == 5983B1CA32CB778F4D74D24ECFF35022CA5B5959 ]]
+          current_sequence=$(sed -n 's/^sequence=//p' /tmp/current-release/omarchy-mx-mac-release)
+          [[ $current_sequence =~ ^[1-9][0-9]*$ ]]
+          (( RELEASE_SEQUENCE > current_sequence ))
       - name: Build signed release assets
         env:
           RELEASE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Source tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: source-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  source-tests:
+    name: Source test suites
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Install test dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq lua5.4 shellcheck
+      - name: Run CLI and shell suites
+        run: ./test/all
+      - name: Verify stable release contract
+        run: bash tests/stable-release-test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,13 @@ jobs:
         with:
           node-version: 24
       - name: Install test dependencies
-        run: sudo apt-get update && sudo apt-get install -y imagemagick jq libarchive-tools lua5.4 ripgrep shellcheck
+        run: sudo apt-get update && sudo apt-get install -y jq libarchive-tools lua5.4 ripgrep shellcheck
+      - name: Install ImageMagick 7
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+        run: |
+          /home/linuxbrew/.linuxbrew/bin/brew install imagemagick
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "${GITHUB_PATH}"
       - name: Expose Omarchy commands
         run: echo "${GITHUB_WORKSPACE}/bin" >> "${GITHUB_PATH}"
       - name: Run CLI and shell suites

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,13 +18,31 @@ jobs:
     name: Source test suites
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      OMARCHY_PATH: ${{ github.workspace }}
+      OMARCHY_PKGS_PATH: ${{ github.workspace }}/dependencies/omarchy-pkgs
+      OMARCHY_ISO_PATH: ${{ github.workspace }}/dependencies/omarchy-iso
     steps:
       - uses: actions/checkout@v7
+      - name: Check out package contracts
+        uses: actions/checkout@v7
+        with:
+          repository: maralcbr/omarchy-pkgs
+          path: dependencies/omarchy-pkgs
+          persist-credentials: false
+      - name: Check out installer contracts
+        uses: actions/checkout@v7
+        with:
+          repository: maralcbr/omarchy-iso
+          path: dependencies/omarchy-iso
+          persist-credentials: false
       - uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Install test dependencies
-        run: sudo apt-get update && sudo apt-get install -y jq lua5.4 shellcheck
+        run: sudo apt-get update && sudo apt-get install -y imagemagick jq libarchive-tools lua5.4 ripgrep shellcheck
+      - name: Expose Omarchy commands
+        run: echo "${GITHUB_WORKSPACE}/bin" >> "${GITHUB_PATH}"
       - name: Run CLI and shell suites
         run: ./test/all
       - name: Verify stable release contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Release notes for the maintained Apple Silicon line are version-controlled in
 [`docs/releases/`](docs/releases/). GitHub Releases publish those files
 verbatim.
 
+## [4.0.1-mac.2] - 2026-08-26
+
+- Corrected numbered Mac release handling in the signed Quattro upgrade path.
+- Published immutable Apple Silicon channel sequence 25 from source commit
+  `fe8d2bf8aa64f33b5cff285445900e5d1a2eb4b2`.
+- Separated release and package signing trust, restored ARM Node selection, and
+  repaired updates with active zram.
+- Accepted the release in the generic ARM64 QEMU/HVF VM; physical Apple-hardware
+  qualification is not claimed for this release.
+
+[Release notes](docs/releases/v4.0.1-mac.2.md) | [Full diff](https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.1-mac.1...v4.0.1-mac.2)
+
 ## [4.0.1-mac.1] - 2026-08-25
 
 - Integrated upstream Omarchy 4.0.1 while preserving the Apple Silicon install,
@@ -96,3 +108,5 @@ verbatim.
 [4.0.1-mac.1]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.1-mac.1
 [4.0.0-mac.12]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.0-mac.12
 [4.0.0-mac.11]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.0-mac.11
+
+[4.0.1-mac.2]: https://github.com/maralcbr/omarchy-mx-mac/releases/tag/v4.0.1-mac.2

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ Omarchy 4 (Quattro) is the maintained release:
 
 | Version | Status | Installation |
 | --- | --- | --- |
-| Omarchy `4.0.1-mac.1` | Recommended stable version | Direct signed installation on Asahi Arch Minimal |
+| Omarchy `4.0.1-mac.2` | Recommended stable version | Direct signed installation on Asahi Arch Minimal |
 | Omarchy `3.8.4-mac.4` | Legacy | Existing installations can update to Omarchy 4 |
 
 > [!NOTE]
-> Omarchy Mac has been tested on M1, M2, and M3 Macs. The complete signed
-> release, update, and reboot regression is run on a 14-inch 2021 MacBook Pro
-> with M1 Pro (`apple,j314s`). Apple Silicon support still depends on the
-> upstream Asahi Linux support available for each model.
+> Omarchy Mac has been tested on M1, M2, and M3 Macs. Physical Apple-hardware
+> qualification is recorded per release against a 14-inch 2021 MacBook Pro
+> with M1 Pro (`apple,j314s`). The current `4.0.1-mac.2` release was accepted in
+> a generic ARM64 QEMU/HVF VM and does not claim physical Apple-hardware
+> qualification. Apple Silicon support still depends on the upstream Asahi
+> Linux support available for each model.
 
 ## Before You Begin
 
@@ -80,6 +82,11 @@ available.
 The signed installer takes a prepared Asahi Arch Minimal system directly to
 Omarchy 4. It verifies immutable release metadata and never installs moving
 `main` or an intermediate Omarchy 3 release.
+
+The `vX.Y.Z-mac.N` tag records the product source and release notes. Installer,
+channel, and package assets are published separately as immutable releases in
+[`maralcbr/omarchy-pkgs`](https://github.com/maralcbr/omarchy-pkgs). Stable
+channel sequence 25 installs product version `4.0.1-mac.2`.
 
 ### 1. Install Asahi Arch Minimal
 
@@ -223,8 +230,8 @@ sudo journalctl -u NetworkManager -b
 
 ## Releases And Support
 
-- [Latest stable release](https://github.com/maralcbr/omarchy-mx-mac/releases/latest)
-- [Current signed Quattro channel](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-quattro-channel-25)
+- [Latest product release and validation notes](https://github.com/maralcbr/omarchy-mx-mac/releases/latest)
+- [Current signed installer and package channel](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-quattro-channel-25)
 - [Issues](https://github.com/maralcbr/omarchy-mx-mac/issues)
 - [Discussions](https://github.com/maralcbr/omarchy-mx-mac/discussions)
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,25 @@ sudo systemctl restart NetworkManager
 sudo journalctl -u NetworkManager -b
 ```
 
+### Quickshell Fails After A Partial Update
+
+Do not replace the signed `quickshell-git` package with `quickshell` or rebuild
+it from the AUR. Those workarounds move the machine outside the validated Apple
+Silicon package bundle and can block later updates.
+
+Switch to a TTY, preserve the package and journal evidence, then use the normal
+signed updater:
+
+```bash
+pacman -Q quickshell-git qt6-base 2>&1 || true
+pacman -Qm | grep -E '^quickshell' || true
+journalctl --user -b | grep -i quickshell || true
+omarchy update
+```
+
+If the update fails, do not reboot or remove packages manually. Preserve the
+complete output and open a verified bug report with the commands above.
+
 ### An Installation Or Upgrade Failed
 
 - Do not reboot during or after a failed package transaction.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -15,3 +15,16 @@ Release preparation must:
 The notes file must exist in the tagged commit. The publishing workflow reads
 it with `git show`, validates its title and required sections, and passes the
 immutable copy to `gh release create --notes-file`.
+
+Product releases and package-channel releases are separate immutable records:
+
+- `maralcbr/omarchy-mx-mac` tags identify the product source and publish the
+  curated validation notes.
+- `maralcbr/omarchy-pkgs` channel releases contain the signed installer,
+  channel pointer, manifests, and package assets consumed by installations.
+
+The recommended version in `README.md`, the root `version` file,
+`CHANGELOG.md`, the product release notes, and the source version identified
+by the current stable package channel must agree before a release is called
+stable. Validation scope is recorded per release; generic ARM64 VM acceptance
+must not be described as physical Apple-hardware qualification.

--- a/docs/releases/v4.0.1-mac.2.md
+++ b/docs/releases/v4.0.1-mac.2.md
@@ -1,0 +1,38 @@
+# Omarchy MX Mac 4.0.1-mac.2
+
+## Update compatibility
+
+- Accepts numbered Mac release versions during the Quattro upgrade path, so
+  existing `4.0.1-mac.N` installations route through the signed Apple Silicon
+  bundle instead of failing the release-version gate.
+- Uses promoted immutable package channel sequence 25 from candidate
+  `asahi-packages-candidate-a04c1a0c270b0522adee70ea257bce6d91a8f556`.
+- Separates channel-pointer verification with the release key from runtime
+  package verification with the repository package key.
+- Allows signed Apple Silicon updates while the normal Omarchy zram device is
+  active and restores architecture-matched Node bundle selection.
+
+## Validation
+
+- Candidate descriptor SHA-256:
+  `fff94e6073d192fc3ce8bc9ab0e817eebdd4154118b735e3e41e3870dca0a505`.
+- Runtime manifest SHA-256:
+  `08e10e5a18cc5d4ad06cf0331af4e2e9089204a79bfa3d5630f938acfa5c23af`.
+- The unpublished ARM64 ISO from source commit
+  `b5d562ff0b62ac62a5c76709c8ffdca34bd096fe` was built once on the native
+  10-vCPU M4 builder. Its SHA-256 is
+  `aca64be559f84a318b1cf0aa750f294bd9f8d0fbc1b4603225ab9bbdf8251f1b`.
+- That exact ISO passed fresh encrypted installation and reboot, graphical
+  Plymouth unlock under QEMU/HVF with `virtio-gpu-pci`, SDDM and Omarchy
+  desktop startup, and the complete encrypted headless acceptance suite.
+
+## Known Limitations
+
+- Acceptance is generic ARM64 VM coverage on the M4 builder, not physical Apple
+  hardware coverage.
+- The accepted replacement ISO remains unpublished and no public ISO channel
+  has been advanced.
+- Apple GPU, Wi-Fi, audio, suspend, built-in input devices, and other physical
+  hardware behavior are outside this release's validation scope.
+
+**Full Changelog**: https://github.com/maralcbr/omarchy-mx-mac/compare/v4.0.1-mac.1...v4.0.1-mac.2

--- a/scripts/find-previous-stable-release
+++ b/scripts/find-previous-stable-release
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repository="${1:-${GITHUB_REPOSITORY:-}}"
+if [[ ! $repository =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "Usage: scripts/find-previous-stable-release OWNER/REPOSITORY" >&2
+  exit 1
+fi
+
+releases=$(mktemp)
+trap 'rm -f "$releases"' EXIT
+
+gh api --paginate "/repos/$repository/releases?per_page=100" >"$releases"
+
+previous_tag=$(jq -r -s '
+  map(.[]) |
+  map(select(any(.assets[]?; .name == "omarchy-mx-mac-release"))) |
+  first |
+  .tag_name // empty
+' "$releases")
+
+if [[ ! $previous_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+-mac\.[0-9]+$ ]]; then
+  echo "No previous signed stable Mac release descriptor found" >&2
+  exit 1
+fi
+
+printf '%s\n' "$previous_tag"

--- a/test/shell.d/theme-install-guards-test.sh
+++ b/test/shell.d/theme-install-guards-test.sh
@@ -42,7 +42,7 @@ install_theme() {
 
   HOME="$test_tmp/home" PATH="${2-$mock_bin:$ROOT/bin:$PATH}" \
     OMARCHY_TEST_GIT_CALLS="$git_calls" OMARCHY_TEST_THEME_CALLS="$theme_calls" \
-    bash "$ROOT/bin/omarchy-theme-install" "$1" >"$test_tmp/out" 2>&1 || return $?
+    /bin/bash "$ROOT/bin/omarchy-theme-install" "$1" >"$test_tmp/out" 2>&1 || return $?
 }
 
 mkdir -p "$test_tmp/home/.config/omarchy/themes"
@@ -72,7 +72,7 @@ pass "a URL naming a transport git does not implement never reaches git"
 
 # The checker is a separate command, so its absence has to refuse the URL rather
 # than wave it through to git.
-if install_theme "https://github.com/example/omarchy-cool-theme.git" "$mock_bin:$PATH"; then
+if install_theme "https://github.com/example/omarchy-cool-theme.git" "$mock_bin"; then
   fail "omarchy-theme-install refuses a URL it cannot check"
 fi
 

--- a/tests/stable-release-test.sh
+++ b/tests/stable-release-test.sh
@@ -10,6 +10,7 @@ grep -Fxq "# Omarchy MX Mac $version" "$notes"
 grep -Fxq '## Validation' "$notes"
 grep -Fq '**Full Changelog**:' "$notes"
 grep -Fq "## [$version]" "$ROOT/CHANGELOG.md"
+grep -Fq "| Omarchy `$version` | Recommended stable version |" "$ROOT/README.md"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
@@ -52,6 +53,54 @@ elif [[ " $* " == *" --verify "* ]]; then
 fi
 EOF
 chmod +x "$tmp/bin"/*
+
+
+cat >"$tmp/bin/gh" <<'EOF'
+#!/bin/bash
+[[ $1 == "api" ]] || exit 2
+case "${GH_RELEASE_SCENARIO:-assetless-latest}" in
+  assetless-latest)
+    printf '%s\n' '[{"tag_name":"v4.0.1-mac.2","assets":[]},{"tag_name":"v4.0.1-mac.1","assets":[{"name":"omarchy-mx-mac-release"},{"name":"omarchy-mx-mac-release.sig"}]}]'
+    ;;
+  paginated)
+    printf '%s\n' '[{"tag_name":"v4.0.1-mac.2","assets":[]}]'
+    printf '%s\n' '[{"tag_name":"v4.0.1-mac.1","assets":[{"name":"omarchy-mx-mac-release"}]}]'
+    ;;
+  no-descriptor)
+    printf '%s\n' '[{"tag_name":"v4.0.1-mac.2","assets":[]}]'
+    ;;
+  api-failure)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$tmp/bin/gh"
+
+previous_tag=$(PATH="$tmp/bin:$PATH" GH_RELEASE_SCENARIO=assetless-latest \
+  "$ROOT/scripts/find-previous-stable-release" maralcbr/omarchy-mx-mac)
+[[ $previous_tag == "v4.0.1-mac.1" ]] || {
+  echo "not ok - assetless latest release did not fall back to signed descriptor" >&2
+  exit 1
+}
+
+previous_tag=$(PATH="$tmp/bin:$PATH" GH_RELEASE_SCENARIO=paginated \
+  "$ROOT/scripts/find-previous-stable-release" maralcbr/omarchy-mx-mac)
+[[ $previous_tag == "v4.0.1-mac.1" ]] || {
+  echo "not ok - paginated release lookup missed signed descriptor" >&2
+  exit 1
+}
+
+if PATH="$tmp/bin:$PATH" GH_RELEASE_SCENARIO=no-descriptor \
+  "$ROOT/scripts/find-previous-stable-release" maralcbr/omarchy-mx-mac >/dev/null 2>&1; then
+  echo "not ok - missing signed descriptor was accepted" >&2
+  exit 1
+fi
+
+if PATH="$tmp/bin:$PATH" GH_RELEASE_SCENARIO=api-failure \
+  "$ROOT/scripts/find-previous-stable-release" maralcbr/omarchy-mx-mac >/dev/null 2>&1; then
+  echo "not ok - GitHub API failure was accepted" >&2
+  exit 1
+fi
 
 run_resolver() {
   PATH="$tmp/bin:$ROOT/bin:/usr/bin" XDG_STATE_HOME="$tmp/state" \

--- a/tests/stable-release-test.sh
+++ b/tests/stable-release-test.sh
@@ -10,7 +10,7 @@ grep -Fxq "# Omarchy MX Mac $version" "$notes"
 grep -Fxq '## Validation' "$notes"
 grep -Fq '**Full Changelog**:' "$notes"
 grep -Fq "## [$version]" "$ROOT/CHANGELOG.md"
-grep -Fq "| Omarchy `$version` | Recommended stable version |" "$ROOT/README.md"
+grep -Fq "| Omarchy \`$version\` | Recommended stable version |" "$ROOT/README.md"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
## Summary

- restore the missing `4.0.1-mac.2` changelog, release notes, README version, and per-release hardware-validation scope
- make stable release sequencing find the newest signed descriptor across all releases and fail closed when none exists
- cover assetless-latest, pagination, missing-descriptor, and API-failure cases
- run the complete CLI and shell suites plus the stable-release contract for every PR and push to `main`
- route Apple Silicon suggestions and support to this repository's Discussions
- document safe Quickshell evidence capture without unsupported package substitution

## Validation

GitHub Actions in this PR is the first execution of the new universal `Source test suites` gate. It runs:

- `./test/all`
- `bash tests/stable-release-test.sh`

The release workflow remains manually dispatched and no release, package channel, installer, runtime, or user machine is changed by this PR.

## Follow-up

After this gate passes and lands, protect `main` with the new required check and re-trigger PR #50 through the same validation path.
