### PR TITLE
Validate Apple Silicon backlight fix from #50

### DIFF
--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -7,11 +7,11 @@ backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
 
 # Start with the first possible output, then refine to the most likely given an order heuristic.
 # Glob the candidates in the loop list: [[ ]] does not do pathname expansion.
-# The Touch Bar on T2 Macs registers a backlight that never drives the display panel.
-device="$(ls -1 "$backlight_path" 2>/dev/null | grep -vx appletb_backlight | head -n1)"
+# Touch Bars register backlights that never drive the built-in display panel.
+device="$(ls -1 "$backlight_path" 2>/dev/null | grep -Evx 'appletb_backlight|display-pipe|228600000\.dsi\.0' | head -n1)"
 # gmux comes first: apple-gmux only registers when the kernel has already picked it, and on
 # dual-GPU Macs the GPU's own PWM stops driving the panel once that GPU suspends.
-for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
+for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/apple-panel-bl "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
   if [[ -e $candidate ]]; then
     device="${candidate##*/}"
     break

--- a/test/shell.d/hw-display-test.sh
+++ b/test/shell.d/hw-display-test.sh
@@ -46,11 +46,18 @@ device=$(hw_display)
 [[ $device == "gmux_backlight" ]] || fail "a T2 Mac uses gmux instead of the Touch Bar" "actual: $device"
 pass "a T2 Mac uses gmux instead of the Touch Bar"
 
-write_backlights appletb_backlight
-if hw_display >/dev/null 2>&1; then
-  fail "the Touch Bar is never used as the display backlight"
-fi
-pass "the Touch Bar is never used as the display backlight"
+write_backlights 228600000.dsi.0 apple-panel-bl
+device=$(hw_display)
+[[ $device == "apple-panel-bl" ]] || fail "Apple Silicon uses the Retina panel instead of the Touch Bar" "actual: $device"
+pass "Apple Silicon uses the Retina panel instead of the Touch Bar"
+
+for touch_bar in appletb_backlight display-pipe 228600000.dsi.0; do
+  write_backlights "$touch_bar"
+  if hw_display >/dev/null 2>&1; then
+    fail "a Touch Bar is never used as the display backlight" "actual: $touch_bar"
+  fi
+done
+pass "Touch Bars are never used as the display backlight"
 
 write_backlights acpi_video0 amdgpu_bl0 appletb_backlight gmux_backlight intel_backlight
 device=$(hw_display)


### PR DESCRIPTION
Temporary same-repository validation mirror for #50 because GitHub requires an owner approval before running Actions on the contributor fork. This branch has the exact #50 source tree plus a content-neutral trigger commit. Do not merge this PR; close it after the Source tests gate passes, then merge #50.