### PR TITLE
Consolidate workspace assets and test layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           bash test/shell.d/asahi-bundle-update-test.sh
           bash test/shell.d/asahi-fresh-install-test.sh
           bash test/shell.d/fastfetch-branding-migration-test.sh
-          bash tests/stable-release-test.sh
+          bash test/shell.d/stable-release-test.sh
       - name: Validate release inputs
         env:
           RELEASE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run CLI and shell suites
         run: ./test/all
       - name: Verify stable release contract
-        run: bash tests/stable-release-test.sh
+        run: bash test/shell.d/stable-release-test.sh

--- a/apps/omarchy-apple-installer/Design/Authorize.dc.html
+++ b/apps/omarchy-apple-installer/Design/Authorize.dc.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --sidebar:#EAEDE2; --content:#F5F7F1; --card:#FFFFFF;
+      --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2; --track:#E3E7D9;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B; --caution:#8A6D1B;
+      --accent-soft:rgba(78,138,34,0.14); --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18);
+      color: var(--text); }
+    .win { --window:#23261E; --sidebar:#272B21; --content:#191C14; --card:#242820;
+      --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B; --track:#2E3326;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E; --caution:#F3C96B;
+      --accent-soft:rgba(144,208,90,0.16); --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .rail { width: 208px; flex: none; background: var(--sidebar); padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+    .rrow { display: flex; align-items: center; gap: 11px; padding: 8px 12px; border-radius: 10px; }
+    .rrow.cur { background: var(--accent-soft); }
+    .stepnum { width: 27px; height: 27px; border-radius: 50%; background: var(--track); color: var(--text2); font-size: 15px; font-weight: 600; display: flex; align-items: center; justify-content: center; flex: none; }
+    .cur .stepnum, .done .stepnum { background: var(--accent); color: var(--accent-text); }
+    .steplbl { font-size: 19.5px; color: var(--text); }
+    .cur .steplbl { font-weight: 600; }
+    .done .steplbl { color: var(--text2); }
+    .railfoot { margin-top: auto; padding: 0 10px 10px; display: flex; flex-direction: column; gap: 2px; }
+    .panel { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; padding: 13px 14px; display: flex; flex-direction: column; gap: 10px; }
+    .details { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; display: flex; flex-direction: column; }
+    .btn { font-size: 16px; height: 42px; padding: 0 21px; border-radius: 9px; display: inline-flex; align-items: center; justify-content: center; white-space: nowrap; }
+    .btn.primary { background: var(--accent); color: var(--accent-text); font-weight: 500; box-shadow: 0 0.5px 1.5px rgba(0,0,0,0.18); }
+    .btn.secondary { background: var(--btn-bg); color: var(--text); border: 1px solid var(--btn-border); box-shadow: 0 0.5px 1px rgba(0,0,0,0.06); }
+    .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 1000px; height: 700px; display: flex; background: var(--window)">
+  <div class="rail">
+    <div style="padding: 10px 6px 28px 12px"><div style="width: 126px; height: 126px; border-radius: 28px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center"><img src="icon.png" alt="Omarchy" style="width: 76px; height: 76px"></div></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Check</span></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Plan</span></div>
+    <div class="rrow cur"><span class="stepnum">3</span><span class="steplbl">Authorize</span></div>
+    <div class="rrow"><span class="stepnum">4</span><span class="steplbl">Install</span></div>
+    <div class="rrow"><span class="stepnum">5</span><span class="steplbl">Recovery</span></div>
+    <div class="rrow"><span class="stepnum">6</span><span class="steplbl">Boot</span></div>
+    <div class="railfoot">
+      <div style="display: flex; align-items: center; gap: 6px">
+        <span style="width: 7px; height: 7px; border-radius: 50%; background: var(--accent)"></span>
+        <span style="font-size: 11px; font-weight: 500">Safety active</span>
+      </div>
+      <div style="font-size: 11px; color: var(--text2)">Bound to the reviewed plan</div>
+    </div>
+  </div>
+  <div style="width: 1px; background: var(--sep); flex: none"></div>
+  <div style="flex: 1; background: var(--content); padding: 28px; display: flex; flex-direction: column; overflow: hidden">
+    <div style="max-width: 640px; width: 100%; display: flex; flex-direction: column; flex: 1; min-height: 0">
+      <div style="font-size: 22px; font-weight: 600; margin-bottom: 6px">300 GB for Omarchy</div>
+      <div style="font-size: 13px; color: var(--text2); margin-bottom: 20px">macOS keeps the rest, untouched.</div>
+      <div style="display: flex; flex-direction: column; gap: 14px">
+        <div class="panel">
+          <div style="font-size: 11px; font-weight: 600; color: var(--text2)">Disk · 994.66 GB</div>
+          <div style="display: flex; height: 24px; border-radius: 8px; overflow: hidden">
+            <div style="width: 70%; background: var(--track); display: flex; align-items: center; justify-content: center">
+              <span style="font-size: 10.5px; font-weight: 600; color: var(--text2)">macOS · 694.66 GB</span>
+            </div>
+            <div style="width: 30%; background: var(--accent); display: flex; align-items: center; justify-content: center">
+              <span style="font-size: 10.5px; font-weight: 600; color: var(--accent-text)">Omarchy · 300 GB</span>
+            </div>
+          </div>
+        </div>
+        <div class="panel">
+          <div style="display: flex; align-items: baseline; gap: 8px">
+            <span style="font-size: 11px; font-weight: 600; color: var(--text2)">Downloaded</span>
+            <span class="mono" style="margin-left: auto; font-size: 11px; font-weight: 600; color: var(--accent)">Verified ✓</span>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 3px">
+            <div style="display: flex; align-items: center; gap: 8px">
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">omarchy-2026.08.29-aarch64-apple-silicon.zip</span>
+              <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">4.6 GB</span>
+            </div>
+            <div style="display: flex; align-items: center; gap: 8px">
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">installer_data.json</span>
+              <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">34 MB</span>
+            </div>
+            <div style="display: flex; align-items: center; gap: 8px">
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">installer-v0.9.0-omarchy.7.tar.gz</span>
+              <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">22 MB</span>
+            </div>
+          </div>
+        </div>
+        <div class="panel">
+          <div style="display: flex; align-items: center; gap: 10px">
+            <svg width="16" height="16" viewBox="0 0 16 16" style="color: var(--accent); flex: none"><path d="M8 1.5 13 3.2 V7.5 C13 11 10.8 13.4 8 14.5 C5.2 13.4 3 11 3 7.5 V3.2 Z" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/><path d="M5.8 8 7.3 9.5 10.2 6.2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <div style="display: flex; flex-direction: column; gap: 2px">
+              <span style="font-size: 13px; font-weight: 600">Privileged helper</span>
+              <span style="font-size: 11px; color: var(--text2)">Approved</span>
+            </div>
+            <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-left: auto"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+          </div>
+        </div>
+        <div class="details">
+          <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px">
+            <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent)"><path d="M3.5 2 6.5 5 3.5 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span style="font-size: 12px; font-weight: 500; color: var(--text2)">Exact plan</span>
+          </div>
+        </div>
+      </div>
+      <div style="flex: 1; min-height: 16px"></div>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; padding-top: 16px">
+        <div style="margin-left: auto; display: flex; gap: 8px">
+          <span class="btn secondary">Back</span>
+          <span class="btn primary">Install…</span>
+        </div>
+      </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  renderVals() {
+    return { theme: (this.props.dark ?? true) ? 'dark' : 'light' };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/CredentialSheet.dc.html
+++ b/apps/omarchy-apple-installer/Design/CredentialSheet.dc.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --card:#FFFFFF; --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B;
+      --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18); color: var(--text); }
+    .win { --window:#23261E; --card:#242820; --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E;
+      --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .btn { font-size: 13px; height: 24px; padding: 0 12px; border-radius: 6px; display: inline-flex; align-items: center; justify-content: center; white-space: nowrap; }
+    .btn.primary { background: var(--accent); color: var(--accent-text); font-weight: 500; box-shadow: 0 0.5px 1.5px rgba(0,0,0,0.18); }
+    .btn.secondary { background: var(--btn-bg); color: var(--text); border: 1px solid var(--btn-border); box-shadow: 0 0.5px 1px rgba(0,0,0,0.06); }
+    .field { width: 100%; height: 24px; border-radius: 5px; border: 1px solid var(--sep); background: var(--card); padding: 0 8px; font-size: 13px; display: flex; align-items: center; }
+    .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 380px; padding: 24px; background: var(--window); display: flex; flex-direction: column; align-items: center">
+  <div style="width: 64px; height: 64px; border-radius: 15px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center; margin-bottom: 6px">
+    <img src="icon.png" alt="Omarchy" style="width: 39px; height: 39px">
+  </div>
+  <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); margin-bottom: 10px"><rect x="2.4" y="5.2" width="7.2" height="5.4" rx="1.2" fill="currentColor"></rect><path d="M4 5 V3.8 a2 2 0 0 1 4 0 V5" fill="none" stroke="currentColor" stroke-width="1.2"></path></svg>
+  <div style="font-size: 13px; font-weight: 700; text-align: center; margin-bottom: 6px">Omarchy Installer wants to make changes.</div>
+  <div style="font-size: 11px; color: var(--text2); text-align: center; margin-bottom: 8px">Enter your password to allow this.</div>
+  
+  <div style="width: 100%; display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px">
+    <span style="font-size: 11px; font-weight: 500; color: var(--text2)">User Name</span>
+    <div class="field">maralc</div>
+  </div>
+  <div style="width: 100%; display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px">
+    <span style="font-size: 11px; font-weight: 500; color: var(--text2)">Password</span>
+    <div class="field" style="letter-spacing: 2px">••••••••••</div>
+  </div>
+  <div style="width: 100%; display: flex; justify-content: flex-end; gap: 8px; padding-top: 14px">
+    <span class="btn secondary">Cancel</span>
+    <span class="btn primary">Install</span>
+  </div>
+  
+  
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  renderVals() {
+    return { theme: (this.props.dark ?? true) ? 'dark' : 'light' };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/Installing.dc.html
+++ b/apps/omarchy-apple-installer/Design/Installing.dc.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --sidebar:#EAEDE2; --content:#F5F7F1; --card:#FFFFFF;
+      --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2; --track:#E3E7D9;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B; --caution:#8A6D1B;
+      --accent-soft:rgba(78,138,34,0.14); --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18);
+      color: var(--text); }
+    .win { --window:#23261E; --sidebar:#272B21; --content:#191C14; --card:#242820;
+      --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B; --track:#2E3326;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E; --caution:#F3C96B;
+      --accent-soft:rgba(144,208,90,0.16); --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .rail { width: 208px; flex: none; background: var(--sidebar); padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+    .rrow { display: flex; align-items: center; gap: 11px; padding: 8px 12px; border-radius: 10px; }
+    .rrow.cur { background: var(--accent-soft); }
+    .stepnum { width: 27px; height: 27px; border-radius: 50%; background: var(--track); color: var(--text2); font-size: 15px; font-weight: 600; display: flex; align-items: center; justify-content: center; flex: none; }
+    .cur .stepnum, .done .stepnum { background: var(--accent); color: var(--accent-text); }
+    .steplbl { font-size: 19.5px; color: var(--text); }
+    .cur .steplbl { font-weight: 600; }
+    .done .steplbl { color: var(--text2); }
+    .railfoot { margin-top: auto; padding: 0 10px 10px; display: flex; flex-direction: column; gap: 2px; }
+    .details { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; display: flex; flex-direction: column; }
+    .track { height: 12px; border-radius: 6px; background: var(--track); overflow: hidden; }
+    .fill { height: 100%; border-radius: 3px; background: var(--accent); }
+    .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 1000px; height: 700px; display: flex; background: var(--window)">
+  <div class="rail">
+    <div style="padding: 10px 6px 28px 12px"><div style="width: 126px; height: 126px; border-radius: 28px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center"><img src="icon.png" alt="Omarchy" style="width: 76px; height: 76px"></div></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Check</span></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Plan</span></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Authorize</span></div>
+    <div class="rrow cur"><span class="stepnum">4</span><span class="steplbl">Install</span></div>
+    <div class="rrow"><span class="stepnum">5</span><span class="steplbl">Recovery</span></div>
+    <div class="rrow"><span class="stepnum">6</span><span class="steplbl">Boot</span></div>
+    <div class="railfoot">
+      <div style="display: flex; align-items: center; gap: 6px">
+        <span style="width: 7px; height: 7px; border-radius: 50%; background: var(--accent)"></span>
+        <span style="font-size: 11px; font-weight: 500">Safety active</span>
+      </div>
+      <div style="font-size: 11px; color: var(--text2)">Bound to the reviewed plan</div>
+    </div>
+  </div>
+  <div style="width: 1px; background: var(--sep); flex: none"></div>
+  <div style="flex: 1; background: var(--content); padding: 28px; display: flex; flex-direction: column; overflow: hidden">
+    <div style="max-width: 640px; width: 100%; display: flex; flex-direction: column; flex: 1; min-height: 0">
+      <div style="font-size: 22px; font-weight: 600; margin-bottom: 20px">Writing boot files…</div>
+      <div style="display: flex; flex-direction: column; gap: 14px">
+        <div style="display: flex; align-items: baseline; gap: 8px">
+          <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; align-self: center"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+          <span class="mono" style="margin-left: auto; font-size: 11px; color: var(--text2)">04:12</span>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 4px">
+          <div style="display: flex; gap: 2px">
+            <div class="track" style="flex: 1"><div class="fill" style="width: 100%"></div></div>
+            <div class="track" style="flex: 1"><div class="fill" style="width: 45%"></div></div>
+            <div class="track" style="flex: 1"></div>
+          </div>
+          <div style="display: flex; gap: 2px">
+            <span style="flex: 1; font-size: 10.5px; color: var(--text2)">Prepare space</span>
+            <span style="flex: 1; font-size: 10.5px; font-weight: 600; color: var(--accent)">Boot files</span>
+            <span style="flex: 1; font-size: 10.5px; color: var(--text2)">Recovery handoff</span>
+          </div>
+        </div>
+        <div style="font-size: 12.5px; font-weight: 500; color: var(--caution); margin-top: 6px">Keep the lid open and power connected.</div>
+        <div class="details">
+          <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px">
+            <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent)"><path d="M2 3.5 5 6.5 8 3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span style="font-size: 12px; font-weight: 500; color: var(--text2)">Live journal</span>
+          </div>
+          <div style="height: 1px; background: var(--sep)"></div>
+          <div style="display: flex; flex-direction: column; gap: 3px; padding: 10px 12px 12px">
+            <span class="mono" style="font-size: 10.5px; color: var(--text2)">Started preparing space</span>
+            <span class="mono" style="font-size: 10.5px; color: var(--accent)">Space for Omarchy is reserved</span>
+            <span class="mono" style="font-size: 10.5px; color: var(--text2)">Started writing boot files</span>
+          </div>
+        </div>
+      </div>
+      <div style="flex: 1; min-height: 16px"></div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  renderVals() {
+    return { theme: (this.props.dark ?? true) ? 'dark' : 'light' };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/Main.dc.html
+++ b/apps/omarchy-apple-installer/Design/Main.dc.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --sidebar:#EAEDE2; --content:#F5F7F1; --card:#FFFFFF;
+      --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2; --track:#E3E7D9;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B; --caution:#8A6D1B;
+      --accent-soft:rgba(78,138,34,0.14); --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18);
+      color: var(--text); }
+    .win { --window:#23261E; --sidebar:#272B21; --content:#191C14; --card:#242820;
+      --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B; --track:#2E3326;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E; --caution:#F3C96B;
+      --accent-soft:rgba(144,208,90,0.16); --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .rail { width: 208px; flex: none; background: var(--sidebar); padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+    .rrow { display: flex; align-items: center; gap: 11px; padding: 8px 12px; border-radius: 10px; }
+    .rrow.cur { background: var(--accent-soft); }
+    .stepnum { width: 27px; height: 27px; border-radius: 50%; background: var(--track); color: var(--text2); font-size: 15px; font-weight: 600; display: flex; align-items: center; justify-content: center; flex: none; }
+    .cur .stepnum, .done .stepnum { background: var(--accent); color: var(--accent-text); }
+    .steplbl { font-size: 19.5px; color: var(--text); }
+    .cur .steplbl { font-weight: 600; }
+    .done .steplbl { color: var(--text2); }
+    .railfoot { margin-top: auto; padding: 0 10px 10px; display: flex; flex-direction: column; gap: 2px; }
+    .panel { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; padding: 13px 14px; display: flex; flex-direction: column; gap: 10px; }
+    .details { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; display: flex; flex-direction: column; }
+    .btn { font-size: 16px; height: 42px; padding: 0 21px; border-radius: 9px; display: inline-flex; align-items: center; justify-content: center; white-space: nowrap; }
+    .btn.primary { background: var(--accent); color: var(--accent-text); font-weight: 500; box-shadow: 0 0.5px 1.5px rgba(0,0,0,0.18); }
+    .btn.secondary { background: var(--btn-bg); color: var(--text); border: 1px solid var(--btn-border); box-shadow: 0 0.5px 1px rgba(0,0,0,0.06); }
+    .track { height: 6px; border-radius: 3px; background: var(--track); overflow: hidden; }
+    .fill { height: 100%; border-radius: 3px; background: var(--accent); }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 1000px; height: 700px; display: flex; background: var(--window)">
+  <div class="rail">
+    <div style="padding: 10px 6px 28px 12px"><div style="width: 126px; height: 126px; border-radius: 28px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center"><img src="icon.png" alt="Omarchy" style="width: 76px; height: 76px"></div></div>
+    <div class="rrow cur"><span class="stepnum">1</span><span class="steplbl">Check</span></div>
+    <div class="rrow"><span class="stepnum">2</span><span class="steplbl">Plan</span></div>
+    <div class="rrow"><span class="stepnum">3</span><span class="steplbl">Authorize</span></div>
+    <div class="rrow"><span class="stepnum">4</span><span class="steplbl">Install</span></div>
+    <div class="rrow"><span class="stepnum">5</span><span class="steplbl">Recovery</span></div>
+    <div class="rrow"><span class="stepnum">6</span><span class="steplbl">Boot</span></div>
+    <div class="railfoot">
+      <div style="display: flex; align-items: center; gap: 6px">
+        <span style="width: 7px; height: 7px; border-radius: 50%; background: var(--accent)"></span>
+        <span style="font-size: 11px; font-weight: 500">Safety active</span>
+      </div>
+      <div style="font-size: 11px; color: var(--text2)">Bound to the reviewed plan</div>
+    </div>
+  </div>
+  <div style="width: 1px; background: var(--sep); flex: none"></div>
+  <div style="flex: 1; background: var(--content); padding: 28px; display: flex; flex-direction: column; overflow: hidden">
+    <div style="max-width: 640px; width: 100%; display: flex; flex-direction: column; flex: 1; min-height: 0">
+      <div style="font-size: 22px; font-weight: 600; margin-bottom: 6px">Install Omarchy</div>
+      <div style="font-size: 13px; color: var(--text2); margin-bottom: 20px">macOS stays. Omarchy gets its own space and its own place in the boot menu.</div>
+      <div style="display: flex; flex-direction: column; gap: 14px">
+        <div class="panel">
+          <div style="display: flex; align-items: center; gap: 14px">
+            <div style="display: flex; flex-direction: column; gap: 2px">
+              <span style="font-size: 14px; font-weight: 600">MacBook Pro (14-inch, 2021)</span>
+              <span style="font-size: 11.5px; color: var(--text2)">Apple M1 Pro · 464 GB free</span>
+            </div>
+            <span style="margin-left: auto; font-size: 11px; font-weight: 600; color: var(--accent-text); background: var(--accent); border-radius: 999px; padding: 4px 12px">Supported</span>
+          </div>
+        </div>
+        <div class="details">
+          <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px">
+            <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent)"><path d="M2 3.5 5 6.5 8 3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span style="font-size: 12px; font-weight: 500; color: var(--text2)">What was checked</span>
+          </div>
+          <div style="height: 1px; background: var(--sep)"></div>
+          <div style="display: flex; flex-direction: column; gap: 8px; padding: 12px 12px 14px">
+            <div style="display: flex; align-items: baseline; gap: 12px">
+              <span style="width: 118px; flex: none; font-size: 12.5px; color: var(--text2)">Model</span>
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none; align-self: center"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">MacBook Pro (M1 Pro) · apple,j314s</span>
+              <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-left: auto; align-self: center"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 12px">
+              <span style="width: 118px; flex: none; font-size: 12.5px; color: var(--text2)">macOS</span>
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none; align-self: center"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">macOS 15.6</span>
+              <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-left: auto; align-self: center"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 12px">
+              <span style="width: 118px; flex: none; font-size: 12.5px; color: var(--text2)">Power</span>
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none; align-self: center"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">Connected</span>
+              <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-left: auto; align-self: center"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 12px">
+              <span style="width: 118px; flex: none; font-size: 12.5px; color: var(--text2)">FileVault</span>
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none; align-self: center"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">Off</span>
+              <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-left: auto; align-self: center"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+            </div>
+            <div style="display: flex; align-items: baseline; gap: 12px">
+              <span style="width: 118px; flex: none; font-size: 12.5px; color: var(--text2)">Free space</span>
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none; align-self: center"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">464 GB of 994.66 GB</span>
+              <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-left: auto; align-self: center"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div style="flex: 1; min-height: 16px"></div>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; padding-top: 16px">
+        <span style="font-size: 11px; color: var(--text2)">Nothing has been changed.</span>
+        <div style="margin-left: auto; display: flex; gap: 8px">
+          <span class="btn secondary">Check again</span>
+          <span class="btn primary">Continue</span>
+        </div>
+      </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  renderVals() {
+    return { theme: (this.props.dark ?? true) ? 'dark' : 'light' };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/Plan.dc.html
+++ b/apps/omarchy-apple-installer/Design/Plan.dc.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --sidebar:#EAEDE2; --content:#F5F7F1; --card:#FFFFFF;
+      --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2; --track:#E3E7D9;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B; --caution:#8A6D1B;
+      --accent-soft:rgba(78,138,34,0.14); --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18);
+      color: var(--text); }
+    .win { --window:#23261E; --sidebar:#272B21; --content:#191C14; --card:#242820;
+      --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B; --track:#2E3326;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E; --caution:#F3C96B;
+      --accent-soft:rgba(144,208,90,0.16); --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .rail { width: 208px; flex: none; background: var(--sidebar); padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+    .rrow { display: flex; align-items: center; gap: 11px; padding: 8px 12px; border-radius: 10px; }
+    .rrow.cur { background: var(--accent-soft); }
+    .stepnum { width: 27px; height: 27px; border-radius: 50%; background: var(--track); color: var(--text2); font-size: 15px; font-weight: 600; display: flex; align-items: center; justify-content: center; flex: none; }
+    .cur .stepnum, .done .stepnum { background: var(--accent); color: var(--accent-text); }
+    .steplbl { font-size: 19.5px; color: var(--text); }
+    .cur .steplbl { font-weight: 600; }
+    .done .steplbl { color: var(--text2); }
+    .railfoot { margin-top: auto; padding: 0 10px 10px; display: flex; flex-direction: column; gap: 2px; }
+    .panel { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; padding: 13px 14px; display: flex; flex-direction: column; gap: 10px; }
+    .details { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; display: flex; flex-direction: column; }
+    .btn { font-size: 16px; height: 42px; padding: 0 21px; border-radius: 9px; display: inline-flex; align-items: center; justify-content: center; white-space: nowrap; }
+    .btn.primary { background: var(--accent); color: var(--accent-text); font-weight: 500; box-shadow: 0 0.5px 1.5px rgba(0,0,0,0.18); }
+    .btn.secondary { background: var(--btn-bg); color: var(--text); border: 1px solid var(--btn-border); box-shadow: 0 0.5px 1px rgba(0,0,0,0.06); }
+    .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+    .factrow { display: flex; align-items: baseline; gap: 12px; }
+    .factlbl { width: 104px; flex: none; font-size: 12.5px; color: var(--text2); }
+    .factval { font-size: 12.5px; }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 1000px; height: 760px; display: flex; background: var(--window)">
+  <div class="rail">
+    <div style="padding: 10px 6px 28px 12px"><div style="width: 126px; height: 126px; border-radius: 28px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center"><img src="icon.png" alt="Omarchy" style="width: 76px; height: 76px"></div></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Check</span></div>
+    <div class="rrow cur"><span class="stepnum">2</span><span class="steplbl">Plan</span></div>
+    <div class="rrow"><span class="stepnum">3</span><span class="steplbl">Authorize</span></div>
+    <div class="rrow"><span class="stepnum">4</span><span class="steplbl">Install</span></div>
+    <div class="rrow"><span class="stepnum">5</span><span class="steplbl">Recovery</span></div>
+    <div class="rrow"><span class="stepnum">6</span><span class="steplbl">Boot</span></div>
+    <div class="railfoot">
+      <div style="display: flex; align-items: center; gap: 6px">
+        <span style="width: 7px; height: 7px; border-radius: 50%; background: var(--accent)"></span>
+        <span style="font-size: 11px; font-weight: 500">Safety active</span>
+      </div>
+      <div style="font-size: 11px; color: var(--text2)">Bound to the reviewed plan</div>
+    </div>
+  </div>
+  <div style="width: 1px; background: var(--sep); flex: none"></div>
+  <div style="flex: 1; background: var(--content); padding: 28px; display: flex; flex-direction: column; overflow: hidden">
+    <div style="max-width: 640px; width: 100%; display: flex; flex-direction: column; flex: 1; min-height: 0">
+      <div style="font-size: 22px; font-weight: 600; margin-bottom: 6px">{{headline}}</div>
+      <div style="font-size: 13px; color: var(--text2); margin-bottom: 20px">macOS keeps the rest, untouched.</div>
+      <div style="display: flex; flex-direction: column; gap: 14px">
+        <div class="panel">
+          <div style="font-size: 11px; font-weight: 600; color: var(--text2)">Disk · 994.66 GB</div>
+          <div style="display: flex; height: 24px; border-radius: 8px; overflow: hidden">
+            <div style="width: {{macWidth}}; background: var(--track); display: flex; align-items: center; justify-content: center; overflow: hidden">
+              <span style="font-size: 10.5px; font-weight: 600; color: var(--text2); white-space: nowrap">{{macLabel}}</span>
+            </div>
+            <div style="width: {{omarchyWidth}}; background: var(--accent); display: flex; align-items: center; justify-content: center; overflow: hidden">
+              <span style="font-size: 10.5px; font-weight: 600; color: var(--accent-text); white-space: nowrap">{{omarchyLabel}}</span>
+            </div>
+          </div>
+          <input type="range" min="120" max="800" step="10" value="{{omarchyGB}}" onChange="{{pickSize}}" style="width: 100%; accent-color: var(--accent); margin: 0; height: 18px">
+          <div style="display: flex; align-items: baseline; gap: 8px">
+            <span style="font-size: 11px; color: var(--text2)">Drag to choose how much space Omarchy gets · minimum 120 GB</span>
+            <span class="mono" style="margin-left: auto; font-size: 11px; font-weight: 600; color: var(--accent)"><span>{{omarchyGB}}</span> GB</span>
+          </div>
+        </div>
+        <div class="panel">
+          <div style="display: flex; align-items: baseline; gap: 8px">
+            <span style="font-size: 11px; font-weight: 600; color: var(--text2)">Downloaded</span>
+            <span class="mono" style="margin-left: auto; font-size: 11px; font-weight: 600; color: var(--accent)">Verified ✓</span>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 3px">
+            <div style="display: flex; align-items: center; gap: 8px">
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">omarchy-2026.08.29-aarch64-apple-silicon.zip</span>
+              <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">4.6 GB</span>
+            </div>
+            <div style="display: flex; align-items: center; gap: 8px">
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">installer_data.json</span>
+              <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">34 MB</span>
+            </div>
+            <div style="display: flex; align-items: center; gap: 8px">
+              <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent); flex: none"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <span style="font-size: 12.5px">installer-v0.9.0-omarchy.7.tar.gz</span>
+              <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">22 MB</span>
+            </div>
+          </div>
+        </div>
+        <div class="details">
+          <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px">
+            <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent)"><path d="M2 3.5 5 6.5 8 3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            <span style="font-size: 12px; font-weight: 500; color: var(--text2)">Exact plan</span>
+          </div>
+          <div style="height: 1px; background: var(--sep)"></div>
+          <div style="display: flex; flex-direction: column; gap: 8px; padding: 12px 12px 14px">
+            <div class="factrow"><span class="factlbl">Device</span><span class="factval">apple,j314s</span></div>
+            <div class="factrow"><span class="factlbl">Store</span><span class="factval">disk0 · resize disk0s2</span></div>
+            <div class="factrow"><span class="factlbl">Offset</span><span class="factval">694,662,584,320 bytes</span></div>
+            <div class="factrow"><span class="factlbl">Length</span><span class="factval">300,000,000,000 bytes (300 GB)</span></div>
+            <div class="factrow"><span class="factlbl">Engine</span><span class="factval">installer-v0.9.0-omarchy.7</span></div>
+            <div class="factrow"><span class="factlbl">Plan digest</span><span class="factval mono" style="font-size: 10.5px">9f31c2ab…c47d21e8</span></div>
+            <div class="factrow"><span class="factlbl">Rollback</span><span class="factval">macOS untouched until approval; every write is checkpointed and journaled</span></div>
+          </div>
+        </div>
+        <div style="display: flex; align-items: flex-start; gap: 11px; padding-top: 2px">
+          <span style="width: 14px; height: 14px; border-radius: 3.5px; background: var(--accent); display: inline-flex; align-items: center; justify-content: center; flex: none; margin-top: 1px">
+            <svg width="8" height="8" viewBox="0 0 10 10" style="color: var(--accent-text)"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </span>
+          <span style="font-size: 12.5px">I reviewed the plan and the Recovery steps.</span>
+          <svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--text2); flex: none; margin-top: 2px"><circle cx="6" cy="6" r="5.4" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="6" cy="3.6" r="0.7" fill="currentColor"/><rect x="5.45" y="5.2" width="1.1" height="3.4" rx="0.55" fill="currentColor"/></svg>
+        </div>
+      </div>
+      <div style="flex: 1; min-height: 16px"></div>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; padding-top: 16px">
+      <div style="margin-left: auto; display: flex; gap: 8px">
+        <span class="btn secondary">Re-prepare plan</span>
+        <span class="btn primary">Approve exact plan</span>
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  constructor(props) {
+    super(props);
+    this.state = { omarchyGB: 300 };
+  }
+  renderVals() {
+    const dark = this.props.dark ?? true;
+    const totalGB = 994.66;
+    const gb = Math.max(120, Math.min(800, this.state.omarchyGB));
+    const macGB = Math.round((totalGB - gb) * 100) / 100;
+    const pct = Math.round((gb / totalGB) * 1000) / 10;
+    const macPct = Math.round((100 - pct) * 10) / 10;
+    return {
+      theme: dark ? 'dark' : 'light',
+      headline: gb + ' GB for Omarchy',
+      omarchyGB: gb,
+      omarchyWidth: pct + '%',
+      macWidth: macPct + '%',
+      omarchyLabel: pct < 15 ? gb + ' GB' : 'Omarchy · ' + gb + ' GB',
+      macLabel: macPct < 15 ? macGB + ' GB' : 'macOS · ' + macGB + ' GB',
+      pickSize: (event) => {
+        const value = parseInt(event && event.target ? event.target.value : gb, 10);
+        if (!isNaN(value)) {
+          this.setState({ omarchyGB: value });
+        }
+      }
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/Preparing.dc.html
+++ b/apps/omarchy-apple-installer/Design/Preparing.dc.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --sidebar:#EAEDE2; --content:#F5F7F1; --card:#FFFFFF;
+      --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2; --track:#E3E7D9;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B; --caution:#8A6D1B;
+      --accent-soft:rgba(78,138,34,0.14); --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18);
+      color: var(--text); }
+    .win { --window:#23261E; --sidebar:#272B21; --content:#191C14; --card:#242820;
+      --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B; --track:#2E3326;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E; --caution:#F3C96B;
+      --accent-soft:rgba(144,208,90,0.16); --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .rail { width: 208px; flex: none; background: var(--sidebar); padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+    .rrow { display: flex; align-items: center; gap: 11px; padding: 8px 12px; border-radius: 10px; }
+    .rrow.cur { background: var(--accent-soft); }
+    .stepnum { width: 27px; height: 27px; border-radius: 50%; background: var(--track); color: var(--text2); font-size: 15px; font-weight: 600; display: flex; align-items: center; justify-content: center; flex: none; }
+    .cur .stepnum, .done .stepnum { background: var(--accent); color: var(--accent-text); }
+    .steplbl { font-size: 19.5px; color: var(--text); }
+    .cur .steplbl { font-weight: 600; }
+    .done .steplbl { color: var(--text2); }
+    .railfoot { margin-top: auto; padding: 0 10px 10px; display: flex; flex-direction: column; gap: 2px; }
+    .panel { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; padding: 13px 14px; display: flex; flex-direction: column; gap: 10px; }
+    .track { height: 13.5px; border-radius: 6.75px; background: var(--track); overflow: hidden; }
+    .fill { height: 100%; border-radius: 6.75px; background: var(--accent); }
+    .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 1000px; height: 700px; display: flex; background: var(--window)">
+  <div class="rail">
+    <div style="padding: 10px 6px 28px 12px"><div style="width: 126px; height: 126px; border-radius: 28px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center"><img src="icon.png" alt="Omarchy" style="width: 76px; height: 76px"></div></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span><span class="steplbl">Check</span></div>
+    <div class="rrow cur"><span class="stepnum">2</span><span class="steplbl">Plan</span></div>
+    <div class="rrow"><span class="stepnum">3</span><span class="steplbl">Authorize</span></div>
+    <div class="rrow"><span class="stepnum">4</span><span class="steplbl">Install</span></div>
+    <div class="rrow"><span class="stepnum">5</span><span class="steplbl">Recovery</span></div>
+    <div class="rrow"><span class="stepnum">6</span><span class="steplbl">Boot</span></div>
+    <div class="railfoot">
+      <div style="display: flex; align-items: center; gap: 6px">
+        <span style="width: 7px; height: 7px; border-radius: 50%; background: var(--accent)"></span>
+        <span style="font-size: 11px; font-weight: 500">Safety active</span>
+      </div>
+      <div style="font-size: 11px; color: var(--text2)">Bound to the reviewed plan</div>
+    </div>
+  </div>
+  <div style="width: 1px; background: var(--sep); flex: none"></div>
+  <div style="flex: 1; background: var(--content); padding: 28px; display: flex; flex-direction: column; overflow: hidden">
+    <div style="max-width: 640px; width: 100%; display: flex; flex-direction: column; flex: 1; min-height: 0">
+      <div style="font-size: 22px; font-weight: 600; margin-bottom: 6px">Getting everything ready</div>
+      <div style="font-size: 13px; color: var(--text2); margin-bottom: 20px">Fetching the signed catalog, downloading the verified files, and asking the pinned engine for a plan.</div>
+      <div style="display: flex; flex-direction: column; gap: 14px">
+        <div class="panel">
+          <div style="display: flex; align-items: baseline; gap: 8px">
+            <span style="font-size: 11px; font-weight: 600; color: var(--text2)">Downloading verified files…</span>
+            <span class="mono" style="margin-left: auto; font-size: 11px; font-weight: 600; color: var(--accent)">2.32 GB of 4.66 GB</span>
+          </div>
+          <div class="track"><div class="fill" style="width: 50%"></div></div>
+        </div>
+        <div class="panel">
+          <div style="font-size: 11px; font-weight: 600; color: var(--text2)">Downloading</div>
+          <div style="display: flex; flex-direction: column; gap: 14px">
+            <div style="display: flex; flex-direction: column; gap: 4px">
+              <div style="display: flex; align-items: baseline; gap: 8px">
+                <span style="font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">omarchy-2026.08.29-aarch64-apple-silicon.zip</span>
+                <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--text2)">2.26 GB of 4.6 GB · part 3 of 5</span>
+              </div>
+              <div class="track"><div class="fill" style="width: 49%"></div></div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 4px">
+              <div style="display: flex; align-items: baseline; gap: 8px">
+                <span style="font-size: 12.5px">installer_data.json</span>
+                <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--accent)">Verified ✓</span>
+              </div>
+              <div class="track"><div class="fill" style="width: 100%"></div></div>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 4px">
+              <div style="display: flex; align-items: baseline; gap: 8px">
+                <span style="font-size: 12.5px">installer-v0.9.0-omarchy.7.tar.gz</span>
+                <span class="mono" style="margin-left: auto; flex: none; font-size: 11px; color: var(--accent)">Verified ✓</span>
+              </div>
+              <div class="track"><div class="fill" style="width: 100%"></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div style="flex: 1; min-height: 16px"></div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  renderVals() {
+    return { theme: (this.props.dark ?? true) ? 'dark' : 'light' };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/Recovery.dc.html
+++ b/apps/omarchy-apple-installer/Design/Recovery.dc.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif; -webkit-font-smoothing: antialiased; }
+    a { color: #4E8A22; } a:hover { color: #3D6E1A; }
+    .win.light { --window:#F1F3EC; --sidebar:#EAEDE2; --content:#F5F7F1; --card:#FFFFFF;
+      --text:#1C2117; --text2:#6A7261; --sep:#DDE2D2; --track:#E3E7D9;
+      --accent:#4E8A22; --accent-text:#FFFFFF; --danger:#C4372B; --caution:#8A6D1B;
+      --accent-soft:rgba(78,138,34,0.14); --btn-bg:#FFFFFF; --btn-border:rgba(28,33,23,0.18);
+      color: var(--text); }
+    .win { --window:#23261E; --sidebar:#272B21; --content:#191C14; --card:#242820;
+      --text:#E8EBE2; --text2:#A3AB97; --sep:#343A2B; --track:#2E3326;
+      --accent:#90D05A; --accent-text:#0A0C08; --danger:#FF6B5E; --caution:#F3C96B;
+      --accent-soft:rgba(144,208,90,0.16); --btn-bg:#2E3326; --btn-border:rgba(232,235,226,0.16); color: var(--text); }
+    .win * { box-sizing: border-box; }
+    .rail { width: 208px; flex: none; background: var(--sidebar); padding: 8px; display: flex; flex-direction: column; gap: 8px; }
+    .rrow { display: flex; align-items: center; gap: 11px; padding: 8px 12px; border-radius: 10px; }
+    .rrow.cur { background: var(--accent-soft); }
+    .stepnum { width: 27px; height: 27px; border-radius: 50%; background: var(--track); color: var(--text2); font-size: 15px; font-weight: 600; display: flex; align-items: center; justify-content: center; flex: none; }
+    .cur .stepnum, .done .stepnum { background: var(--accent); color: var(--accent-text); }
+    .steplbl { font-size: 19.5px; color: var(--text); }
+    .cur .steplbl { font-weight: 600; }
+    .done .steplbl { color: var(--text2); }
+    .railfoot { margin-top: auto; padding: 0 10px 10px; display: flex; flex-direction: column; gap: 2px; }
+    .card { background: var(--card); border: 1px solid var(--sep); border-radius: 10px; }
+    .btn { font-size: 16px; height: 42px; padding: 0 21px; border-radius: 9px; display: inline-flex; align-items: center; justify-content: center; white-space: nowrap; }
+    .btn.primary { background: var(--accent); color: var(--accent-text); font-weight: 500; box-shadow: 0 0.5px 1.5px rgba(0,0,0,0.18); }
+  </style>
+</helmet>
+<div class="win {{theme}}" style="width: 1000px; height: 700px; display: flex; background: var(--window)">
+  <div class="rail">
+    <div style="padding: 10px 6px 28px 12px"><div style="width: 126px; height: 126px; border-radius: 28px; background: #0A0D08; border: 1px solid var(--sep); display: flex; align-items: center; justify-content: center"><img src="icon.png" alt="Omarchy" style="width: 76px; height: 76px"></div></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span><span class="steplbl">Check</span></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span><span class="steplbl">Plan</span></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span><span class="steplbl">Authorize</span></div>
+    <div class="rrow done"><span class="stepnum"><svg width="13" height="13" viewBox="0 0 10 10"><path d="M1.5 5.5 4 8 8.5 2" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span><span class="steplbl">Install</span></div>
+    <div class="rrow cur"><span class="stepnum">5</span><span class="steplbl">Finish</span></div>
+    <div class="rrow"></div>
+    <div class="railfoot">
+      <div style="display: flex; align-items: center; gap: 6px">
+        <span style="width: 7px; height: 7px; border-radius: 50%; background: var(--accent)"></span>
+        <span style="font-size: 11px; font-weight: 500">Safety active</span>
+      </div>
+      <div style="font-size: 11px; color: var(--text2)">Bound to the reviewed plan</div>
+    </div>
+  </div>
+  <div style="width: 1px; background: var(--sep); flex: none"></div>
+  <div style="flex: 1; background: var(--content); padding: 28px; display: flex; flex-direction: column; overflow: hidden">
+    <div style="max-width: 640px; width: 100%; display: flex; flex-direction: column; flex: 1; min-height: 0">
+      <div style="font-size: 22px; font-weight: 600; margin-bottom: 6px">One step left, in Recovery</div>
+      <div style="font-size: 13px; color: var(--text2); margin-bottom: 20px">Apple asks you to approve the new system in person. About two minutes.</div>
+      <div style="display: flex; flex-direction: column; gap: 14px">
+        <div style="display: flex; flex-direction: column; gap: 10px">
+          <div class="card" style="display: flex; align-items: flex-start; gap: 13px; padding: 10px 12px">
+            <span style="width: 24px; height: 24px; border-radius: 50%; background: var(--accent); color: var(--accent-text); font-size: 12px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex: none">1</span>
+            <div style="display: flex; flex-direction: column; gap: 2px">
+              <span style="font-size: 13px; font-weight: 600">Shut down</span>
+              <span style="font-size: 12.5px; color: var(--text2)">Apple menu → Shut Down.</span>
+            </div>
+          </div>
+          <div class="card" style="display: flex; align-items: flex-start; gap: 13px; padding: 10px 12px">
+            <span style="width: 24px; height: 24px; border-radius: 50%; background: var(--accent); color: var(--accent-text); font-size: 12px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex: none">2</span>
+            <div style="display: flex; flex-direction: column; gap: 2px">
+              <span style="font-size: 13px; font-weight: 600">Hold the power button</span>
+              <span style="font-size: 12.5px; color: var(--text2)">Until “Loading startup options” appears.</span>
+            </div>
+          </div>
+          <div class="card" style="display: flex; align-items: flex-start; gap: 13px; padding: 10px 12px">
+            <span style="width: 24px; height: 24px; border-radius: 50%; background: var(--accent); color: var(--accent-text); font-size: 12px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex: none">3</span>
+            <div style="display: flex; flex-direction: column; gap: 2px">
+              <span style="font-size: 13px; font-weight: 600">Pick Omarchy → Finish Installation</span>
+              <span style="font-size: 12.5px; color: var(--text2)">Sign in when asked. The Mac restarts into Omarchy.</span>
+            </div>
+          </div>
+        </div>
+        <div class="card" style="display: flex; flex-direction: column">
+          <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px">
+            <svg width="9" height="9" viewBox="0 0 10 10" style="color: var(--accent)"><path d="M2 3.5 5 6.5 8 3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+            <span style="font-size: 12px; font-weight: 500; color: var(--text2)">What happens in Recovery</span>
+          </div>
+          <div style="height: 1px; background: var(--sep)"></div>
+          <div style="padding: 10px 12px 12px">
+            <span style="font-size: 12.5px; color: var(--text2)">This is Apple’s “One True Recovery”. Finish Installation sets the boot policy for the new volume — the same mechanism Asahi Linux uses. macOS keeps full security. Skipping changes nothing; you can return any time.</span>
+          </div>
+        </div>
+      </div>
+      <div style="flex: 1; min-height: 16px"></div>
+    </div>
+    <div style="display: flex; align-items: center; gap: 8px; padding-top: 16px">
+        <span style="font-size: 11px; color: var(--text2)">No rush — these steps stay here.</span>
+        <div style="margin-left: auto; display: flex; gap: 8px">
+          <span class="btn primary">Continue</span>
+        </div>
+      </div>
+  </div>
+</div>
+</x-dc>
+<script data-dc-script data-props='{"dark":{"editor":"boolean","default":true,"section":"Appearance"}}'>
+class Component extends DCLogic {
+  renderVals() {
+    return { theme: (this.props.dark ?? true) ? 'dark' : 'light' };
+  }
+}
+</script>
+</body>
+</html>

--- a/apps/omarchy-apple-installer/Design/canvas.json
+++ b/apps/omarchy-apple-installer/Design/canvas.json
@@ -1,0 +1,73 @@
+{
+  "artboards": [
+    {
+      "file": "Main.dc.html",
+      "x": 0,
+      "y": 0,
+      "w": 1000,
+      "h": 700,
+      "title": "1 · Check"
+    },
+    {
+      "file": "Preparing.dc.html",
+      "x": 1100,
+      "y": 0,
+      "w": 1000,
+      "h": 700,
+      "title": "2 · Plan — preparing"
+    },
+    {
+      "file": "Plan.dc.html",
+      "x": 2200,
+      "y": 0,
+      "w": 1000,
+      "h": 760,
+      "title": "2 · Plan — review",
+      "is_interactive": true
+    },
+    {
+      "file": "Authorize.dc.html",
+      "x": 3300,
+      "y": 0,
+      "w": 1000,
+      "h": 700,
+      "title": "3 · Authorize"
+    },
+    {
+      "file": "Installing.dc.html",
+      "x": 0,
+      "y": 880,
+      "w": 1000,
+      "h": 700,
+      "title": "4 · Install"
+    },
+    {
+      "file": "Recovery.dc.html",
+      "x": 1100,
+      "y": 880,
+      "w": 1000,
+      "h": 700,
+      "title": "5 · Recovery"
+    },
+    {
+      "file": "CredentialSheet.dc.html",
+      "x": 3300,
+      "y": 880,
+      "w": 380,
+      "h": 470,
+      "title": "Authorize sheet"
+    }
+  ],
+  "annotations": [
+    {
+      "id": "about-this-canvas",
+      "x": 0,
+      "y": -180,
+      "w": 340,
+      "text": "The installer's six-step flow, drawn with the app's own colors, type, and spacing (InstallerTheme.swift).\nDark mode by default — turn off a screen's Dark switch above it to preview light mode.\nThe Plan screen's disk bar is a working control: drag the slider to resize Omarchy's share (minimum 120 GB)."
+    }
+  ],
+  "launch": {
+    "view": "canvas"
+  }
+}

--- a/apps/omarchy-apple-installer/Design/ux-redesign.md
+++ b/apps/omarchy-apple-installer/Design/ux-redesign.md
@@ -1,0 +1,427 @@
+Exploration is complete and all anchors verified. Here is the implementation plan.
+
+---
+
+# Omarchy Apple Installer UX Redesign — Implementation Plan
+
+Package root: `/Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer` (all relative paths below are under this root unless absolute).
+
+## 0. Verified ground truth (corrections and load-bearing facts)
+
+- The install journal lives under the **helper's** working directory: `ClosedEngineHelperServer` is constructed with `workingDirectory = /var/db/com.omarchy.mx.installer` (`Sources/OmarchyAppleInstallerHelper/main.swift:54`, `InstallerProductIdentity.helperWorkingDirectory`), the importer materializes the package there, and `PinnedAsahiEngineExecutor.preparePersistentJournal` (`:586-631`) derives `&lt;workingDirectory&gt;/execution-journals/&lt;bindingDigest-hex&gt;.jsonl`. Directory is root-owned 0700, file 0600 root. **The app can never read it directly.** This decides the streaming design (Section 1).
+- `ClosedEngineXPCService` has exactly one method (`AuthenticatedEngineXPCSubmitter.swift:6-14`); the submitter creates a fresh `NSXPCConnection` per submit and invalidates it in the reply (`:76-134`). The app-side connection currently sets no `exportedInterface` — free slot for a callback object.
+- The helper endpoint (`ClosedEngineHelperServer.swift:118-146`) runs its work in a detached `Task`; `NSXPCConnection.current()` is only valid synchronously inside the exported method, before that Task.
+- Engine fsyncs after each journal append (`Engine/overlay/src/omarchy_contract.py:258,467`), and stage-1 is checkpoint-resumable (`omarchy_stage1.py:47-77`); checkpoint ids/phases confirmed at `omarchy_stage1.py:24-44`.
+- `EngineTranscriptDecoder.decode` accepts a **prefix** transcript: it requires trailing `\n`, contiguous sequence from 1, inspection@1/inventory@2/plan@3 order, monotonic phases — but does *not* require a completion message (`EngineContract.swift:127-370`). A complete-lines-only buffer therefore validates incrementally via the public `AppleInstallerTrustCore().validateEngineTranscript(_:)`.
+- Username charset is `[A-Za-z0-9._-]`, 1–255 bytes; password 1–1024 bytes UTF-8, no NUL/LF/CR (`MachineOwnerAuthorization.swift:27-49`). OpenDirectory rejection surfaces today as `ClosedEngineHelperError.invalidMachineOwnerCredentials` bridged to a generic `helperRejected(domain:code:)` NSError on the app side.
+- Downloads use `URLSession.shared.download(from:)` with no progress (`VerifiedArtifactStager.swift:308-321`); expected byte sizes are pinned per artifact from the signed catalog (`PinnedInstallerArtifact.expectedSizeBytes`).
+- Fixture `/Users/maralc/dev/omarchy/omarchy-mx-mac-integration/evidence/apple-silicon/2026-08-29-m1-fresh-install-v6/execution-journal.jsonl` is a 10-line, fully valid `awaiting_recovery` transcript for `apple,j314s` (resize candidate) — it decodes through the real trust core, so the mock can derive every display model from it.
+- Tests use `@testable import OmarchyAppleInstallerTrustCore` and already pass in debug and release, so testability is enabled for release test builds in this toolchain; a new library test target will behave the same.
+- This dev machine is the explicitly blocked `apple,j614s` M4 (`MacHostInspection.swift:53`), which produces the locked state; keep it fail-closed.
+
+---
+
+## 1. Progress streaming design
+
+### Comparison
+
+**(a) Daemon-side journal tailer forwarding envelopes over an XPC client callback — CHOSEN.**
+- The journal is root:0700/0600 under `/var/db`; only the helper can read it. The helper already owns the run lifecycle (single-flight actor) and the XPC connection stays open for the duration of `submit` (reply arrives at the end), so a callback interface on the same connection is the natural, already-authenticated channel (mutual codesigning requirements already pin both peers).
+- Zero changes to the engine, zero changes to `PinnedAsahiEngineExecutor`, no new files on disk, no permission weakening. Advisory-only by construction: the authoritative transcript still arrives via the existing `reply` path and is still re-validated by both the helper (`ClosedEngineHelperServer.swift:87-105`) and the app.
+
+**(b) Piping engine stdout — rejected.** The engine's contract output is the journal (env `OMARCHY_ENGINE_JOURNAL`), not stdout; stdout/stderr are deliberately nulled (`PinnedAsahiEngineExecutor.swift:214-216`). Using stdout would require touching the most qualification-sensitive file's process wiring, changing the pinned engine to double-write, and would create a second, non-fsync'd, unvalidated channel. Worst churn, weakest guarantees.
+
+**(c) App-readable progress file — rejected.** Would require the root daemon either to relax the 0700/0600 hardening or to write into a user-controllable directory (symlink/planting hazards for root, exactly what the current `lstat`/`O_NOFOLLOW` discipline exists to prevent). Also adds polling with no auth binding to the run.
+
+### New/changed trust-core surface (exact signatures)
+
+**New file `Sources/OmarchyAppleInstaller/EngineJournalProgress.swift`** (small; the only place the XPC callback protocol lives):
+
+```swift
+@objc public protocol ClosedEngineProgressClient {
+  // One or more complete, "\n"-terminated NDJSON envelope lines, in file order.
+  // Fire-and-forget (no reply block): XPC does not queue unbounded replies.
+  func engineJournalDidAppend(_ completeLines: Data)
+}
+
+public protocol EngineJournalProgressSink: Sendable {
+  func journalDidAppend(_ completeLines: Data)
+}
+```
+
+**New file `Sources/OmarchyAppleInstaller/EngineJournalTail.swift`:**
+
+```swift
+public enum EngineJournalLocator {
+  /// Mirrors PinnedAsahiEngineExecutor.preparePersistentJournal path derivation:
+  /// &lt;workingDirectory&gt;/execution-journals/&lt;SHA256Digest(rawValue: bindingDigest).hexadecimal&gt;.jsonl
+  /// Returns nil for a malformed digest.
+  public static func journalURL(workingDirectory: URL, bindingDigest: String) -&gt; URL?
+}
+
+public actor EngineJournalTailer {
+  public init(
+    journalURL: URL,
+    expectedOwner: uid_t,
+    pollInterval: Duration,          // default .milliseconds(250)
+    maximumChunkBytes: Int,          // default 262_144
+    sink: any EngineJournalProgressSink
+  )
+  public func start()
+  public func stop() async           // performs one final drain, then stops
+}
+```
+
+Tailer behavior:
+- Loop with `Task.sleep` (suspending, never blocking a pool thread). File may not exist yet — keep polling silently.
+- Each tick: `open(O_RDONLY|O_CLOEXEC|O_NOFOLLOW)`, `fstat` guard (regular file, `mode &amp; 0o077 == 0`, `st_uid == expectedOwner`, `st_size &lt;= PinnedAsahiEngineExecutor.maximumTranscriptBytes`) — same fail-closed checks as `readTranscript` (`:644-674`) but tolerant of a growing file.
+- Read from the last forwarded byte offset; scan backward for the final `\n`; forward only whole lines (`[offset, lastNewline+1)`), capped at `maximumChunkBytes` per message (a single oversized line up to the decoder's 65,536-byte max is still forwarded alone). Partial trailing line stays buffered in the file, not in memory.
+- Always starts from **offset 0** — full replay on every attach (this is what makes reattach trivial; see below).
+- Any guard failure: stop forwarding silently. Advisory channel; never propagate errors into the run.
+
+Backpressure/rate limiting: poll cadence (4 Hz) is the coalescer; messages are no-reply so there is no reply-queue growth; total journal is capped at 8 MiB by contract, ~tens of lines in practice, so worst-case total streamed bytes are trivial.
+
+**`Sources/OmarchyAppleInstaller/ClosedEngineHelperServer.swift` (edit, ~30 lines):**
+
+```swift
+// Actor method gains an optional sink; default nil keeps every existing call site and test identical.
+public func submit(
+  packageDirectory: FileHandle,
+  authorization: MachineOwnerAuthorization,
+  operation: EngineHandoffOperation = .install,
+  progress: (any EngineJournalProgressSink)? = nil
+) async throws -&gt; Data
+```
+
+- After `importer.prepare` (so `package.bindingDigest` is known) and *before* `executor.execute`: if `progress != nil` and `EngineJournalLocator.journalURL(workingDirectory:bindingDigest:)` resolves, start an `EngineJournalTailer` with `expectedOwner: geteuid()` (root, matching the executor's `expectedFileOwnerID`). `await tailer.stop()` on both the success and the throw path (wrap the executor call in `do/catch`; actors cannot `await` in `defer`).
+- In `ClosedEngineXPCServiceEndpoint.submit`: capture the callback proxy **synchronously**, before the `Task`:
+
+```swift
+let client = (NSXPCConnection.current()?
+  .remoteObjectProxyWithErrorHandler { _ in /* peer has no client object: disable streaming */ })
+  as? ClosedEngineProgressClient
+let sink = client.map(XPCJournalProgressSink.init)   // tiny @unchecked Sendable wrapper
+```
+
+- In `AuthenticatedEngineXPCListenerDelegate.listener(_:shouldAcceptNewConnection:)` add one line: `connection.remoteObjectInterface = NSXPCInterface(with: ClosedEngineProgressClient.self)`.
+- **`ClosedEngineXPCService.submit` is byte-for-byte unchanged.** That is the version-skew story: old helper never calls back (app falls back to indeterminate after ~3 s without a chunk); new helper + old app hits the proxy error handler and simply stops streaming. No negotiation, no new failure modes on the authoritative path.
+
+**`Sources/OmarchyAppleInstaller/AuthenticatedEngineXPCSubmitter.swift` (edit, ~20 lines):**
+
+```swift
+public init(
+  machServiceName: String,
+  helperCodeSigningRequirement: String,
+  journalProgress: (@Sendable (Data) -&gt; Void)? = nil
+) throws
+```
+
+Inside `submit(_:authorization:operation:)`, when `journalProgress != nil`:
+
+```swift
+connection.exportedInterface = NSXPCInterface(with: ClosedEngineProgressClient.self)
+connection.exportedObject = EngineProgressClientRelay(handler: journalProgress)  // NSObject, ClosedEngineProgressClient
+```
+
+`EngineHandoffSubmitting` and `ClosedEngineHandoffProcess` stay untouched (progress is bound at submitter construction, not threaded through the protocol).
+
+**`Sources/OmarchyAppleInstaller/InstallerExecutionCoordinator.swift` (edit, additive param):**
+
+```swift
+public func execute(
+  _ prepared: PreparedInstallerPlanExecution,
+  approval: CandidateBoundPlanApproval,
+  configuration: InstallerReleaseConfiguration,
+  handoffDirectory: URL,
+  machineOwnerAuthorization: MachineOwnerAuthorization,
+  journalProgress: (@Sendable (Data) -&gt; Void)? = nil
+) async throws -&gt; InstallerExecutionProgress
+// identical addition on retryRecoveryAuthorization(...)
+```
+
+It forwards `journalProgress` into the submitter initializer. Nothing else in the trust chain changes.
+
+### App-side envelope validation
+
+New UXCore type (Section 2) `LiveInstallJournalModel`:
+- Maintains `raw: Data` of complete lines. `mutating func consume(_ chunk: Data)`: if the buffer is non-empty and the chunk's first line carries `"sequence":1` (helper re-replay from offset 0, e.g. a retry submit on a fresh connection), **replace** the buffer; otherwise append.
+- After each mutation, run `AppleInstallerTrustCore().validateEngineTranscript(raw)` (public API; no new trust-core surface). Success → derive display state: current phase (max checkpoint phase seen, else inferred from last event name), completed checkpoints, last event, completion outcome.
+- Any decode/validation error (sequence gap, garbage line, phase regression) → set `degraded = true`: the UI drops to an indeterminate bar labeled with the last good phase. **Never** surface as an install failure and never cancel anything — the authoritative outcome still arrives via the existing reply and post-run validation, which remain unchanged and authoritative.
+- Re-validating the whole ≤8 MiB, ~10–40 line buffer at ≤4 Hz on a background task is negligible; publish the derived display struct to the `@MainActor` session.
+
+### App quits mid-run and reattaches
+
+- The helper's detached Task keeps executing after connection invalidation; the reply is dropped, the journal keeps being written and fsync'd, the single-flight actor stays busy until the engine exits.
+- Because the tailer always replays from offset 0 on attach, "reattach" needs no protocol state: any future submit for the same binding digest streams the whole journal first, and the engine's own resume logic (`run_stage1` skips completed checkpoints; a finished journal returns its completed outcome immediately) makes an identical resubmission converge fast. In-memory plan/approval are gone after a quit, so the UI path is: relaunch → re-inspect → re-prepare → if the disk is unchanged the digests match and resubmission resumes; if stage-1 already mutated the disk, the engine inventories a `repair` candidate and the normal flow converges through the repair operation. This is pre-existing product behavior; the streaming layer just makes it visible.
+- v1 explicitly does **not** add a read-only "observe a run in flight" XPC method. If a submit while busy throws `ClosedEngineHelperError.busy` (seen as `helperRejected`), the UI shows a dedicated "an installation appears to be in progress — do not power off; quit and reopen later" failure card. A future `observeJournal(bindingDigest:)` method is a noted extension, not in scope.
+
+---
+
+## 2. App architecture
+
+### Targets (Package.swift edit)
+
+Add one library target so the state machine, mapping layer, and journal model are unit-testable in debug **and** release without importing an executable target:
+
+```swift
+.target(
+  name: "OmarchyInstallerUXCore",
+  dependencies: ["OmarchyAppleInstallerTrustCore"],
+  path: "Sources/OmarchyInstallerUXCore"
+),
+.testTarget(
+  name: "OmarchyInstallerUXCoreTests",
+  dependencies: ["OmarchyInstallerUXCore"],
+  path: "Tests/OmarchyInstallerUXCoreTests"
+),
+// OmarchyAppleInstallerApp dependencies gain "OmarchyInstallerUXCore"
+```
+
+### File layout
+
+`Sources/OmarchyInstallerUXCore/` (Foundation + Observation only, no AppKit/SwiftUI):
+- `InstallerSession.swift` — `@MainActor @Observable public final class InstallerSession` + `InstallerSessionPhase`.
+- `InstallerEnvironment.swift` — the seam protocol (below) + display-model structs (`HostDisplay`, `PlanDisplay`, `HelperDisplay`, `InstallProgressDisplay`, `HandoffDisplay`, `CompletionDisplay`, `FailureDisplay`, `AssetProgressUpdate`).
+- `LiveInstallJournalModel.swift` — Section 1 consumer.
+- `PlainLanguage.swift` — mapping layer (below).
+- `CredentialInput.swift` — sheet validation model mirroring `MachineOwnerAuthorization` rules.
+
+`Sources/OmarchyAppleInstallerApp/`:
+- `OmarchyAppleInstallerApp.swift` — slimmed to `@main`, the `NSApplicationDelegate` instance-lease logic (kept verbatim), and the `WindowGroup` hosting the new root. The current 879-line body is deleted at the end of the build (WP11).
+- `InstallerRootView.swift` — phase switch → screen; hosts the credential `.sheet`.
+- `LiveInstallerEnvironment.swift` — real `InstallerEnvironment`: wraps `AppleSiliconHostInspector`, `EngineInspectionRunner`, `InstallerReleaseConfigurationLocator`, `AcceptedCatalogIdentityStore`, `InstallerReleaseAssetCoordinator`, `InstallerAllocationRecommendation`, `InstallerPlanPreparationCoordinator`, `InstallerHelperServiceManager`, `InstallerExecutionCoordinator`; privately retains the trust objects (`AppleSiliconHostInspection`, `Data` transcripts, `PreparedInstallerPlanExecution`, `InstallerPlanReview`, `CandidateBoundPlanApproval`, `InstallerReleaseConfiguration`) and the `installerWorkspace()` logic moved from the old view (`OmarchyAppleInstallerApp.swift:790-826`).
+- `PreviewInstallerEnvironment.swift` — entirely inside `#if DEBUG` (Section 6).
+- `InstallerTheme.swift` — retro tokens: the palette from the prototype (`omarchy-mx-mac/.../InstallerView.swift:1195-1220`, renamed `OmarchyTheme.*`), monospaced type scale, spacing; replaces `OmarchyInstallerPalette`.
+- `RetroComponents.swift` — `RetroBackdrop` (grid + scanline Canvas), `RetroRule`, `RetroButton`, `StatusLight`, `PixelMark`, `SignalPanel`, `RetroProgressBar` (block glyphs `█▓░`), `RetroDisclosure` (the "Details/Advanced" affordance), `StepRail` (adapted from prototype `InstallerView.swift:140-222`).
+- `Screens/WelcomeScreen.swift` (A), `Screens/PreparingScreen.swift`, `Screens/PlanReviewScreen.swift` (B), `Screens/CredentialSheet.swift` (C), `Screens/InstallingScreen.swift` (D), `Screens/RecoveryHandoffScreen.swift` (E), `Screens/CompletionScreen.swift` + `Screens/FailureScreen.swift` + `Screens/UnsupportedScreen.swift` (F and error/locked states).
+- `InstallerChrome.swift` — deleted in WP11 (replaced by Theme/RetroComponents).
+
+### Phase machine (replaces the 11 `@State` booleans)
+
+```swift
+public enum InstallerSessionPhase: Sendable {
+  case inspecting
+  case unsupported(FailureDisplay)                       // locked; re-inspect only
+  case welcome(HostDisplay)                              // Screen A
+  case preparingPlan(AssetProgressUpdate)                // catalog fetch, downloads, engine inspect+plan
+  case planReview(PlanDisplay, acknowledged: Bool)       // Screen B
+  case awaitingInstall(PlanDisplay, helper: HelperDisplay, sheet: CredentialSheetState)
+  case installing(InstallProgressDisplay)                // Screen D
+  case awaitingRecovery(HandoffDisplay)                  // Screen E (awaiting_recovery | awaiting_media)
+  case done(CompletionDisplay)                           // Screen F (installed)
+  case failed(FailureDisplay)                            // includes retryRecoveryAvailable flag
+}
+```
+
+Legal transitions (anything else is a guarded no-op):
+
+| From | To | Trigger |
+|---|---|---|
+| inspecting | welcome | host + engine inspect OK, supported, not blocked |
+| inspecting | unsupported | blockedReason, engine unsupported, engine artifact unavailable, device mismatch |
+| unsupported | inspecting | Re-inspect |
+| welcome | preparingPlan | Continue |
+| welcome | inspecting | Re-inspect |
+| preparingPlan | planReview | prepared |
+| preparingPlan | failed | preparation error (recoverable → Start over) |
+| planReview | awaitingInstall | Approve (requires `acknowledged == true`; calls `environment.approve`) |
+| planReview | preparingPlan | Re-prepare |
+| awaitingInstall | installing | sheet submit (helper `.enabled` + `CredentialInput` valid) |
+| awaitingInstall | planReview | Back (drops approval in environment, mirroring today's reset) |
+| installing | awaitingRecovery / done / failed | reply outcome via `InstallerNextAction` |
+| failed(retry) | installing | sheet submit with `.retryRecoveryAuthorization` |
+| failed / done / awaitingRecovery | inspecting | Start over (full reset identical to `inspectThisMac()` field resets at `:829-845`) |
+
+Mapping of every existing gate:
+- `isInspecting` → `.inspecting`. `installationBlocked` / `engineInspectionError` / `inspectionError` (`:82-84, :191-265`) → `.unsupported`/`.failed` payloads.
+- `isPreparingPlan` / `planPreparationError` → `.preparingPlan` / `.failed`.
+- `planReview` + `ownerAcknowledged` (`:273-279`) → `.planReview(_, acknowledged:)`; the Approve action still calls `InstallerPlanReview.approve(confirming:)` with a confirmation built **from the retained trust objects** exactly as `approve(_:)` does today (`:644-665`) — the display model is render-only and never the source of confirmation values.
+- `planApproval` + `preparedPlan` + `releaseConfiguration` non-nil → encoded structurally: `.awaitingInstall` is only constructible by the environment after a successful approve, so `canStartInstallation`'s nil-checks (`:433-443`) become unrepresentable states.
+- `helperServiceStatus` / `helperRegistrationError` (`:58-59, :418-431, :667-694`) → `HelperDisplay` inside `.awaitingInstall`; `refreshHelperStatus()` re-reads on `scenePhase == .active` as today (`:106-110`). The helper-registration confirmation dialog copy (`:111-124`) is preserved as a confirm step before `registerHelper()`.
+- `machineOwnerCredentialsReady` (`:445-450`) → `CredentialInput.validated()` which attempts the same `MachineOwnerAuthorization(username:password:)` initializer.
+- `isExecuting` / `hasExecutionStarted` (`:63-64`) → the phase machine (only `.awaitingInstall → .installing`, no re-entry); the daemon single-flight remains the backstop.
+- `recoveryAuthorizationRetryAvailable` + `showsRecoveryRetryConfirmation` (`:65,:68,:125-138,:452-462,:708-717`) → `.failed(FailureDisplay(retryRecoveryAvailable: true))`, set from `RecoveryAuthorizationRetryPolicy.isEligible(after:)` unchanged; the retry confirmation copy moves into the sheet's retry variant.
+- `showsExecutionConfirmation` (`:139-153`) → the credential sheet's explicit destructive "INSTALL" button is the confirmation click (Section 3); the semantic chain (checkbox → approve → separate explicit start confirmation → password) is preserved, with the confirmation and credential steps combined into the auth-dialog-style sheet per the decided direction.
+- `executionProgress` / `executionMessage` (`:51,:464-479,:774-779`) → `.awaitingRecovery` / `.done` via `InstallerNextAction` mapping; `.attachInstallationMedia` renders as an `awaitingRecovery` variant, `.manualRecovery` as `.failed`.
+- `selectedStepID` → derived read-only rail highlight (`InstallerRailStep`: INSPECT, REVIEW, AUTHORIZE, INSTALL, RECOVERY, DONE); the sidebar is no longer clickable navigation.
+
+Environment seam:
+
+```swift
+public protocol InstallerEnvironment: Sendable {
+  func inspect() async throws -&gt; HostDisplay
+  func preparePlan(progress: @escaping @Sendable (AssetProgressUpdate) -&gt; Void) async throws -&gt; PlanDisplay
+  func approve() throws                                   // review.approve(confirming:) on retained objects
+  func discardApproval()
+  var helperStatus: HelperDisplay { get }
+  func registerHelper() throws
+  func execute(
+    operation: InstallOperationKind,                       // .install | .retryRecoveryAuthorization
+    authorization: MachineOwnerAuthorization,
+    journal: @escaping @Sendable (Data) -&gt; Void
+  ) async throws -&gt; CompletionDisplay
+}
+```
+
+### Copy movement
+
+- Move to `PlainLanguage.swift`: `executionMessage(_:)` strings (`OmarchyAppleInstallerApp.swift:464-479`), all status-banner strings (`:221-247`), credential explainer (`:288-291`), confirmation-dialog bodies (`:120-152`), preflight row labels (`:176-183`), error strings from `prepareSignedPlan`/`performApprovedPlan`/`inspectThisMac` catch blocks.
+- New tables in `PlainLanguage.swift`: phase → short title ("Checking this Mac", "Making room on the disk", "Installing the starter boot system", "Waiting for Recovery", "Setting the boot policy", "Handing off installation media", "Installing Omarchy"); event/checkpoint names → one-liners; `EngineCompletionOutcome` → next-step instructions; `requiredHumanSteps` tokens (`enterOneTrueRecovery`, `authenticateMachineOwner`) → numbered plain-language Recovery steps for Screen E; error mapping `(headline, plainDetail, technicalDetail, remedy)` for `EngineXPCSubmissionError`, `ClosedEngineHelperError` domains, `InstallerPlanPreparationError`, `ArtifactStageError`, `InstallerReleaseConfigurationError.releaseResourcesUnavailable`, `InstallerAppError`. `technicalDetail` always preserves `String(describing: error)` for the Details disclosure.
+- `Sources/OmarchyAppleInstaller/InstallerWorkflow.swift` is **not touched** (public API pinned by `InstallerWorkflowTests`); the new UI reads `AppleSiliconHostInspection.eligibility` directly and stops consuming the step copy.
+
+### Trust-core files touched (complete list)
+
+1. `Sources/OmarchyAppleInstaller/EngineJournalProgress.swift` — NEW: callback protocol + sink protocol.
+2. `Sources/OmarchyAppleInstaller/EngineJournalTail.swift` — NEW: locator + tailer (no existing behavior modified).
+3. `Sources/OmarchyAppleInstaller/ClosedEngineHelperServer.swift` — additive optional `progress:` param on the actor's `submit`; endpoint captures client proxy; listener delegate sets `remoteObjectInterface`. `ClosedEngineXPCService` unchanged.
+4. `Sources/OmarchyAppleInstaller/AuthenticatedEngineXPCSubmitter.swift` — additive `journalProgress` init param + exported object; new `EngineXPCSubmissionError.machineOwnerCredentialsRejected` case; `EngineXPCErrorBridge` gains a dedicated domain `com.omarchy.mx.installer.machine-owner-authorization` mapped from `ClosedEngineHelperError.invalidMachineOwnerCredentials` (skew-safe: old apps map the unknown domain to the generic `helperRejected` as today).
+5. `Sources/OmarchyAppleInstaller/InstallerExecutionCoordinator.swift` — additive `journalProgress` param threaded to the submitter.
+6. `Sources/OmarchyAppleInstaller/VerifiedArtifactStager.swift` — download progress (Section 4).
+7. `Sources/OmarchyAppleInstaller/InstallerAssetPreparer.swift` — additive optional progress field on the request.
+8. `Sources/OmarchyAppleInstaller/InstallerReleaseAssetCoordinator.swift` — threads the same.
+9. `Package.swift` — new UXCore target + test target.
+
+**`PinnedAsahiEngineExecutor.swift`: zero changes.** The journal-path convention is duplicated in `EngineJournalLocator` and pinned by a unit test plus an end-to-end helper-server test using a stub executor writing to the real derived path, so drift is caught.
+
+---
+
+## 3. Credential sheet (Screen C)
+
+`Sources/OmarchyAppleInstallerApp/Screens/CredentialSheet.swift`, presented from `InstallerRootView` when phase is `.awaitingInstall(sheet: .presented(...))` or `.failed(retry)` with the sheet requested.
+
+Layout, patterned on the macOS authentication dialog in retro-terminal dress: `PixelMark` (64pt) over a box-drawing frame; title `"OMARCHY INSTALLER WANTS TO MAKE CHANGES."`; body: "Enter the machine owner's macOS user name and password to allow this. This authorizes only the exact approved plan." plus a muted `binding &lt;first-8&gt;…&lt;last-8&gt;` line; footer caption reuses the existing lifecycle copy verbatim ("Used only in memory to authorize Apple's Recovery boot-policy handoff. The password is not written to the plan, handoff package, journal, environment, or logs." — from `OmarchyAppleInstallerApp.swift:288-291`). Retry variant title "RETRY RECOVERY AUTHORIZATION" with the existing revalidation body from `:134-137`.
+
+Fields and validation (mirroring `MachineOwnerAuthorization.swift:27-49` via `CredentialInput` in UXCore):
+- `TextField("USER NAME")`, prefilled `NSUserName()`, `.autocorrectionDisabled()`, `.textContentType(.username)`. Live check: 1–255 UTF-8 bytes, charset `[A-Za-z0-9._-]`; violation shows a muted inline reason and disables INSTALL.
+- `SecureField("PASSWORD")`, `.textContentType(.password)`, `.privacySensitive()`. Check on edit/submit: 1–1024 UTF-8 bytes, no NUL/LF/CR (structural truth: `CredentialInput.validated()` attempts the real `MachineOwnerAuthorization` initializer; the UI never re-implements the rules as the source of truth).
+- Focus order: `@FocusState` — password first when username prefilled non-empty, else username; Tab cycles; Return in password submits when valid; Esc cancels (`.keyboardShortcut(.cancelAction)`); INSTALL is `.keyboardShortcut(.defaultAction)`, disabled until valid.
+- Buttons: `CANCEL` and `INSTALL` (primary accent; retry variant `AUTHORIZE`).
+
+Password lifecycle (identical to today's `:751-755`):
+- Password lives only in sheet-local `@State var password: String`.
+- On submit: build `MachineOwnerAuthorization(username:password: Data(password.utf8))`, set `password = ""` immediately, dismiss, call `session.submitInstall(authorization)`. The session and environment APIs accept only `MachineOwnerAuthorization` — no layer above the XPC boundary can retain the string.
+- Wipe on cancel and in `onDisappear` unconditionally; username persists across a rejection.
+
+Error presentation for OpenDirectory rejection: the helper validates credentials before import/execute (`ClosedEngineHelperServer.swift:60-64`), so rejection returns fast. Session flow: submit → phase `.installing` with stage label "VERIFYING MACHINE OWNER…" → on `EngineXPCSubmissionError.machineOwnerCredentialsRejected` (new bridged case) transition back to `.awaitingInstall` with `sheet: .presented(error: .credentialsRejected)`; the sheet reopens showing "The user name or password is not correct." with a brief retro bracket-flash on the fields and password cleared. Other submit errors route to `.failed` with the PlainLanguage mapping.
+
+---
+
+## 4. Download progress
+
+Minimal additive changes, all default-parameterized so existing call sites and the current test doubles keep compiling:
+
+`Sources/OmarchyAppleInstaller/VerifiedArtifactStager.swift`:
+
+```swift
+public func stage(
+  _ artifact: PinnedInstallerArtifact,
+  in stagingDirectory: URL,
+  progress: (@Sendable (_ bytesReceived: UInt64) -&gt; Void)? = nil
+) async throws -&gt; StagedInstallerArtifact
+
+protocol ArtifactDownloading: Sendable {
+  func download(from sourceURL: URL) async throws -&gt; URL                                  // existing, kept
+  func download(from sourceURL: URL, progress: (@Sendable (UInt64) -&gt; Void)?) async throws -&gt; URL
+}
+extension ArtifactDownloading {
+  // default forwards to the legacy requirement, ignoring progress — existing fakes unaffected
+}
+```
+
+`URLSessionArtifactDownloader` implements the progress variant with a delegate-based download task (`urlSession(_:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:)` reporting `totalBytesWritten`); the `progress == nil` path keeps using `URLSession.shared.download(from:)` byte-for-byte. Fractions come from the catalog-pinned `expectedSizeBytes`, not the HTTP header. The `reusedExistingFile` fast path reports one final `expectedSizeBytes` callback.
+
+`Sources/OmarchyAppleInstaller/InstallerAssetPreparer.swift`: `InstallerAssetPreparationRequest` gains `public let progress: InstallerAssetProgress?` (default nil in the init) where
+
+```swift
+public struct InstallerAssetProgress: Sendable {
+  public let didUpdate: @Sendable (_ role: String, _ bytesReceived: UInt64, _ expectedBytes: UInt64) -&gt; Void
+}
+```
+
+The three concurrent `async let stager.stage(...)` calls pass role-tagged closures (`artifact.role`). `InstallerReleasePreparationRequest` (`InstallerReleaseAssetCoordinator.swift`) gains the same optional field and threads it.
+
+UI (PreparingScreen): per-artifact rows (engine ~tens of MB, metadata, payload multi-GB — the dominant bar) as retro block-glyph bars with `bytes / expected`, aggregate line on top; catalog fetch and engine inspect/plan rows are indeterminate ("VERIFYING…" sweep). Post-download SHA-256 verification renders as indeterminate "VERIFYING" per row (extending progress into `verify()` hashing is noted as an optional follow-up, not in scope).
+
+---
+
+## 5. Debug-only mock / preview mode (M4 demo)
+
+- `Sources/OmarchyAppleInstallerApp/PreviewInstallerEnvironment.swift`, the entire file wrapped in `#if DEBUG … #endif`. Selection at startup: `InstallerEnvironmentFactory.make()` returns the live environment unless (`#if DEBUG` only) `ProcessInfo.processInfo.environment["OMARCHY_INSTALLER_UI_PREVIEW"]` is set. In release the env check does not compile; the factory unconditionally returns live.
+- The preview environment reads the fixture path from `OMARCHY_INSTALLER_UI_PREVIEW_JOURNAL` (no fixture is bundled into app resources — nothing ships), decodes it with the real `AppleInstallerTrustCore().validateEngineTranscript(_:)`, and derives `HostDisplay`/`PlanDisplay` from the fixture's inspection/inventory/plan lines. `execute` drips the fixture's raw lines through the same `journal:` callback on a timer (800 ms/line), exercising `LiveInstallJournalModel` and Screen D exactly as production does, then returns the `awaiting_recovery` completion. Trust types with non-public initializers (`InstallerPlanReview`, `CandidateBoundPlanApproval`) are never fabricated — the display-model seam makes that unnecessary, which keeps fail-closed properties intact.
+- Scenarios via the env var's value: `fresh-install` (A→B→C→D→E replay), `unsupported` (locked screen — also the real M4 behavior with no env), `credential-reject` (first submit returns `.machineOwnerCredentialsRejected`), `recovery-retry` (throws a retry-eligible error after the stub-and-esp checkpoint), `degraded-journal` (injects one corrupt line to demo indeterminate fallback).
+- Demo procedure (M4, zero privileged actions, single instance — the `InstallerAppInstanceLease` enforces it; never `open -n`, ensure no packaged app instance is running first):
+
+```
+cd /Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer
+OMARCHY_INSTALLER_UI_PREVIEW=fresh-install \
+OMARCHY_INSTALLER_UI_PREVIEW_JOURNAL=/Users/maralc/dev/omarchy/omarchy-mx-mac-integration/evidence/apple-silicon/2026-08-29-m1-fresh-install-v6/execution-journal.jsonl \
+swift run OmarchyAppleInstallerApp
+```
+
+- Release compile-out verification: `swift build -c release` then launch the release binary with the env vars set → behaves as production (locked on M4); plus the config-dependent unit test in Section 6.
+
+---
+
+## 6. Test plan
+
+New tests (Swift Testing or XCTest to match neighboring files):
+
+In `Tests/OmarchyAppleInstallerTrustCoreTests/`:
+1. `EngineJournalTailTests.swift` — locator derives `&lt;dir&gt;/execution-journals/&lt;hex&gt;.jsonl` for a known `sha256:` digest and rejects malformed digests (pins the executor convention); tailer forwards only complete lines, buffers partial trailing lines, tolerates a not-yet-created file, respects owner/mode guards, drains on stop, caps chunk size.
+2. `ClosedEngineHelperServerProgressTests.swift` — `server.submit(..., progress: recordingSink)` with a stub executor that appends journal lines mid-execute at the locator-derived path → sink receives ordered lines then the reply validates; `progress: nil` path produces byte-identical behavior to today (existing `ClosedEngineHelperServerTests` untouched and still green).
+3. `EngineXPCErrorBridgeTests.swift` — `invalidMachineOwnerCredentials` round-trips to `.machineOwnerCredentialsRejected`; unknown domains still map to `helperRejected`.
+4. `VerifiedArtifactStagerTests.swift` (extend) — progress callback receives monotonic byte counts from a fake downloader; nil-progress path unchanged.
+
+In `Tests/OmarchyInstallerUXCoreTests/`:
+5. `LiveInstallJournalModelTests.swift` — feed the evidence fixture line-by-line (test resource or path-relative read) → assert phase progression preflight→apfs_preparation→stub_and_esp→awaiting_recovery, checkpoint set, final outcome; corrupt line → `degraded == true`, no throw; sequence-restart chunk replaces buffer.
+6. `InstallerSessionTests.swift` — scripted mock environment replays the fixture → phase transition sequence matches the table in Section 2; illegal transitions no-op; Back from `awaitingInstall` calls `discardApproval`; credential-reject loops back to the sheet state; retry path only reachable with `retryRecoveryAvailable`.
+7. `PlainLanguageTests.swift` — every phase/checkpoint/outcome/known error yields non-empty, distinct headline strings and preserves `technicalDetail`.
+8. `CredentialInputTests.swift` — property-style matrix: `CredentialInput.validated() != nil` ⇔ `MachineOwnerAuthorization(username:password:)` succeeds (charset, 255/256 boundary, 0/1/1024/1025 bytes, LF/CR/NUL, non-UTF-8 rejected upstream).
+9. `InstallerEnvironmentFactoryTests.swift` (app behavior via UXCore-visible factory input) — with the preview env var set, `#if DEBUG` asserts the preview environment is chosen, `#else` asserts live is chosen (compiles and passes in both configurations, proving compile-out).
+
+Keeping the existing suite green: every trust-core change is additive with defaulted parameters; no existing public signature changes except the new `EngineXPCSubmissionError` case (fix any newly non-exhaustive `switch` in `AuthenticatedEngineXPCSubmitterTests` — mechanical). `InstallerWorkflow`, `PinnedAsahiEngineExecutor`, `EngineContract`, importer, and all digest/approval logic untouched.
+
+Commands (run from the package root):
+- Format: `xcrun swift-format format --in-place --recursive Sources Tests Package.swift`
+- Lint (strict): `xcrun swift-format lint --strict --recursive Sources Tests Package.swift`
+- Tests: `swift test --jobs 10` and `swift test -c release --jobs 10` (both required; `OMARCHY_BUILD_JOBS` default 10 per `AGENTS.md`)
+- No commits/pushes; no helper registration or privileged runs on this machine (owner-gated).
+
+---
+
+## 7. Risk register (top 5)
+
+1. **Qualified-binary invalidation** (any trust-core/helper byte change makes the build an unqualified candidate needing owner re-qualification on the M1). Mitigation: confine binary-affecting changes to the nine files listed in Section 2 with additive, default-parameterized diffs; keep `PinnedAsahiEngineExecutor` byte-identical; stage the work so the entire trust-core diff lands as one small reviewable package (WP7–WP9) with debug+release suites green, and plan exactly one authoritative re-qualification at the end, not per iteration.
+2. **XPC protocol skew app↔helper** (a previously registered helper daemon keeps running an older binary while a new app connects, or vice versa during development). Mitigation: `ClosedEngineXPCService.submit` is unchanged; progress is a separate, opportunistic exported interface; helper uses `remoteObjectProxyWithErrorHandler` and silently drops streaming; app degrades to indeterminate after a ~3 s no-chunk window; the new credential-error domain degrades to today's generic message on old apps.
+3. **Journal tail races / partial lines / replays** (reading while root's engine appends; file created late; re-replay after reconnect duplicating state). Mitigation: forward only `\n`-terminated whole lines from a tracked offset; full replay-from-zero on attach with app-side buffer replacement keyed on a `sequence:1` restart; all validation failures degrade the *display* only (indeterminate), never the run; the authoritative post-run transcript validation path is untouched.
+4. **Mock leaking into release** (preview scenarios or fixture handling reachable in a shipped build). Mitigation: entire preview environment file inside `#if DEBUG`; env-var read itself compiled out; nothing added to app resources; factory unit test asserts opposite behavior per configuration; release build + release test run in the WP11 checklist.
+5. **Password-lifecycle regression in the new sheet** (SwiftUI state copies or session retaining credentials). Mitigation: password exists only as sheet-local `@State`, cleared on submit/cancel/disappear exactly mirroring `machineOwnerPassword = ""` at `OmarchyAppleInstallerApp.swift:755/842`; all session/environment APIs accept only `MachineOwnerAuthorization`; XPC raw-`Data` → stdin-pipe path unchanged; review checklist item forbids logging/printing display or context objects that could embed authorization, and `InstallerSessionTests` assert no credential storage on the session.
+
+---
+
+## 8. Sequencing (work packages, ~1–3 h each)
+
+- **WP0 — Mockup approval checkpoint (gate).** Build phase starts only after the retro-terminal mockup for screens A–F is approved (mockup production itself out of scope here). Everything below assumes the approved layouts.
+- **WP1 (2–3 h)** Package.swift: add `OmarchyInstallerUXCore` + test target. Skeleton: `InstallerSessionPhase`, display models, `InstallerEnvironment`, `CredentialInput`. Tests: transition table, credential matrix (tests 6 partial, 8).
+- **WP2 (2–3 h)** `InstallerTheme.swift` + `RetroComponents.swift` ported from the prototype (`omarchy-mx-mac/.../InstallerView.swift` backdrop/rail/buttons/panels), app shell `InstallerRootView` with rail + phase switch stubs.
+- **WP3 (1–2 h)** `PlainLanguage.swift`: move existing copy, add phase/event/checkpoint/outcome/error tables. Test 7.
+- **WP4 (2 h)** `LiveInstallJournalModel` + fixture replay tests (test 5).
+- **WP5 (3 h)** Screens A, Preparing, B, Unsupported wired to the session; `PreviewInstallerEnvironment` (`fresh-install`, `unsupported` scenarios); first M4 demo of A→B.
+- **WP6 (2 h)** `CredentialSheet` (both variants), sheet state in `.awaitingInstall`/`.failed(retry)`, `credential-reject` scenario. Focus/wipe behavior verified in demo.
+- **WP7 (2–3 h)** Trust core part 1: `EngineJournalProgress.swift`, `EngineJournalTail.swift`, tests 1.
+- **WP8 (2–3 h)** Trust core part 2: helper server `progress:` param + endpoint proxy capture + listener interface; submitter `journalProgress` + exported object; `machineOwnerCredentialsRejected` bridge; coordinator threading. Tests 2, 3; fix any newly non-exhaustive switches.
+- **WP9 (2 h)** Trust core part 3: download progress through stager/preparer/coordinator (test 4); PreparingScreen bound to real byte updates.
+- **WP10 (2–3 h)** `LiveInstallerEnvironment` (move workspace/coordinator logic out of the old view), Screens D/E/F + Failure with live journal binding, retry flow end-to-end against the mock (`recovery-retry`, `degraded-journal` scenarios).
+- **WP11 (2 h)** Delete the old view body and `InstallerChrome.swift`; full `xcrun swift-format` format + strict lint; `swift test --jobs 10` and `swift test -c release --jobs 10`; release-binary env-var check; scripted M4 demo walkthrough of all scenarios; produce the reviewable trust-core diff summary for the owner's re-qualification decision.
+
+Total ≈ 22–28 h across 11 packages, with the trust-core diff isolated to WP7–WP9.
+
+---
+
+### Critical Files for Implementation
+
+- /Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer/Sources/OmarchyAppleInstaller/ClosedEngineHelperServer.swift
+- /Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer/Sources/OmarchyAppleInstaller/AuthenticatedEngineXPCSubmitter.swift
+- /Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer/Sources/OmarchyAppleInstallerApp/OmarchyAppleInstallerApp.swift
+- /Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer/Sources/OmarchyAppleInstaller/PinnedAsahiEngineExecutor.swift (read-only reference: journal path convention and fail-closed file validation to mirror in the tailer)
+- /Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer/Package.swift

--- a/apps/omarchy-apple-installer/Packaging/pkg/build-pkg.sh
+++ b/apps/omarchy-apple-installer/Packaging/pkg/build-pkg.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Build a signed + notarized macOS installer package for the Omarchy Apple
+# Silicon installer. The package installs the notarized app to /Applications and
+# a system LaunchDaemon to /Library/LaunchDaemons, then loads the daemon in its
+# postinstall — so the recipient enters one admin password (the macOS installer
+# prompt) and never touches Login Items.
+#
+# Usage: build-pkg.sh --app <signed .app> --plist <helper-launchdaemon.plist> \
+#          --version <x.y.z> --out <output.pkg>
+set -euo pipefail
+
+APP="" PLIST="" VERSION="" OUT=""
+INSTALLER_ID="Developer ID Installer: MARCELO DE BARROS ALCANTARA (T2C384FJBD)"
+PKG_IDENTIFIER="com.omarchy.mx.installer.pkg"
+SCRIPTS="$(cd "$(dirname "$0")" && pwd)/scripts"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) APP="$2"; shift 2 ;;
+    --plist) PLIST="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --installer-identity) INSTALLER_ID="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 64 ;;
+  esac
+done
+[[ -d "$APP" && -f "$PLIST" && -n "$VERSION" && -n "$OUT" ]] || {
+  echo "usage: build-pkg.sh --app <app> --plist <plist> --version <v> --out <pkg>" >&2
+  exit 64
+}
+
+work="$(mktemp -d /tmp/omarchy-pkg.XXXXXX)"
+trap 'rm -rf "$work"' EXIT
+root="$work/root"
+mkdir -p "$root/Applications" "$root/Library/LaunchDaemons"
+
+# Payload: the notarized app and the system daemon plist.
+/usr/bin/ditto "$APP" "$root/Applications/$(basename "$APP")"
+/usr/bin/install -m 0644 "$PLIST" "$root/Library/LaunchDaemons/com.omarchy.mx.installer.helper.plist"
+
+# Confirm the plist's Program points at where the app actually lands.
+prog="$(/usr/bin/plutil -extract Program raw -o - "$PLIST" 2>/dev/null || true)"
+echo "daemon Program: $prog"
+
+# Pin the app to /Applications. Without this, PackageKit "relocates" the
+# install onto any existing copy of the bundle it can find anywhere on disk
+# (it did exactly that onto a stale test copy in /Users/Shared), leaving
+# /Applications empty and the daemon pointing at nothing.
+component_plist="$work/component.plist"
+/usr/bin/pkgbuild --analyze --root "$root" "$component_plist"
+/usr/bin/plutil -replace 0.BundleIsRelocatable -bool false "$component_plist"
+
+echo "=== pkgbuild (component) ==="
+comp="$work/component.pkg"
+/usr/bin/pkgbuild \
+  --root "$root" \
+  --component-plist "$component_plist" \
+  --scripts "$SCRIPTS" \
+  --identifier "$PKG_IDENTIFIER" \
+  --version "$VERSION" \
+  --install-location / \
+  --ownership recommended \
+  "$comp"
+
+echo "=== productbuild (signed distribution) ==="
+/usr/bin/productbuild \
+  --package "$comp" \
+  --identifier "$PKG_IDENTIFIER" \
+  --version "$VERSION" \
+  --sign "$INSTALLER_ID" \
+  "$OUT"
+
+echo "=== verify signature ==="
+/usr/sbin/pkgutil --check-signature "$OUT" | head -6
+
+echo "PKG_BUILT: $OUT"
+echo "sha256: $(/usr/bin/shasum -a 256 "$OUT" | awk '{print $1}')"

--- a/apps/omarchy-apple-installer/Packaging/pkg/scripts/postinstall
+++ b/apps/omarchy-apple-installer/Packaging/pkg/scripts/postinstall
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Runs as root during package install. Loads the pre-installed privileged helper
+# as a system LaunchDaemon so the app can reach it immediately — no Login Items,
+# no reboot, no per-user approval.
+set -u
+PLIST=/Library/LaunchDaemons/com.omarchy.mx.installer.helper.plist
+LABEL=com.omarchy.mx.installer.helper
+
+if [[ -f "$PLIST" ]]; then
+  /usr/sbin/chown root:wheel "$PLIST"
+  /bin/chmod 0644 "$PLIST"
+  # Replace any stale registration, then load fresh.
+  /bin/launchctl bootout system/"$LABEL" 2>/dev/null || true
+  /bin/launchctl bootstrap system "$PLIST" 2>/dev/null || \
+    /bin/launchctl load -w "$PLIST" 2>/dev/null || true
+fi
+
+APP="/Applications/Omarchy MX Mac Installer.app"
+
+# Pre-run Gatekeeper's one-time inspection of the new app now, while the
+# installer's own progress UI is still on screen. Without this, the first
+# open sits invisibly for a minute or more while macOS scans the app.
+if [[ -d "$APP" && -x /usr/bin/gktool ]]; then
+  /usr/bin/gktool scan "$APP" 2>/dev/null || true
+fi
+
+# Open the installer app for whoever is at the screen, so finishing the
+# package flows straight into the app. Root context: resolve the console
+# user; skip silently for headless installs, and never fail the package.
+console_user="$(/usr/bin/stat -f %Su /dev/console 2>/dev/null || true)"
+if [[ -d "$APP" && -n "$console_user" && "$console_user" != "root" ]]; then
+  console_uid="$(/usr/bin/id -u "$console_user" 2>/dev/null || true)"
+  if [[ -n "$console_uid" ]]; then
+    /bin/launchctl asuser "$console_uid" \
+      /usr/bin/sudo -u "$console_user" /usr/bin/open "$APP" 2>/dev/null || true
+  fi
+fi
+exit 0

--- a/apps/omarchy-apple-installer/docs/docker-hygiene.md
+++ b/apps/omarchy-apple-installer/docs/docker-hygiene.md
@@ -1,0 +1,77 @@
+# Docker Desktop pins deleted files — restart it between build marathons
+
+## The problem
+
+Docker Desktop runs a Linux VM that reaches into the Mac's filesystem through
+virtiofs. When a build inside the VM opens host files, the VM holds file
+handles open. Those handles survive the container that made them.
+
+If the host then deletes those files, the disk space is **not** returned. The
+files are unlinked from the directory tree but still held open by
+`com.docker.virtualization`, so macOS keeps the blocks allocated. `du` and
+Finder both report the space as free. It is not.
+
+Observed on 2026-08-31: roughly **12,000 open handles holding about 330 GB**
+after a run of OS payload builds and a reviewed cleanup. The cleanup looked
+like it worked; the disk did not grow back.
+
+## How to detect it
+
+```bash
+lsof +L1 2>/dev/null | grep -i -E 'docker|virtualization'
+```
+
+`+L1` lists open files whose link count is below 1 — that is, files already
+deleted but still open. Any lines belonging to Docker are space that a restart
+will return.
+
+Note that `lsof` truncates the COMMAND column to nine characters, so
+`com.docker.virtualization` appears as `com.docke` — match on the whole line,
+not on the process name alone.
+
+To see how much (column 7 is SIZE/OFF once `+L1` inserts the NLINK column):
+
+```bash
+lsof +L1 2>/dev/null |
+  awk 'tolower($0) ~ /docker|virtualization/ && $7 ~ /^[0-9]+$/ {
+         bytes += $7; n += 1
+       }
+       END { printf "%d handles, %.1f GB pinned\n", n, bytes / 1073741824 }'
+```
+
+Add `sudo` if Docker Desktop is running under a different account than the one
+you are logged in as; without it `lsof` only reports your own processes.
+
+Cross-check against what the volume claims:
+
+```bash
+df -h /System/Volumes/Data
+```
+
+A large gap between "free space" here and what you expected after a cleanup is
+the same symptom seen from the other side.
+
+## The fix
+
+Quit and reopen Docker Desktop. The VM shuts down, every handle is released,
+and the space comes back immediately. Nothing else is needed — no reboot, no
+`docker system prune`, no unmounting.
+
+```bash
+osascript -e 'quit app "Docker"'
+sleep 20
+open -a Docker
+```
+
+`docker system prune` does **not** fix this. It reclaims Docker's own images
+and layers inside the VM; this is host-side space held by the VM process.
+
+## When to do it
+
+- After any run of image or payload builds.
+- After deleting build artifacts or running a store cleanup, and **before**
+  measuring how much space you got back — otherwise the measurement is wrong.
+- Before starting a long build, so it begins with the full disk available.
+
+Treat "restart Docker Desktop" as a normal step between build marathons, not
+as troubleshooting.

--- a/apps/omarchy-apple-installer/docs/e2e-runbook.md
+++ b/apps/omarchy-apple-installer/docs/e2e-runbook.md
@@ -1,0 +1,334 @@
+# Omarchy v8 — full end-to-end test runbook
+
+This is the whole test, start to finish, in order. It proves that a person who
+was handed nothing but a GitHub link can install Omarchy on an M1 Pro, that the
+hardware works without hand-holding, that macOS is untouched, and that Omarchy
+boots twice.
+
+Two people are involved:
+
+- **You (owner)** — at the M1. Steps marked **OWNER** need your hands: your
+  password, a click, or a Recovery-mode restart. Nobody else can do them.
+- **Me (agent)** — on the M4, over the Thunderbolt cable. Everything else.
+
+Anything can be stopped at any point. Nothing writes to the M1 until step 5.
+
+---
+
+## Before you start
+
+- The M1 is awake, logged in, plugged into power, and connected to the M4 by
+  the Thunderbolt cable.
+- The release is already published on GitHub with the app zip attached.
+- Write the tag down here before you begin, and use the same one everywhere:
+
+  ```
+  TAG=<the published tag, e.g. v0.8.0-m1>
+  RELEASE=https://github.com/maralcbr/omarchy-mx-mac/releases/tag/$TAG
+  ```
+
+- Expect about 2 hours end to end, most of it waiting on a download and two
+  reboots.
+
+---
+
+## Step 1 — Pre-clean the M1
+
+Removes the old Omarchy install and every trace of the old app, so the test
+starts from a genuinely clean machine. macOS, Recovery, and your files are
+never touched.
+
+**First, look at the plan without changing anything:**
+
+```bash
+/Users/maralc/dev/omarchy/iteration2/preclean-m1.sh
+```
+
+Read what it prints. It shows the live partition table, which partitions it has
+decided are protected (macOS, Recovery, the Apple ISC partition), and exactly
+which partitions it would erase. If anything is ambiguous it stops on its own
+and erases nothing.
+
+**Check three things before going further:**
+
+1. The protected list contains the big macOS partition and the Recovery
+   partition.
+2. The deletion list contains only Omarchy things: the Omarchy APFS stub, the
+   ESP named `EFI - OMARC`, and the two Linux partitions.
+3. The sizes look right — macOS should still be roughly 857 GB.
+
+**OWNER: say go.** Then:
+
+```bash
+/Users/maralc/dev/omarchy/iteration2/preclean-m1.sh --confirm
+```
+
+It deletes the Omarchy APFS container, frees each Omarchy partition by its
+UUID (not by name — names shift as space is released), clears the installer's
+staging and state folder, and removes old copies of the app from
+`/Applications` and `~/Downloads`. It prints what it did.
+
+**Write down the protected partition UUIDs it printed.** Step 10 compares
+against them.
+
+---
+
+## Step 2 — OWNER: download the app from GitHub, on the M1
+
+This is the whole point of the test: the M1 gets the app the same way a
+stranger would.
+
+On the M1, in Safari, open `$RELEASE`, and download the app zip from the
+Assets list into `~/Downloads`. Do not copy anything over the cable.
+
+Double-click the zip to unpack it. You should get
+`Omarchy MX Mac Installer.app`.
+
+---
+
+## Step 3 — OWNER: open the app
+
+Double-click the app.
+
+**What should happen:** it opens. No "unidentified developer" warning, no
+right-click-Open trick, no trip to System Settings. The app is notarized, so
+macOS checks it silently and lets it run.
+
+**If macOS blocks it, stop.** That is a real failure of this release, not
+something to work around. Tell me what the dialog said.
+
+---
+
+## Step 4 — Walk the six screens
+
+The redesigned app is six screens, one decision each. Move through them and
+check what each one shows.
+
+1. **Check** — the app confirms this Mac is a supported M1 Pro
+   (`apple,j314s`) and that the engine it carries is valid. Expect
+   "Verified - supported".
+2. **Plan** — the app downloads what it needs from the release and shows real
+   progress. The OS payload arrives as two or more parts. Watch that the
+   progress bar actually moves and that each part ends up marked verified. This
+   is the slowest screen: roughly 3.6 GB.
+3. **Authorize** — **OWNER: type your password.** The app says it is used once
+   and kept only in memory. This is the point of no return, and it appears
+   after the plan is on screen, not before.
+4. **Install** — checkpoints tick over and the journal feed scrolls. Roughly
+   15-25 minutes. Nothing to do but watch.
+5. **Recovery** — the app tells you to finish in Recovery mode. See step 5.
+6. **Boot** — after Recovery, this screen confirms the system is bootable.
+
+**Before you type your password on screen 3, check the plan on screen 2 says
+what you expect:** it should be installing into free space, not shrinking
+macOS. If it proposes resizing the macOS partition, stop and tell me.
+
+---
+
+## Step 5 — OWNER: the Recovery step (1TR)
+
+The app cannot do this part; Apple requires a human in Recovery mode.
+
+1. Shut the M1 down completely.
+2. Hold the power button until "Loading startup options" appears. Keep holding
+   until it says that — a normal restart will not work.
+3. Choose Options, then log in when asked.
+4. Follow the on-screen instructions the app gave you to finish installation
+   and set the boot policy.
+5. Let it restart.
+
+---
+
+## Step 6 — OWNER: first Omarchy boot
+
+The M1 should come up in Omarchy and reach a usable desktop. Complete any
+first-run setup it asks for.
+
+**Then tell me the machine's IP address on your network.** On the Omarchy
+desktop, open a terminal and run:
+
+```bash
+ip -4 addr show scope global | grep inet
+hostname
+```
+
+Read me the address. Everything in steps 7-9 runs over SSH to that address.
+(The Thunderbolt bridge alias `omarchy-m1-thunderbolt` reaches the *macOS*
+side only; the Linux side has no pinned alias, which is why WiFi has to work
+before I can check anything.)
+
+---
+
+## Step 7 — Verify the hardware
+
+Each block below is one thing that was broken or manual in v7. Run them over
+SSH to the Omarchy machine.
+
+### WiFi — must be up with no manual command
+
+The v7 failure: WiFi firmware was not copied to the installed system, so WiFi
+only worked after somebody ran a command by hand. If the previous step gave me
+an IP address over WiFi at all, this is already most of the proof.
+
+```bash
+ls /lib/firmware/brcm | wc -l
+ls /lib/firmware/brcm | head -20
+systemctl status omarchy-vendor-firmware.service --no-pager
+nmcli device status
+nmcli -f ACTIVE,SSID,SIGNAL device wifi list | head -5
+```
+
+**Pass:** the `brcm` directory has files in it (not zero), the vendor-firmware
+service shows as having run successfully, and `nmcli device status` shows the
+wifi device `connected`.
+
+### Audio — must use the Asahi DSP profile, not the raw hardware
+
+The v7 failure: the Apple ALSA profiles package was missing, so PipeWire fell
+back to raw `hw:0` and the speakers were unusable and unsafe.
+
+```bash
+pacman -Q alsa-ucm-conf-asahi
+systemctl is-active speakersafetyd
+systemctl status speakersafetyd --no-pager | head -12
+wpctl status
+```
+
+**Pass:** `wpctl status` lists a real sink with an Asahi/Apple profile name
+under Sinks — **not** a bare `alsa_output...hw:0` fallback. `speakersafetyd`
+is `active`. The package query returns a version, not "was not found".
+
+Then a quiet, short speaker test. **Keep the volume low.**
+
+```bash
+wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.25
+speaker-test -c 2 -t sine -f 440 -l 1
+```
+
+**OWNER: listen.** You should hear a short tone from both speakers, clean, at
+a modest level. Stop it with Ctrl-C if it keeps going.
+
+### Bluetooth
+
+```bash
+systemctl is-active bluetooth
+bluetoothctl show
+rfkill list bluetooth
+```
+
+**Pass:** `active`, `bluetoothctl show` prints a controller with `Powered:
+yes`, and rfkill shows it is not blocked.
+
+### Boot-selection tools
+
+These let you switch back to macOS from inside Omarchy without Recovery mode.
+
+```bash
+pacman -Q asahi-bless startup-disk
+which asahi-bless startup-disk
+```
+
+**Pass:** both return a version and a path.
+
+### Capture the evidence
+
+```bash
+{
+  echo "Observed: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Host: $(hostname)  Kernel: $(uname -r)"
+  echo
+  echo "## firmware"; ls /lib/firmware/brcm | wc -l
+  echo "## network"; nmcli device status
+  echo "## audio"; wpctl status
+  echo "## speakersafetyd"; systemctl is-active speakersafetyd
+  echo "## bluetooth"; systemctl is-active bluetooth; bluetoothctl show
+  echo "## boot tools"; pacman -Q asahi-bless startup-disk alsa-ucm-conf-asahi
+  echo "## packages"; pacman -Q | wc -l
+  echo "## mounts"; findmnt -no SOURCE,TARGET,FSTYPE /
+} > /tmp/omarchy-v8-hardware.txt
+cat /tmp/omarchy-v8-hardware.txt
+```
+
+I copy that file back and store it beside the v6/v7 evidence, in the same
+style: a short README naming the device, engine digest, plan digest, payload
+digest and result, plus the raw capture.
+
+---
+
+## Step 8 — OWNER: reboot into macOS
+
+Restart and hold the power button again to pick macOS (or use `asahi-bless` /
+`startup-disk` from Omarchy if you want to prove those work too).
+
+macOS must come up normally, with your files and settings exactly as before.
+
+---
+
+## Step 9 — Check macOS is unchanged
+
+Over the Thunderbolt cable again:
+
+```bash
+ssh omarchy-m1-thunderbolt '/usr/sbin/diskutil list /dev/disk0'
+ssh omarchy-m1-thunderbolt '/usr/sbin/diskutil apfs list'
+ssh omarchy-m1-thunderbolt 'sudo /usr/sbin/bputil -d' 2>/dev/null || true
+```
+
+**Pass:** the macOS partition UUID and the Recovery partition UUID are exactly
+the ones the pre-clean printed in step 1. The macOS partition is still its full
+size — it must never have been shrunk. New Omarchy partitions are present with
+new UUIDs.
+
+---
+
+## Step 10 — OWNER: boot Omarchy a second time
+
+This is the step the old evidence never captured. A first boot can succeed on
+leftover state; a second boot proves the installed system is genuinely
+self-sufficient.
+
+Restart into Omarchy again. It must reach the desktop, and WiFi must come up on
+its own with no commands typed.
+
+Re-run the short version of step 7 to confirm nothing regressed:
+
+```bash
+nmcli device status
+wpctl status | head -20
+systemctl is-active bluetooth speakersafetyd
+```
+
+---
+
+## Step 11 — Wrap up
+
+I do this part:
+
+- Store the evidence in the v6/v7 style under
+  `evidence/apple-silicon/<date>-m1-fresh-install-v8/`.
+- Record the result in the plan document's Adjudication log.
+- Update session memory.
+
+**OWNER, last thing:** the M1's SSH and firewall were opened up for this
+session. Close them again when we are done:
+
+```
+System Settings → General → Sharing → Remote Login → off
+System Settings → Network → Firewall → on
+```
+
+---
+
+## Stop rules
+
+Any one of these ends the session. Do not work around them.
+
+- The pre-clean cannot tell the partitions apart, or the protected list looks
+  wrong.
+- macOS warns about the app in step 3 (a notarization failure is a real bug).
+- The plan on screen 2 proposes shrinking macOS.
+- Any download part fails verification.
+- The install reports a mismatch between what it wrote and what it read back.
+- macOS does not boot, or its partition UUIDs changed.
+- WiFi needs a manual command — that is the v7 bug, unfixed.
+- Audio still shows a raw `hw:0` sink — that is the other v7 bug, unfixed.

--- a/apps/omarchy-apple-installer/scripts/assemble-candidate-v8.sh
+++ b/apps/omarchy-apple-installer/scripts/assemble-candidate-v8.sh
@@ -1,0 +1,648 @@
+#!/bin/bash
+
+# Assemble an Omarchy Apple Silicon candidate directory (v8 generation) from a
+# freshly built OS payload, mirroring the proven v7 candidate layout.
+#
+# This script only *assembles and verifies*. It never generates a catalog,
+# mints a key, signs, builds, notarizes, or publishes. Those steps are printed
+# as exact commands at the end.
+
+set -uo pipefail
+
+readonly DEFAULT_REPO_ROOT="/Users/maralc/dev/omarchy/omarchy-mx-mac-integration"
+readonly DEFAULT_REFERENCE_CANDIDATE="/private/tmp/omarchy-mx-mac-candidate-v7.bXXpzZ"
+readonly APP_PACKAGE_RELATIVE="apps/omarchy-apple-installer"
+readonly REFERENCE_SIGNING_TOOL_DIGEST="af52a6f38d110ef2684a0114abe13928b7e9414857a25b07ce16d4807b825f96"
+readonly DEFAULT_APP_VERSION="0.8.0"
+readonly DEFAULT_BUILD_NUMBER="9"
+readonly DEFAULT_TAG="v0.8.0-m1"
+readonly DEFAULT_RELEASE_REPO="maralcbr/omarchy-mx-mac"
+readonly DEFAULT_TEAM_ID="T2C384FJBD"
+
+clone_copies=0
+plain_copies=0
+warnings=0
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  assemble-candidate-v8.sh --payload FILE --out DIR [options]
+
+Required:
+  --payload FILE        the sealed OS payload zip. Both sidecars must sit
+                        beside it:
+                          FILE.installer-data.json
+                          FILE.asahi-package-evidence.json
+
+  --out DIR             candidate directory to create. Must not exist.
+
+Options:
+  --repo-root DIR       integration repo (default: the known checkout)
+  --reference DIR       reference candidate supplying catalog-signing.swift
+                        and the previous release descriptor (default: v7)
+  --tag TAG             release tag used in the printed next steps
+  --release-repo O/R    GitHub repo used in the printed next steps
+  --app-version X.Y.Z   app marketing version for the printed build command
+  --build-number N      app build number for the printed build command
+  --team-id ID          signing team identifier for the printed build command
+  --allow-metadata-drift
+                        continue when the payload's installer-data sidecar is
+                        not byte-identical to the app package's
+                        Engine/installer_data.json (default: hard error)
+  -h, --help            this text
+USAGE
+  exit 64
+}
+
+die() {
+  echo "assemble-candidate-v8: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "assemble-candidate-v8: WARNING: $*" >&2
+  warnings=$((warnings + 1))
+}
+
+step() {
+  echo
+  echo "== $* =="
+}
+
+require_regular_file() {
+  [[ -f $1 && ! -L $1 ]] || die "missing or unsafe file: $1"
+}
+
+require_real_directory() {
+  [[ -d $1 && ! -L $1 ]] || die "missing or unsafe directory: $1"
+}
+
+file_digest() {
+  shasum -a 256 "$1" | cut -d ' ' -f 1
+}
+
+file_size() {
+  wc -c <"$1" | tr -d ' '
+}
+
+# Copy one file, verifying its digest before and after. Prefers an APFS clone
+# (cp -c) and falls back to a plain copy on filesystems that cannot clone.
+verified_copy() {
+  local source=$1 destination=$2 label=$3
+  local before after before_size after_size mode
+
+  require_regular_file "$source"
+  [[ ! -e $destination ]] || die "refusing to overwrite $destination"
+
+  before=$(file_digest "$source") || die "cannot digest $source"
+  before_size=$(file_size "$source")
+
+  if cp -c "$source" "$destination" 2>/dev/null; then
+    mode="clone"
+    clone_copies=$((clone_copies + 1))
+  elif cp "$source" "$destination"; then
+    mode="copy"
+    plain_copies=$((plain_copies + 1))
+  else
+    die "copy failed: $source -> $destination"
+  fi
+
+  after=$(file_digest "$destination") || die "cannot digest $destination"
+  after_size=$(file_size "$destination")
+
+  [[ $before == "$after" ]] ||
+    die "digest changed across copy of $label: $before -> $after"
+  (( before_size == after_size )) ||
+    die "size changed across copy of $label: $before_size -> $after_size"
+
+  printf '  %-6s %s\n' "$mode" "$(basename "$destination")"
+  printf '         sha256 %s  %s bytes\n' "$after" "$after_size"
+}
+
+# Pull a shell assignment out of build-app.sh so the engine identity is read
+# from the app package's own pin rather than restated here.
+read_pinned_value() {
+  local file=$1 name=$2 value
+  value=$(
+    awk -v name="$name" '
+      $0 ~ "^" name "=" {
+        line = $0
+        sub("^" name "=", "", line)
+        gsub(/^"|"$/, "", line)
+        print line
+        exit
+      }
+    ' "$file"
+  )
+  [[ -n $value ]] || die "cannot read $name from $file"
+  printf '%s\n' "$value"
+}
+
+read_python_constant() {
+  local file=$1 name=$2 value
+  value=$(
+    awk -v name="$name" '
+      $0 ~ "^" name " = \"" {
+        line = $0
+        sub("^" name " = \"", "", line)
+        sub("\"$", "", line)
+        print line
+        exit
+      }
+    ' "$file"
+  )
+  [[ -n $value ]] || die "cannot read $name from $file"
+  printf '%s\n' "$value"
+}
+
+write_manifest() {
+  local out=$1 payload_name=$2 payload_digest=$3 payload_size=$4
+  local manifest="$out/MANIFEST.txt"
+  local generated
+  generated=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  {
+    echo "# v8 candidate file manifest (sha256  size  path)"
+    echo "# Generated $generated - ASSEMBLED candidate: payload + sidecars"
+    echo "# embedded and digest-verified, engine pinned from the app package."
+    echo "# Catalog is NOT generated, NOT signed; app is NOT built."
+    echo "# Payload $payload_name is $payload_size bytes, sha256 $payload_digest."
+  } >"$manifest" || die "cannot write $manifest"
+
+  (
+    cd "$out" || exit 1
+    find . -type f ! -name MANIFEST.txt -print |
+      LC_ALL=C sort |
+      while IFS= read -r path; do
+        printf '%s %13s  %s\n' \
+          "$(shasum -a 256 "$path" | cut -d ' ' -f 1)" \
+          "$(wc -c <"$path" | tr -d ' ')" \
+          "$path"
+      done
+  ) >>"$manifest" || die "cannot append to $manifest"
+
+  echo "  wrote MANIFEST.txt ($(grep -c '' "$manifest") lines)"
+}
+
+main() {
+  local payload="" out="" repo_root="$DEFAULT_REPO_ROOT"
+  local reference="$DEFAULT_REFERENCE_CANDIDATE"
+  local tag="$DEFAULT_TAG" release_repo="$DEFAULT_RELEASE_REPO"
+  local app_version="$DEFAULT_APP_VERSION" build_number="$DEFAULT_BUILD_NUMBER"
+  local team_id="$DEFAULT_TEAM_ID" allow_metadata_drift="no"
+
+  while (( $# > 0 )); do
+    case $1 in
+      --payload) payload=${2:-}; shift 2 ;;
+      --out) out=${2:-}; shift 2 ;;
+      --repo-root) repo_root=${2:-}; shift 2 ;;
+      --reference) reference=${2:-}; shift 2 ;;
+      --tag) tag=${2:-}; shift 2 ;;
+      --release-repo) release_repo=${2:-}; shift 2 ;;
+      --app-version) app_version=${2:-}; shift 2 ;;
+      --build-number) build_number=${2:-}; shift 2 ;;
+      --team-id) team_id=${2:-}; shift 2 ;;
+      --allow-metadata-drift) allow_metadata_drift="yes"; shift ;;
+      -h|--help) usage ;;
+      *) echo "assemble-candidate-v8: unknown argument: $1" >&2; usage ;;
+    esac
+  done
+
+  [[ -n $payload && -n $out ]] || usage
+  [[ $tag =~ ^v[0-9A-Za-z][0-9A-Za-z.+_-]*$ ]] ||
+    die "--tag must match publish-m1-release's rule ^v[0-9A-Za-z][0-9A-Za-z.+_-]*$ (got: $tag)"
+  [[ $release_repo =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] ||
+    die "--release-repo must be OWNER/REPO"
+  [[ $app_version =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9]+)*$ ]] ||
+    die "--app-version has an invalid format"
+  [[ $build_number =~ ^[1-9][0-9]*$ ]] ||
+    die "--build-number must be a positive integer"
+  [[ $team_id =~ ^[A-Z0-9]{10}$ ]] || die "--team-id must be 10 characters"
+
+  # ---- inputs ------------------------------------------------------------
+  require_regular_file "$payload"
+  local payload_dir payload_name metadata_sidecar evidence_sidecar
+  payload_dir=$({ cd "$(dirname "$payload")" && pwd -P; }) ||
+    die "cannot resolve payload directory"
+  payload_name=$(basename "$payload")
+  payload="$payload_dir/$payload_name"
+  metadata_sidecar="$payload.installer-data.json"
+  evidence_sidecar="$payload.asahi-package-evidence.json"
+  require_regular_file "$metadata_sidecar"
+  require_regular_file "$evidence_sidecar"
+
+  require_real_directory "$repo_root"
+  local app_package="$repo_root/$APP_PACKAGE_RELATIVE"
+  require_real_directory "$app_package"
+  local build_app="$app_package/Packaging/build-app.sh"
+  local notarize_app="$app_package/Packaging/notarize-app.sh"
+  local publisher="$app_package/scripts/publish-m1-release"
+  local generator="$app_package/scripts/make-unsigned-catalog.py"
+  require_regular_file "$build_app"
+  require_regular_file "$notarize_app"
+  require_regular_file "$publisher"
+  require_regular_file "$generator"
+
+  require_real_directory "$reference"
+  local signing_tool="$reference/catalog/catalog-signing.swift"
+  local reference_release="$reference/catalog/release/release.json"
+  local reference_trust_root="$reference/catalog/release/trust-root.ed25519.pub"
+  require_regular_file "$signing_tool"
+  require_regular_file "$reference_release"
+  require_regular_file "$reference_trust_root"
+
+  [[ ! -e $out ]] || die "refusing to overwrite existing path: $out"
+  [[ $out != */ ]] || die "--out must not end with a slash"
+
+  # ---- engine identity, read from the app package's own pin --------------
+  step "Engine pin (from $build_app)"
+  local engine_name engine_digest_pin engine_source engine_digest
+  engine_name=$(read_pinned_value "$build_app" engine_file_name) || exit 1
+  engine_digest_pin=$(read_pinned_value "$build_app" engine_digest) || exit 1
+  engine_source="$app_package/Engine/artifacts/$engine_name"
+  require_regular_file "$engine_source"
+  engine_digest=$(file_digest "$engine_source")
+  echo "  name   $engine_name"
+  echo "  pinned $engine_digest_pin"
+  echo "  actual $engine_digest"
+  [[ $engine_digest == "$engine_digest_pin" ]] ||
+    die "engine at $engine_source does not match the pin in build-app.sh"
+
+  # ---- metadata agreement -------------------------------------------------
+  step "Installer metadata agreement"
+  local engine_metadata="$app_package/Engine/installer_data.json"
+  require_regular_file "$engine_metadata"
+  if cmp -s "$metadata_sidecar" "$engine_metadata"; then
+    echo "  payload sidecar is byte-identical to Engine/installer_data.json"
+  else
+    echo "  sidecar  $(file_digest "$metadata_sidecar")"
+    echo "  engine   $(file_digest "$engine_metadata")"
+    if [[ $allow_metadata_drift == "yes" ]]; then
+      warn "installer metadata drift accepted by --allow-metadata-drift"
+    else
+      die "payload installer-data sidecar differs from Engine/installer_data.json;
+  the catalog binds the Engine copy, so the two must agree.
+  Re-run with --allow-metadata-drift only if that divergence is intended."
+    fi
+  fi
+
+  # ---- generator name agreement ------------------------------------------
+  step "Catalog generator name agreement"
+  local generator_payload generator_engine generator_metadata generator_evidence
+  generator_payload=$(read_python_constant "$generator" PAYLOAD_NAME) || exit 1
+  generator_engine=$(read_python_constant "$generator" ENGINE_NAME) || exit 1
+  generator_metadata=$(read_python_constant "$generator" METADATA_NAME) || exit 1
+  generator_evidence=$(read_python_constant "$generator" EVIDENCE_REVISION) || exit 1
+  [[ $generator_payload == "$payload_name" ]] ||
+    warn "make-unsigned-catalog.py pins PAYLOAD_NAME=$generator_payload but this payload is $payload_name; update the constant before generating the catalog"
+  [[ $generator_engine == "$engine_name" ]] ||
+    warn "make-unsigned-catalog.py pins ENGINE_NAME=$generator_engine but the app package pins $engine_name"
+  [[ $generator_metadata == "installer_data.json" ]] ||
+    warn "make-unsigned-catalog.py pins METADATA_NAME=$generator_metadata"
+  case $generator_evidence in
+    *v8*) echo "  EVIDENCE_REVISION=$generator_evidence" ;;
+    *) warn "make-unsigned-catalog.py still declares EVIDENCE_REVISION=$generator_evidence; bump it for the v8 generation" ;;
+  esac
+
+  # ---- reference signing tool --------------------------------------------
+  step "Reference catalog-signing tool"
+  local signing_tool_digest
+  signing_tool_digest=$(file_digest "$signing_tool")
+  echo "  $signing_tool"
+  echo "  sha256 $signing_tool_digest"
+  [[ $signing_tool_digest == "$REFERENCE_SIGNING_TOOL_DIGEST" ]] ||
+    warn "catalog-signing.swift does not match the v6/v7 digest $REFERENCE_SIGNING_TOOL_DIGEST"
+
+  # ---- build the tree -----------------------------------------------------
+  step "Creating candidate tree at $out"
+  mkdir -p \
+    "$out/package/build-evidence" \
+    "$out/engine" \
+    "$out/catalog/unsigned" \
+    "$out/catalog/release" \
+    "$out/catalog/public" \
+    "$out/catalog/v7-reference" \
+    "$out/app/build" \
+    "$out/app/transfer" \
+    "$out/dist" \
+    "$out/evidence/omarchy-mx-mac" \
+    "$out/evidence/omarchy-iso" ||
+    die "cannot create candidate tree at $out"
+  chmod 0700 "$out" || die "cannot restrict $out"
+  echo "  created"
+
+  step "Embedding the payload and its sidecars"
+  verified_copy "$payload" "$out/package/$payload_name" "payload"
+  verified_copy "$metadata_sidecar" \
+    "$out/package/$payload_name.installer-data.json" "installer-data sidecar"
+  verified_copy "$evidence_sidecar" \
+    "$out/package/$payload_name.asahi-package-evidence.json" "package-evidence sidecar"
+
+  local payload_digest payload_size
+  payload_digest=$(file_digest "$out/package/$payload_name")
+  payload_size=$(file_size "$out/package/$payload_name")
+
+  step "Embedding the pinned engine and its lock files"
+  verified_copy "$engine_source" "$out/engine/$engine_name" "engine"
+  verified_copy "$engine_metadata" "$out/engine/installer_data.json" "installer metadata"
+  local lock_file
+  for lock_file in source-lock.json build-locked-engine.sh verify-source-lock.py \
+    verify-archive-modes.py; do
+    if [[ -f "$app_package/Engine/$lock_file" && ! -L "$app_package/Engine/$lock_file" ]]; then
+      verified_copy "$app_package/Engine/$lock_file" "$out/engine/$lock_file" "$lock_file"
+    else
+      warn "app package has no Engine/$lock_file; not embedded"
+    fi
+  done
+
+  step "Staging the catalog scaffolding"
+  verified_copy "$signing_tool" "$out/catalog/catalog-signing.swift" "catalog-signing.swift"
+  verified_copy "$generator" "$out/catalog/make-unsigned-catalog.py" "make-unsigned-catalog.py"
+  verified_copy "$reference_release" "$out/catalog/v7-reference/release.json" "v7 release.json"
+  verified_copy "$reference_trust_root" \
+    "$out/catalog/v7-reference/trust-root.ed25519.pub" "v7 trust root"
+  echo "  catalog/unsigned, catalog/release and catalog/public are empty on purpose:"
+  echo "  the generator is templated below, not run by this script."
+
+  # ---- summaries ----------------------------------------------------------
+  local assembled_at
+  assembled_at=$(date -u '+%Y-%m-%dT%H:%MZ')
+  local base_url="https://github.com/$release_repo/releases/download/$tag"
+  local dist_dir="$out/dist/$tag"
+  local engine_size metadata_size evidence_size
+  engine_size=$(file_size "$out/engine/$engine_name")
+  metadata_size=$(file_size "$out/engine/installer_data.json")
+  evidence_size=$(file_size "$out/package/$payload_name.asahi-package-evidence.json")
+
+  step "Writing CANDIDATE-SUMMARY.md and NEXT-STEPS.md"
+  cat >"$out/CANDIDATE-SUMMARY.md" <<SUMMARY
+# Omarchy MX Mac candidate v8 — local assembly summary
+
+This is private local candidate construction evidence. It is **not** M1
+admission, authorization, publication, notarization, deployment, or an
+end-to-end installed-system claim. Nothing here is signed, published,
+notarized, or connected to any device.
+
+- Candidate path: \`$out\`
+- Assembled (UTC): \`$assembled_at\`
+- Assembled by: \`assemble-candidate-v8.sh\`
+- Reference candidate (read-only): \`$reference\`
+- Source worktree: \`$repo_root\`
+- Status: **ASSEMBLED, UNSIGNED.** Catalog not generated, not signed; app not
+  built; nothing published.
+
+## Identities
+
+| Role | Identity |
+| --- | --- |
+| Full-OS payload | \`$payload_name\` |
+| — size | \`$payload_size\` bytes |
+| — SHA-256 | \`$payload_digest\` |
+| Package evidence sidecar | \`$payload_name.asahi-package-evidence.json\`, \`$evidence_size\` bytes |
+| — SHA-256 | \`$(file_digest "$out/package/$payload_name.asahi-package-evidence.json")\` |
+| Installer metadata | \`installer_data.json\`, \`$metadata_size\` bytes |
+| — SHA-256 | \`$(file_digest "$out/engine/installer_data.json")\` |
+| Engine | \`$engine_name\`, \`$engine_size\` bytes |
+| — SHA-256 | \`$engine_digest\` (matches the pin in \`Packaging/build-app.sh\`) |
+
+## Verification performed by the assembler
+
+- Payload, both sidecars, and the engine were digested **before** the copy and
+  re-digested **after**; sizes were compared too. Any drift is a hard error.
+- Copies preferred an APFS clone (\`cp -c\`) and fell back to a plain \`cp\`
+  where cloning is unavailable. Clones: $clone_copies. Plain copies: $plain_copies.
+- The engine digest was checked against the pin hard-coded in
+  \`Packaging/build-app.sh\` before embedding.
+- The payload's \`installer-data.json\` sidecar was compared byte-for-byte with
+  the app package's \`Engine/installer_data.json\` (the bytes the catalog binds).
+- The catalog generator's pinned \`PAYLOAD_NAME\`/\`ENGINE_NAME\` constants were
+  compared against the real file names.
+- Per-file digests for the whole tree: \`MANIFEST.txt\`.
+
+## What is NOT done here
+
+1. **Catalog generation** — templated in \`NEXT-STEPS.md\`, not run.
+2. **Catalog signing** — owner-hands ephemeral-key ritual, see \`NEXT-STEPS.md\`.
+3. **Source-lock rebind** — \`$APP_PACKAGE_RELATIVE/Engine/source-lock.json\`
+   still binds whatever payload it bound before this assembly. It must be
+   rebound to \`$payload_digest\` / \`$payload_size\`
+   before the app is built. That is a repository source edit, deliberately not
+   performed here.
+4. **App build, notarization, publication** — all downstream, all templated.
+SUMMARY
+
+  cat >"$out/NEXT-STEPS.md" <<NEXTSTEPS
+# v8 candidate — exact next steps
+
+Run these in order. Nothing below has been run by the assembler.
+
+Shell variables used throughout:
+
+\`\`\`bash
+CANDIDATE="$out"
+REPO="$repo_root"
+APP="\$REPO/$APP_PACKAGE_RELATIVE"
+TAG="$tag"
+RELEASE_REPO="$release_repo"
+BASE_URL="$base_url"
+DIST="$dist_dir"
+\`\`\`
+
+## 0. Rebind the source lock (repository edit, before the app build)
+
+\`$APP_PACKAGE_RELATIVE/Engine/source-lock.json\` → \`full_os_payload\`:
+
+- sha256 \`$payload_digest\`
+- size \`$payload_size\`
+
+Then refresh the candidate's copy:
+
+\`\`\`bash
+cp "\$APP/Engine/source-lock.json" "\$CANDIDATE/engine/source-lock.json"
+\`\`\`
+
+## 1. Stage the release assets and split the payload
+
+\`\`\`bash
+"\$APP/scripts/publish-m1-release" prepare \\
+  --payload "\$CANDIDATE/package/$payload_name" \\
+  --engine "\$CANDIDATE/engine/$engine_name" \\
+  --metadata "\$CANDIDATE/engine/installer_data.json" \\
+  --tag "\$TAG" \\
+  --repo "\$RELEASE_REPO" \\
+  --out-dir "\$DIST"
+\`\`\`
+
+This writes \`SHA256SUMS\` and \`release-urls.env\` into \`\$DIST\` and splits the
+payload into \`$payload_name.partNN\`. The URLs are deterministic before the
+release exists, which is why the catalog can be generated next.
+
+## 2. Generate the unsigned catalog (TEMPLATED — not run by the assembler)
+
+Confirm first that \`scripts/make-unsigned-catalog.py\` pins the right names and
+evidence revision for this generation (\`PAYLOAD_NAME\`, \`ENGINE_NAME\`,
+\`EVIDENCE_REVISION\`, \`DOWNSTREAM_REVISION\`), then:
+
+\`\`\`bash
+python3 "\$APP/scripts/make-unsigned-catalog.py" \\
+  --base-url "\$BASE_URL" \\
+  --assets-dir "\$DIST" \\
+  --validity-days 90 \\
+  --output "\$CANDIDATE/catalog/unsigned/catalog.json"
+\`\`\`
+
+The generator digests every \`.partNN\` file, proves the parts concatenate back
+into the whole payload, and refuses to emit anything if they do not.
+
+## 3. Sign the catalog — owner-hands ephemeral-key ritual
+
+The private catalog-signing key is ephemeral by design: minted in a private
+temporary directory, used once, destroyed. It never enters the candidate, the
+repository, a log, or an evidence file.
+
+\`\`\`bash
+# 3a. Private, owner-only workspace outside the candidate.
+KEYDIR="\$(mktemp -d /private/tmp/omarchy-v8-signing.XXXXXX)"
+chmod 0700 "\$KEYDIR"
+
+# 3b. Mint the v8 trust root.
+xcrun swift "\$CANDIDATE/catalog/catalog-signing.swift" generate \\
+  "\$KEYDIR/catalog-signing.ed25519" \\
+  "\$KEYDIR/trust-root.ed25519.pub"
+
+# 3c. Sign the unsigned catalog.
+cp "\$CANDIDATE/catalog/unsigned/catalog.json" "\$CANDIDATE/catalog/release/catalog.json"
+xcrun swift "\$CANDIDATE/catalog/catalog-signing.swift" sign \\
+  "\$KEYDIR/catalog-signing.ed25519" \\
+  "\$CANDIDATE/catalog/release/catalog.json" \\
+  "\$CANDIDATE/catalog/release/catalog.json.sig"
+
+# 3d. Publish the public half into the candidate and write release.json.
+cp "\$KEYDIR/trust-root.ed25519.pub" "\$CANDIDATE/catalog/release/trust-root.ed25519.pub"
+FINGERPRINT="sha256:\$(shasum -a 256 "\$CANDIDATE/catalog/release/trust-root.ed25519.pub" | cut -d ' ' -f 1)"
+sed "s|\"trust_root_fingerprint\": \".*\"|\"trust_root_fingerprint\": \"\$FINGERPRINT\"|" \\
+  "\$CANDIDATE/catalog/v7-reference/release.json" \\
+  >"\$CANDIDATE/catalog/release/release.json"
+
+# 3e. Verify BEFORE the app build. This must print catalog_signature=passed.
+xcrun swift "\$CANDIDATE/catalog/catalog-signing.swift" verify \\
+  "\$CANDIDATE/catalog/release/trust-root.ed25519.pub" \\
+  "\$CANDIDATE/catalog/release/catalog.json" \\
+  "\$CANDIDATE/catalog/release/catalog.json.sig"
+
+# 3f. Mirror the signed pair into catalog/public (the v6/v7 layout).
+cp "\$CANDIDATE/catalog/release/catalog.json" "\$CANDIDATE/catalog/public/catalog.json"
+cp "\$CANDIDATE/catalog/release/catalog.json.sig" "\$CANDIDATE/catalog/public/catalog.json.sig"
+
+# 3g. Destroy the key and its workspace. Do not skip, do not copy it anywhere.
+rm -rf "\$KEYDIR"
+unset KEYDIR
+\`\`\`
+
+Signing freezes the tag: the signed catalog names \`\$BASE_URL\` asset URLs, so
+those exact bytes must be what gets published under \`\$TAG\`, forever.
+
+## 4. Build the app
+
+\`\`\`bash
+OMARCHY_APP_VERSION=$app_version \\
+OMARCHY_APP_BUILD_NUMBER=$build_number \\
+OMARCHY_APP_SIGNING_IDENTITY="<Developer ID Application SHA-1 fingerprint>" \\
+OMARCHY_TEAM_ID=$team_id \\
+OMARCHY_BUILD_JOBS=10 \\
+"\$APP/Packaging/build-app.sh" \\
+  "\$CANDIDATE/catalog/release" \\
+  "\$CANDIDATE/app/build"
+\`\`\`
+
+Pass the certificate **SHA-1 fingerprint**, not the common name: the keychain
+holds duplicate same-name certificates and a name is ambiguous.
+
+## 5. Notarize and staple
+
+\`\`\`bash
+OMARCHY_NOTARY_PROFILE=omarchy-notary \\
+  "\$APP/Packaging/notarize-app.sh" \\
+  "\$CANDIDATE/app/build/Omarchy MX Mac Installer.app"
+\`\`\`
+
+One-time owner setup this needs: a "Developer ID Application" certificate in
+the keychain, and
+\`xcrun notarytool store-credentials omarchy-notary\`.
+
+## 6. Package the app for transfer
+
+\`\`\`bash
+ditto -c -k --keepParent \\
+  "\$CANDIDATE/app/build/Omarchy MX Mac Installer.app" \\
+  "\$CANDIDATE/app/transfer/Omarchy-MX-Mac-Installer-$app_version.zip"
+\`\`\`
+
+## 7. Publish (owner confirms at the prompt)
+
+\`\`\`bash
+git push origin "\$TAG"   # the tag must already exist on origin
+"\$APP/scripts/publish-m1-release" publish \\
+  --dir "\$DIST" \\
+  --app "\$CANDIDATE/app/transfer/Omarchy-MX-Mac-Installer-$app_version.zip" \\
+  --tag "\$TAG" \\
+  --repo "\$RELEASE_REPO" \\
+  --notes-file /Users/maralc/dev/omarchy/iteration2/release-notes-v8.md
+\`\`\`
+
+Assets are uploaded once and never clobbered. A published asset whose bytes
+differ from the staged bytes is a hard error that requires a new tag.
+
+## 8. Refresh the manifest after every step that adds files
+
+\`\`\`bash
+( cd "\$CANDIDATE" && find . -type f ! -name MANIFEST.txt -print | LC_ALL=C sort |
+    while IFS= read -r f; do
+      printf '%s %13s  %s\\n' "\$(shasum -a 256 "\$f" | cut -d ' ' -f 1)" \\
+        "\$(wc -c <"\$f" | tr -d ' ')" "\$f"
+    done )
+\`\`\`
+NEXTSTEPS
+  echo "  wrote CANDIDATE-SUMMARY.md"
+  echo "  wrote NEXT-STEPS.md"
+
+  step "Writing MANIFEST.txt"
+  write_manifest "$out" "$payload_name" "$payload_digest" "$payload_size"
+
+  # ---- report -------------------------------------------------------------
+  echo
+  echo "candidate=$out"
+  echo "payload=$payload_name"
+  echo "payload_sha256=$payload_digest"
+  echo "payload_bytes=$payload_size"
+  echo "engine=$engine_name"
+  echo "engine_sha256=$engine_digest"
+  echo "clone_copies=$clone_copies"
+  echo "plain_copies=$plain_copies"
+  echo "warnings=$warnings"
+  echo
+  echo "Next steps, in order (full commands in $out/NEXT-STEPS.md):"
+  echo "  1. rebind Engine/source-lock.json full_os_payload -> $payload_digest / $payload_size"
+  echo "  2. $publisher prepare --payload $out/package/$payload_name \\"
+  echo "       --engine $out/engine/$engine_name \\"
+  echo "       --metadata $out/engine/installer_data.json \\"
+  echo "       --tag $tag --repo $release_repo --out-dir $dist_dir"
+  echo "  3. python3 $generator --base-url $base_url \\"
+  echo "       --assets-dir $dist_dir --validity-days 90 \\"
+  echo "       --output $out/catalog/unsigned/catalog.json"
+  echo "  4. OWNER: ephemeral-key signing ritual (mint in a 0700 mktemp dir,"
+  echo "     sign, write release.json, verify -> catalog_signature=passed,"
+  echo "     destroy the key). Section 3 of NEXT-STEPS.md."
+  echo "  5. build: OMARCHY_APP_VERSION=$app_version OMARCHY_APP_BUILD_NUMBER=$build_number \\"
+  echo "       OMARCHY_TEAM_ID=$team_id OMARCHY_APP_SIGNING_IDENTITY=<Developer ID SHA-1> \\"
+  echo "       $build_app $out/catalog/release $out/app/build"
+  echo "  6. notarize: OMARCHY_NOTARY_PROFILE=omarchy-notary $notarize_app \\"
+  echo "       \"$out/app/build/Omarchy MX Mac Installer.app\""
+  echo "  7. ditto -c -k --keepParent the app, then publish-m1-release publish."
+  if (( warnings > 0 )); then
+    echo
+    echo "Assembly completed with $warnings warning(s) — read them before step 2."
+  fi
+}
+
+main "$@"

--- a/apps/omarchy-apple-installer/scripts/fix-engine-framework-sign.sh
+++ b/apps/omarchy-apple-installer/scripts/fix-engine-framework-sign.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Sign the Python.framework as a proper bundle (not just its inner Mach-O),
+# which is what Apple notarization validates, then repack omarchy.7.
+# Innermost binaries were already Developer-ID signed; this adds the bundle
+# signatures over the framework wrappers and re-verifies everything.
+set -euo pipefail
+
+IDENTITY="Developer ID Application: MARCELO DE BARROS ALCANTARA (T2C384FJBD)"
+ROOT=/private/tmp/engine-resign/tree
+PYVER="$ROOT/Frameworks/Python.framework/Versions/3.13"
+
+# Sign the versioned framework as a bundle (covers Info.plist + the dylib).
+codesign --force --sign "$IDENTITY" --options runtime --timestamp "$PYVER"
+# Sign the framework at its top level too, so the Current symlink resolves signed.
+codesign --force --sign "$IDENTITY" --options runtime --timestamp \
+  "$ROOT/Frameworks/Python.framework"
+
+echo "=== verify the framework as a bundle ==="
+codesign --verify --strict --verbose=2 "$ROOT/Frameworks/Python.framework" && echo "  framework OK"
+
+echo "=== full re-audit of every Mach-O ==="
+bad=0
+while IFS= read -r -d '' f; do
+  if file -b "$f" 2>/dev/null | grep -q "Mach-O"; then
+    if ! codesign --verify --strict "$f" >/dev/null 2>&1; then
+      # Files inside a signed bundle verify via the bundle, not standalone;
+      # confirm the bundle covers them instead of flagging.
+      case "$f" in
+        *Python.framework*) : ;;
+        *) echo "UNVERIFIED (standalone): $f"; bad=$((bad + 1)) ;;
+      esac
+    fi
+  fi
+done < <(find "$ROOT" -type f -print0)
+echo "standalone problems outside the framework: $bad"
+
+cd /private/tmp/engine-resign
+rm -f installer-v0.9.0-omarchy.7.tar.gz
+tar -czf installer-v0.9.0-omarchy.7.tar.gz -C tree .
+echo "size_bytes: $(stat -f %z installer-v0.9.0-omarchy.7.tar.gz)"
+echo "sha256: $(shasum -a 256 installer-v0.9.0-omarchy.7.tar.gz | awk '{print $1}')"

--- a/apps/omarchy-apple-installer/scripts/preclean-m1.sh
+++ b/apps/omarchy-apple-installer/scripts/preclean-m1.sh
@@ -1,0 +1,693 @@
+#!/bin/bash
+
+# E2E pre-clean for the M1 (macOS side), driven over the pinned Thunderbolt
+# SSH alias.
+#
+# What it does:
+#   1. Proves it is talking to the expected machine.
+#   2. Reads the LIVE disk0 layout and the LIVE APFS container list.
+#   3. Identifies the protected partitions from those live values —
+#      the macOS Apple_APFS store carrying the "Macintosh HD" volume group,
+#      the Apple_APFS_Recovery partition, and the Apple_APFS_ISC partition.
+#      Anything ambiguous is a HARD ABORT.
+#   4. Identifies the Omarchy partitions by TYPE and NAME.
+#   5. Prints the complete deletion plan.
+#   6. Only with --confirm: deletes every Omarchy APFS container, then frees
+#      each Omarchy partition BY UUID, then clears the installer's staging/state
+#      and removes old installer copies.
+#
+# Multiple Omarchy installs (repeated test installs) are supported: every APFS
+# container holding an "Omarchy" volume, every "EFI - OMARC" ESP, and every
+# Linux filesystem partition is planned. A container that claims to hold both
+# an Omarchy volume and "Macintosh HD" is a HARD ABORT.
+#
+# Without --confirm it changes nothing. It never touches Macintosh HD, the
+# Recovery partition, the ISC partition, or any user data.
+#
+# Testing hook: set OMARCHY_PRECLEAN_SSH_SHIM to an executable that receives
+# (operation, command) and prints canned output. When it is set, no ssh is run.
+
+set -uo pipefail
+
+readonly DEFAULT_HOST="omarchy-m1-thunderbolt"
+readonly EXPECTED_USER="mina"
+readonly EXPECTED_MODEL="MacBookPro18,3"
+readonly EXPECTED_BRIDGE_IP="10.77.0.2"
+readonly EXPECTED_INTERFACE="bridge0"
+readonly OMARCHY_EFI_NAME="EFI - OMARC"
+readonly OMARCHY_VOLUME_NAME="Omarchy"
+readonly MACOS_VOLUME_NAME="Macintosh HD"
+readonly APP_SUPPORT_ID="com.omarchy.mx.installer"
+readonly APP_BUNDLE_NAME="Omarchy MX Mac Installer.app"
+
+# Volume names and partition types that must never appear in a deletion plan.
+readonly PROTECTED_NAME_PATTERN='^(Macintosh HD|Macintosh HD - Data|Recovery|Preboot|VM|Update|xART|iSCPreboot|Hardware)$'
+readonly PROTECTED_TYPE_PATTERN='^(Apple_APFS_Recovery|Apple_APFS_ISC|Apple_boot|Apple_KernelCoreDump)$'
+
+host="$DEFAULT_HOST"
+confirm="no"
+dry_run="no"
+skip_partitions="no"
+skip_macos="no"
+work=""
+actions_taken=0
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  preclean-m1.sh [--dry-run] [--confirm] [--host ALIAS]
+                 [--skip-partitions] [--skip-macos-cleanup]
+
+Default behaviour is a dry run: the plan is printed and nothing is changed.
+--confirm is the only thing that lets a destructive command run.
+
+  --dry-run              explicit no-op mode (the default); refuses --confirm
+  --confirm              actually perform the printed plan
+  --host ALIAS           ssh alias for the M1 (default: omarchy-m1-thunderbolt)
+  --skip-partitions      leave the disk alone; only clean staging/state/apps
+  --skip-macos-cleanup   only the partitions; leave staging/state/apps alone
+  -h, --help             this text
+
+Environment:
+  OMARCHY_PRECLEAN_SSH_SHIM   test hook. When set, this executable is called as
+                              "$SHIM <operation> <command>" instead of ssh.
+USAGE
+  exit 64
+}
+
+die() {
+  echo >&2
+  echo "preclean-m1: HARD ABORT: $*" >&2
+  exit 1
+}
+
+note() {
+  echo "preclean-m1: $*"
+}
+
+heading() {
+  echo
+  echo "== $* =="
+}
+
+cleanup() {
+  [[ -z $work ]] || rm -rf "$work"
+}
+
+# ---------------------------------------------------------------------------
+# Remote execution
+# ---------------------------------------------------------------------------
+
+remote() {
+  local operation=$1 command=$2
+  # Detached stdin on both paths: several callers run inside while-read
+  # loops, and a remote command that reads stdin silently consumes the
+  # remaining loop input (ssh's default behavior).
+  if [[ -n ${OMARCHY_PRECLEAN_SSH_SHIM:-} ]]; then
+    "$OMARCHY_PRECLEAN_SSH_SHIM" "$operation" "$command" </dev/null
+    return $?
+  fi
+  ssh -n -T -o BatchMode=yes "$host" "$command"
+}
+
+# Every destructive command funnels through here. Without --confirm it is only
+# echoed. Nothing else in this script is allowed to write to the M1.
+remote_destructive() {
+  local operation=$1 command=$2
+  if [[ $confirm != "yes" ]]; then
+    echo "  WOULD RUN: $command"
+    return 0
+  fi
+  echo "  RUNNING:   $command"
+  remote "$operation" "$command"
+  local status=$?
+  if (( status != 0 )); then
+    die "$operation failed with status $status; stopping before any further destructive step"
+  fi
+  actions_taken=$((actions_taken + 1))
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Remote command bodies (quoted heredocs — nothing expands locally)
+# ---------------------------------------------------------------------------
+
+identity_command() {
+  cat <<'REMOTE'
+/usr/bin/id -un
+/usr/sbin/system_profiler SPHardwareDataType | /usr/bin/awk -F': ' '/Model Identifier/ { print $2 }'
+REMOTE
+}
+
+partitions_command() {
+  cat <<'REMOTE'
+for slice in $(/usr/sbin/diskutil list /dev/disk0 | /usr/bin/awk '$NF ~ /^disk0s[0-9]+$/ { print $NF }'); do
+  /usr/sbin/diskutil info "$slice" | /usr/bin/awk -v id="$slice" '
+    /Partition Type:/ { line = $0; sub(/^ *Partition Type: */, "", line); type = line }
+    /Volume Name:/ { line = $0; sub(/^ *Volume Name: */, "", line); name = line }
+    /Partition UUID:/ { line = $0; sub(/^.*Partition UUID: */, "", line); uuid = line }
+    /Disk Size:/ {
+      if (bytes == "" && match($0, /\(([0-9]+) Bytes\)/)) {
+        bytes = substr($0, RSTART + 1, RLENGTH - 8)
+      }
+    }
+    END {
+      if (name ~ /^Not applicable/ || name == "") { name = "-" }
+      printf "%s\t%s\t%s\t%s\t%s\n", id, type, name, uuid, bytes
+    }
+  '
+done
+REMOTE
+}
+
+containers_command() {
+  cat <<'REMOTE'
+/usr/sbin/diskutil apfs list | /usr/bin/awk '
+  function flush() {
+    if (ref != "") { printf "%s\t%s\t%s\t%s\t%s\n", ref, uuid, store, storeuuid, names }
+    ref = ""; uuid = ""; store = ""; storeuuid = ""; names = ""
+  }
+  /^\+-- Container disk/ {
+    flush()
+    line = $0
+    sub(/^\+-- Container */, "", line)
+    n = split(line, field, " ")
+    ref = field[1]
+    uuid = field[2]
+  }
+  /Physical Store disk/ {
+    line = $0
+    sub(/^.*Physical Store */, "", line)
+    n = split(line, field, " ")
+    if (n >= 2 && field[1] ~ /^disk[0-9]+s[0-9]+$/) {
+      store = field[1]
+      storeuuid = field[2]
+    }
+  }
+  {
+    line = $0
+    sub(/^[ |+<>-]*/, "", line)
+    if (line ~ /^Name: /) {
+      sub(/^Name: */, "", line)
+      sub(/ +\(Case-.*$/, "", line)
+      names = (names == "") ? line : names "," line
+    }
+  }
+  END { flush() }
+'
+REMOTE
+}
+
+app_support_command() {
+  cat <<'REMOTE'
+base="$HOME/Library/Application Support/com.omarchy.mx.installer"
+if [ -d "$base" ] && [ ! -L "$base" ]; then
+  /usr/bin/du -sk "$base" | /usr/bin/awk -v p="$base" '{ printf "present\t%s\t%s\n", $1, p }'
+else
+  printf 'absent\t0\t%s\n' "$base"
+fi
+REMOTE
+}
+
+old_apps_command() {
+  cat <<'REMOTE'
+for candidate in \
+  "/Applications/Omarchy MX Mac Installer.app" \
+  "$HOME/Downloads/Omarchy MX Mac Installer.app" \
+  "$HOME/Downloads/__MACOSX"
+do
+  if [ -e "$candidate" ] && [ ! -L "$candidate" ]; then
+    printf '%s\n' "$candidate"
+  fi
+done
+/usr/bin/find "$HOME/Downloads" -maxdepth 1 -type f -name 'Omarchy-MX-Mac-Installer-*.zip' -print 2>/dev/null
+REMOTE
+}
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+verify_local_route() {
+  [[ -z ${OMARCHY_PRECLEAN_SSH_SHIM:-} ]] || return 0
+  local interface
+  interface=$(
+    /sbin/route -n get "$EXPECTED_BRIDGE_IP" 2>/dev/null |
+      /usr/bin/awk '/interface:/ { print $2 }'
+  )
+  [[ $interface == "$EXPECTED_INTERFACE" ]] ||
+    die "route to $EXPECTED_BRIDGE_IP is via '${interface:-none}', expected $EXPECTED_INTERFACE"
+  note "route to $EXPECTED_BRIDGE_IP is $EXPECTED_INTERFACE"
+}
+
+verify_identity() {
+  local output user model
+  output=$(remote identity "$(identity_command)") ||
+    die "cannot reach $host over ssh"
+  user=$(printf '%s\n' "$output" | sed -n '1p' | tr -d '[:space:]')
+  model=$(printf '%s\n' "$output" | sed -n '2p' | sed 's/^ *//; s/ *$//')
+  [[ $user == "$EXPECTED_USER" ]] ||
+    die "remote user is '$user', expected '$EXPECTED_USER'"
+  [[ $model == "$EXPECTED_MODEL" ]] ||
+    die "remote model is '$model', expected '$EXPECTED_MODEL'"
+  note "peer verified: $user@$host is a $model"
+}
+
+read_partitions() {
+  remote partitions "$(partitions_command)" >"$work/partitions.tsv" ||
+    die "cannot read the disk0 partition table"
+  [[ -s $work/partitions.tsv ]] || die "the disk0 partition table came back empty"
+  local count
+  count=$(grep -c '' "$work/partitions.tsv")
+  note "read $count partitions from disk0"
+}
+
+read_containers() {
+  remote containers "$(containers_command)" >"$work/containers.tsv" ||
+    die "cannot read the APFS container list"
+  [[ -s $work/containers.tsv ]] || die "the APFS container list came back empty"
+  local count
+  count=$(grep -c '' "$work/containers.tsv")
+  note "read $count APFS containers"
+}
+
+partition_field() {
+  local uuid=$1 column=$2
+  awk -F '\t' -v uuid="$uuid" -v column="$column" \
+    '$4 == uuid { print $column; exit }' "$work/partitions.tsv"
+}
+
+partition_uuid_for_identifier() {
+  awk -F '\t' -v id="$1" '$1 == id { print $4; exit }' "$work/partitions.tsv"
+}
+
+is_protected_uuid() {
+  [[ -s $work/protected.txt ]] || return 1
+  grep -qxF "$1" "$work/protected.txt"
+}
+
+add_protected() {
+  local uuid=$1 reason=$2
+  [[ -n $uuid ]] || die "cannot protect an empty UUID ($reason)"
+  printf '%s\n' "$uuid" >>"$work/protected.txt"
+  printf '  PROTECTED  %-10s %-22s %s\n' \
+    "$(awk -F '\t' -v u="$uuid" '$4 == u { print $1; exit }' "$work/partitions.tsv")" \
+    "$reason" "$uuid"
+}
+
+identify_protected() {
+  : >"$work/protected.txt"
+
+  # macOS: exactly one APFS container whose volumes include "Macintosh HD".
+  local macos_stores macos_store macos_count
+  macos_stores=$(
+    awk -F '\t' -v name="$MACOS_VOLUME_NAME" '
+      index("," $5 ",", "," name ",") > 0 { print $3 }
+    ' "$work/containers.tsv"
+  )
+  macos_count=$(printf '%s' "$macos_stores" | grep -c '.')
+  (( macos_count == 1 )) ||
+    die "expected exactly one APFS container holding a '$MACOS_VOLUME_NAME' volume, found $macos_count — the layout is ambiguous, refusing to plan any deletion"
+  macos_store=$(printf '%s\n' "$macos_stores" | head -1)
+  local macos_uuid
+  macos_uuid=$(partition_uuid_for_identifier "$macos_store")
+  [[ -n $macos_uuid ]] ||
+    die "the macOS physical store '$macos_store' has no partition UUID in the live table"
+  local macos_type
+  macos_type=$(partition_field "$macos_uuid" 2)
+  [[ $macos_type == "Apple_APFS" ]] ||
+    die "the macOS physical store '$macos_store' is type '$macos_type', expected Apple_APFS"
+  add_protected "$macos_uuid" "macOS ($macos_store)"
+
+  # Recovery: exactly one Apple_APFS_Recovery partition.
+  local recovery_uuids recovery_count uuid
+  recovery_uuids=$(
+    awk -F '\t' '$2 == "Apple_APFS_Recovery" { print $4 }' "$work/partitions.tsv"
+  )
+  recovery_count=$(printf '%s' "$recovery_uuids" | grep -c '.')
+  (( recovery_count == 1 )) ||
+    die "expected exactly one Apple_APFS_Recovery partition, found $recovery_count — refusing to plan any deletion"
+  add_protected "$(printf '%s\n' "$recovery_uuids" | head -1)" "Recovery"
+
+  # Everything else Apple reserves: ISC, Apple_boot, core dumps.
+  while IFS= read -r uuid; do
+    [[ -n $uuid ]] || continue
+    is_protected_uuid "$uuid" && continue
+    add_protected "$uuid" "Apple reserved"
+  done <<EOF
+$(awk -F '\t' -v pattern="$PROTECTED_TYPE_PATTERN" \
+    '$2 ~ pattern { print $4 }' "$work/partitions.tsv")
+EOF
+
+  # Any partition carrying a protected volume name, whatever its type.
+  while IFS= read -r uuid; do
+    [[ -n $uuid ]] || continue
+    is_protected_uuid "$uuid" && continue
+    add_protected "$uuid" "protected volume name"
+  done <<EOF
+$(awk -F '\t' -v pattern="$PROTECTED_NAME_PATTERN" \
+    '$3 ~ pattern { print $4 }' "$work/partitions.tsv")
+EOF
+}
+
+identify_omarchy() {
+  : >"$work/targets.tsv"
+  : >"$work/container.tsv"
+
+  # A container claiming to hold both an Omarchy volume and macOS would make
+  # every later decision unsafe. Refuse outright.
+  local conflicted
+  conflicted=$(
+    awk -F '\t' -v want="$OMARCHY_VOLUME_NAME" -v macos="$MACOS_VOLUME_NAME" '
+      index("," $5 ",", "," want ",") > 0 &&
+      index("," $5 ",", "," macos ",") > 0 { print $1 }
+    ' "$work/containers.tsv"
+  )
+  [[ -z $conflicted ]] ||
+    die "container $conflicted holds both an '$OMARCHY_VOLUME_NAME' volume and '$MACOS_VOLUME_NAME' — refusing to plan any deletion"
+
+  # The Omarchy stubs: every APFS container holding an "Omarchy" volume that is
+  # not the macOS container. Repeated test installs leave one stub each.
+  local rows count
+  rows=$(
+    awk -F '\t' -v want="$OMARCHY_VOLUME_NAME" -v macos="$MACOS_VOLUME_NAME" '
+      index("," $5 ",", "," want ",") > 0 &&
+      index("," $5 ",", "," macos ",") == 0 { print }
+    ' "$work/containers.tsv"
+  )
+  count=$(printf '%s' "$rows" | grep -c '.')
+  if (( count > 0 )); then
+    printf '%s\n' "$rows" >"$work/container.tsv"
+    local ref cuuid store storeuuid names store_uuid
+    while IFS=$'\t' read -r ref cuuid store storeuuid names; do
+      [[ -n $ref ]] || continue
+      store_uuid=$(partition_uuid_for_identifier "$store")
+      [[ -n $store_uuid ]] ||
+        die "the Omarchy physical store '$store' has no partition UUID in the live table"
+      printf '%s\t%s\n' "$store_uuid" "Omarchy APFS stub store" >>"$work/target-uuids.tsv"
+    done <"$work/container.tsv"
+    note "found $count Omarchy APFS container(s)"
+  fi
+
+  # The Omarchy ESP, matched on its distinctive volume name.
+  local uuid
+  while IFS= read -r uuid; do
+    [[ -n $uuid ]] || continue
+    printf '%s\t%s\n' "$uuid" "Omarchy ESP" >>"$work/target-uuids.tsv"
+  done <<EOF
+$(awk -F '\t' -v name="$OMARCHY_EFI_NAME" '$3 == name { print $4 }' "$work/partitions.tsv")
+EOF
+
+  # The Omarchy boot and root partitions.
+  while IFS= read -r uuid; do
+    [[ -n $uuid ]] || continue
+    printf '%s\t%s\n' "$uuid" "Omarchy Linux filesystem" >>"$work/target-uuids.tsv"
+  done <<EOF
+$(awk -F '\t' '$2 == "Linux Filesystem" { print $4 }' "$work/partitions.tsv")
+EOF
+
+  [[ -f $work/target-uuids.tsv ]] || : >"$work/target-uuids.tsv"
+
+  # Guard every candidate before it is allowed into the plan.
+  local role type name identifier size
+  while IFS=$'\t' read -r uuid role; do
+    [[ -n $uuid ]] || continue
+    is_protected_uuid "$uuid" &&
+      die "candidate $uuid ($role) is also on the protected list — refusing to delete anything"
+    identifier=$(partition_field "$uuid" 1)
+    type=$(partition_field "$uuid" 2)
+    name=$(partition_field "$uuid" 3)
+    size=$(partition_field "$uuid" 5)
+    [[ -n $identifier ]] ||
+      die "candidate $uuid ($role) is not in the live partition table"
+    [[ ! $name =~ $PROTECTED_NAME_PATTERN ]] ||
+      die "candidate $identifier carries the protected volume name '$name'"
+    [[ ! $type =~ $PROTECTED_TYPE_PATTERN ]] ||
+      die "candidate $identifier is a protected partition type '$type'"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$identifier" "$type" "$name" "$uuid" "$size" "$role" >>"$work/targets.tsv"
+  done <"$work/target-uuids.tsv"
+
+  # Duplicate UUIDs would mean the same partition is planned twice.
+  local unique total
+  total=$(grep -c '' "$work/targets.tsv")
+  unique=$(cut -f 4 <"$work/targets.tsv" | LC_ALL=C sort -u | grep -c '.')
+  (( total == unique )) ||
+    die "the deletion plan lists $total entries but only $unique distinct partitions"
+}
+
+read_macos_cleanup_candidates() {
+  remote app-support "$(app_support_command)" >"$work/app-support.tsv" ||
+    die "cannot inspect the installer's Application Support directory"
+  remote old-apps "$(old_apps_command)" >"$work/old-apps.txt"
+  [[ -f $work/old-apps.txt ]] || : >"$work/old-apps.txt"
+}
+
+# ---------------------------------------------------------------------------
+# Plan and execution
+# ---------------------------------------------------------------------------
+
+print_plan() {
+  heading "Live disk0 layout on $host"
+  printf '  %-9s %-22s %-24s %-38s %s\n' IDENT TYPE NAME "PARTITION UUID" BYTES
+  local identifier type name uuid size
+  while IFS=$'\t' read -r identifier type name uuid size; do
+    printf '  %-9s %-22s %-24s %-38s %s\n' \
+      "$identifier" "$type" "$name" "$uuid" "$size"
+  done <"$work/partitions.tsv"
+
+  heading "Protected — these are never touched"
+  local reason
+  while IFS= read -r uuid; do
+    [[ -n $uuid ]] || continue
+    printf '  %-9s %-22s %-24s %s\n' \
+      "$(partition_field "$uuid" 1)" \
+      "$(partition_field "$uuid" 2)" \
+      "$(partition_field "$uuid" 3)" \
+      "$uuid"
+  done <"$work/protected.txt"
+
+  heading "Deletion plan"
+  if [[ ! -s $work/targets.tsv ]]; then
+    echo "  No Omarchy partitions found. Nothing to erase."
+  else
+    local step=1
+    if [[ -s $work/container.tsv ]]; then
+      local ref cuuid store storeuuid names
+      while IFS=$'\t' read -r ref cuuid store storeuuid names; do
+        [[ -n $ref ]] || continue
+        echo "  $step. Delete the Omarchy APFS container $ref ($cuuid), physical store $store."
+        step=$((step + 1))
+      done <"$work/container.tsv"
+    fi
+    echo "  $step. Free each partition below BY UUID (identifiers shift as space is"
+    echo "     released, UUIDs do not — that is why UUIDs are used):"
+    while IFS=$'\t' read -r identifier type name uuid size reason; do
+      printf '     %-9s %-22s %-24s %-38s %-13s %s\n' \
+        "$identifier" "$type" "$name" "$uuid" "$size" "$reason"
+    done <"$work/targets.tsv"
+  fi
+
+  heading "macOS-side cleanup plan"
+  if [[ $skip_macos == "yes" ]]; then
+    echo "  skipped (--skip-macos-cleanup)"
+  else
+    local state size path
+    IFS=$'\t' read -r state size path <"$work/app-support.tsv"
+    if [[ $state == "present" ]]; then
+      echo "  Remove installer staging + scratch + state + handoff:"
+      echo "    $path (${size} KiB)"
+    else
+      echo "  Installer staging/state directory is already absent."
+    fi
+    if [[ -s $work/old-apps.txt ]]; then
+      echo "  Remove old installer copies:"
+      while IFS= read -r path; do
+        [[ -n $path ]] || continue
+        echo "    $path"
+      done <"$work/old-apps.txt"
+    else
+      echo "  No old installer copies found in /Applications or ~/Downloads."
+    fi
+  fi
+}
+
+erase_partitions() {
+  heading "Erasing Omarchy partitions"
+  if [[ ! -s $work/targets.tsv ]]; then
+    echo "  nothing to do"
+    return 0
+  fi
+
+  if [[ -s $work/container.tsv ]]; then
+    local ref cuuid store storeuuid names
+    while IFS=$'\t' read -r ref cuuid store storeuuid names; do
+      [[ -n $cuuid ]] || continue
+      remote_destructive delete-container \
+        "/usr/sbin/diskutil apfs deleteContainer $cuuid"
+      echo "  (container $ref addressed by its UUID $cuuid)"
+    done <"$work/container.tsv"
+  fi
+
+  local identifier type name uuid size reason recheck
+  while IFS=$'\t' read -r identifier type name uuid size reason; do
+    [[ -n $uuid ]] || continue
+    is_protected_uuid "$uuid" &&
+      die "refusing to erase $uuid: it is on the protected list"
+
+    # Re-read the partition immediately before erasing it. Identifiers move as
+    # space is released; the UUID must still name a non-protected partition.
+    # deleteContainer also removes its physical store partition from the
+    # partition map on current macOS, so a target that no longer exists is
+    # already freed — verified by asking, never assumed.
+    if [[ $confirm == "yes" ]]; then
+      if ! remote exists "/usr/sbin/diskutil info $uuid >/dev/null 2>&1"; then
+        echo "  already freed $reason (was $identifier; removed with its container)"
+        continue
+      fi
+      recheck=$(remote recheck "/usr/sbin/diskutil info $uuid | /usr/bin/awk '/Volume Name:/ { line = \$0; sub(/^ *Volume Name: */, \"\", line); print line }'")
+      if [[ -n $recheck && $recheck =~ $PROTECTED_NAME_PATTERN ]]; then
+        die "$uuid now reports volume name '$recheck' — refusing to erase it"
+      fi
+    fi
+
+    remote_destructive erase-volume \
+      "/usr/sbin/diskutil eraseVolume free none $uuid"
+    echo "  freed $reason (was $identifier, $name)"
+  done <"$work/targets.tsv"
+}
+
+clean_macos_state() {
+  heading "Clearing installer staging, state, and old copies"
+  local state size path
+  IFS=$'\t' read -r state size path <"$work/app-support.tsv"
+  if [[ $state == "present" ]]; then
+    remote_destructive clear-app-support \
+      "rm -rf \"\$HOME/Library/Application Support/$APP_SUPPORT_ID\""
+    echo "  cleared staging, scratch, state and handoff"
+  else
+    echo "  staging/state already absent"
+  fi
+
+  if [[ -s $work/old-apps.txt ]]; then
+    while IFS= read -r path; do
+      [[ -n $path ]] || continue
+      case $path in
+        */"$APP_BUNDLE_NAME"|*/Omarchy-MX-Mac-Installer-*.zip|*/__MACOSX) ;;
+        *) die "refusing to remove an unexpected path: $path" ;;
+      esac
+      # The installer package installs the app root-owned in /Applications;
+      # copies in the user's own folders stay a plain rm.
+      if [[ $path == /Applications/* ]]; then
+        remote_destructive remove-old-app "sudo -n rm -rf \"$path\""
+      else
+        remote_destructive remove-old-app "rm -rf \"$path\""
+      fi
+    done <"$work/old-apps.txt"
+  else
+    echo "  no old installer copies to remove"
+  fi
+
+  echo
+  echo "  NOT done here (owner step, needs sudo, changes system state):"
+  echo "    sudo launchctl bootout system/$APP_SUPPORT_ID.helper"
+  echo "    sudo rm -f /Library/LaunchDaemons/$APP_SUPPORT_ID.helper.plist"
+  echo "  A fresh notarized app re-registers its own helper on first launch;"
+  echo "  only unregister by hand if a stale registration blocks the run."
+}
+
+# ---------------------------------------------------------------------------
+
+main() {
+  while (( $# > 0 )); do
+    case $1 in
+      --confirm) confirm="yes"; shift ;;
+      --dry-run) dry_run="yes"; shift ;;
+      --host) host=${2:-}; shift 2 ;;
+      --skip-partitions) skip_partitions="yes"; shift ;;
+      --skip-macos-cleanup) skip_macos="yes"; shift ;;
+      -h|--help) usage ;;
+      *) echo "preclean-m1: unknown argument: $1" >&2; usage ;;
+    esac
+  done
+
+  [[ -n $host ]] || die "--host must not be empty"
+  if [[ $dry_run == "yes" && $confirm == "yes" ]]; then
+    die "--dry-run and --confirm are mutually exclusive"
+  fi
+  if [[ $skip_partitions == "yes" && $skip_macos == "yes" ]]; then
+    die "--skip-partitions and --skip-macos-cleanup together leave nothing to do"
+  fi
+
+  work=$(mktemp -d "${TMPDIR:-/private/tmp}/omarchy-preclean.XXXXXX") ||
+    die "cannot create a working directory"
+  chmod 0700 "$work"
+  trap cleanup EXIT
+
+  heading "Preflight"
+  if [[ -n ${OMARCHY_PRECLEAN_SSH_SHIM:-} ]]; then
+    note "SHIM MODE: using $OMARCHY_PRECLEAN_SSH_SHIM instead of ssh"
+  fi
+  verify_local_route
+  verify_identity
+
+  heading "Discovery (read-only)"
+  read_partitions
+  read_containers
+  identify_protected
+  if [[ $skip_partitions == "yes" ]]; then
+    : >"$work/targets.tsv"
+    : >"$work/container.tsv"
+    note "partition work skipped (--skip-partitions)"
+  else
+    identify_omarchy
+  fi
+  if [[ $skip_macos == "yes" ]]; then
+    printf 'absent\t0\t(skipped)\n' >"$work/app-support.tsv"
+    : >"$work/old-apps.txt"
+  else
+    read_macos_cleanup_candidates
+  fi
+
+  print_plan
+
+  if [[ $confirm != "yes" ]]; then
+    heading "DRY RUN — nothing was changed"
+    echo "  Re-run with --confirm to perform the plan above."
+    echo "  Commands that would run:"
+    if [[ $skip_partitions != "yes" ]]; then
+      erase_partitions
+    fi
+    if [[ $skip_macos != "yes" ]]; then
+      clean_macos_state
+    fi
+    echo
+    echo "result=dry-run"
+    echo "targets=$(grep -c '' "$work/targets.tsv" 2>/dev/null)"
+    exit 0
+  fi
+
+  heading "CONFIRMED — performing the plan"
+  if [[ $skip_partitions != "yes" ]]; then
+    erase_partitions
+  fi
+  if [[ $skip_macos != "yes" ]]; then
+    clean_macos_state
+  fi
+
+  heading "What was done"
+  echo "  host=$host"
+  echo "  destructive_commands_run=$actions_taken"
+  echo "  partitions_freed=$(grep -c '' "$work/targets.tsv" 2>/dev/null)"
+  echo "  protected_untouched=$(grep -c '' "$work/protected.txt" 2>/dev/null)"
+  echo
+  echo "  Verify with:"
+  echo "    ssh $host '/usr/sbin/diskutil list /dev/disk0'"
+  echo "    ssh $host '/usr/sbin/diskutil apfs list'"
+  echo "  macOS and Recovery must still be present with the same partition UUIDs"
+  echo "  listed under \"Protected\" above."
+  echo
+  echo "result=performed"
+}
+
+main "$@"

--- a/apps/omarchy-apple-installer/scripts/resign-engine-omarchy7.sh
+++ b/apps/omarchy-apple-installer/scripts/resign-engine-omarchy7.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Produce engine artifact v0.9.0-omarchy.7 from omarchy.6 for Apple notarization.
+#
+# Why: Apple notarization rejected the app because the PINNED engine tarball
+# bundles a Python runtime with broken/absent Developer ID signatures
+# (submission 0fa2c71b, 10 issues: Python dylib, libffi, Tk/Tcl, python.o).
+# This is an intentional, version-bumped engine re-release, not silent
+# tampering: every change is listed below, the new artifact gets a new name
+# and digest, and every pin (build-app.sh, ValidationEngineArtifact.swift,
+# catalog) is updated to match in tracked code.
+#
+# Changes to the engine contents:
+#   1. Remove Tk/Tcl frameworks, tkinter, idlelib, turtledemo, and the
+#      config-3.13-darwin static-linking objects — the console installer
+#      imports none of them, and they are exactly what Apple flagged.
+#   2. Re-sign every remaining Mach-O with the owner's Developer ID
+#      (hardened runtime + secure timestamp), which Apple requires.
+#   3. Repack as installer-v0.9.0-omarchy.7.tar.gz.
+set -euo pipefail
+
+IDENTITY="Developer ID Application: MARCELO DE BARROS ALCANTARA (T2C384FJBD)"
+SRC=/Users/maralc/dev/omarchy/omarchy-mx-mac-integration/apps/omarchy-apple-installer/Engine/artifacts/installer-v0.9.0-omarchy.6.tar.gz
+OUT_DIR=/private/tmp/engine-resign
+NEW_NAME=installer-v0.9.0-omarchy.7.tar.gz
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR/tree"
+cd "$OUT_DIR/tree"
+tar -xzf "$SRC"
+
+rm -rf \
+  Frameworks/Python.framework/Versions/3.13/Frameworks/Tk.framework \
+  Frameworks/Python.framework/Versions/3.13/Frameworks/Tcl.framework \
+  Frameworks/Python.framework/Versions/3.13/lib/python3.13/config-3.13-darwin \
+  Frameworks/Python.framework/Versions/3.13/lib/python3.13/tkinter \
+  Frameworks/Python.framework/Versions/3.13/lib/python3.13/idlelib \
+  Frameworks/Python.framework/Versions/3.13/lib/python3.13/turtledemo
+rm -f Frameworks/Python.framework/Versions/3.13/lib/python3.13/lib-dynload/_tkinter*.so
+echo "pruned unused GUI/static-link components"
+
+count=0
+while IFS= read -r -d '' f; do
+  if file -b "$f" 2>/dev/null | grep -q "Mach-O"; then
+    codesign --force --sign "$IDENTITY" --options runtime --timestamp "$f" 2>/dev/null
+    count=$((count + 1))
+  fi
+done < <(find . -type f \( -perm +111 -o -name "*.so" -o -name "*.dylib" -o -name "*.o" -o -name "*.a" \) -print0)
+echo "re-signed $count Mach-O files with Developer ID"
+
+echo "verifying a sample of signatures:"
+codesign --verify --strict Frameworks/Python.framework/Versions/3.13/bin/python3.13 && echo "  python3.13 OK"
+codesign --verify --strict Frameworks/Python.framework/Versions/3.13/Python && echo "  Python dylib OK"
+
+cd "$OUT_DIR"
+tar -czf "$NEW_NAME" -C tree .
+size=$(stat -f %z "$NEW_NAME")
+digest=$(shasum -a 256 "$NEW_NAME" | awk '{print $1}')
+echo "NEW ENGINE: $OUT_DIR/$NEW_NAME"
+echo "size_bytes: $size"
+echo "sha256: $digest"

--- a/apps/omarchy-apple-installer/scripts/tests/preclean-m1-test.sh
+++ b/apps/omarchy-apple-installer/scripts/tests/preclean-m1-test.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+# Tests for preclean-m1.sh using its OMARCHY_PRECLEAN_SSH_SHIM hook.
+# No ssh is run and no disk is touched: the shim feeds canned diskutil
+# output and records every destructive command the script asks for.
+#
+# Run: bash iteration2/test/preclean-m1-test.sh
+
+set -uo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+readonly PRECLEAN="$script_dir/../preclean-m1.sh"
+[[ -x $PRECLEAN || -f $PRECLEAN ]] || { echo "cannot find preclean-m1.sh" >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/preclean-test.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+current_test=""
+
+fail() {
+  echo "FAIL [$current_test] $*" >&2
+  failures=$((failures + 1))
+}
+
+assert_contains() {
+  local file=$1 needle=$2
+  grep -qF -- "$needle" "$file" || fail "expected to find: $needle (in $(basename "$file"))"
+}
+
+assert_not_contains() {
+  local file=$1 needle=$2
+  ! grep -qF -- "$needle" "$file" || fail "expected NOT to find: $needle (in $(basename "$file"))"
+}
+
+assert_line_count() {
+  local file=$1 pattern=$2 expected=$3 actual
+  actual=$(grep -cF -- "$pattern" "$file" 2>/dev/null)
+  [[ $actual == "$expected" ]] || fail "expected $expected lines matching '$pattern', got $actual"
+}
+
+# ---------------------------------------------------------------------------
+# Shim
+# ---------------------------------------------------------------------------
+
+cat >"$work/shim.sh" <<'SHIM'
+#!/bin/bash
+op=$1
+cmd=$2
+# Emulate ssh's default stdin behavior: consume whatever is on stdin. This is
+# what silently ate the erase loop's target list until ssh -n was added.
+[[ -t 0 ]] || cat >/dev/null
+case $op in
+  identity) printf 'mina\nMacBookPro18,3\n' ;;
+  partitions) cat "$SHIM_DATA_DIR/partitions.tsv" ;;
+  containers) cat "$SHIM_DATA_DIR/containers.tsv" ;;
+  app-support) printf 'present\t2048\t/Users/mina/Library/Application Support/com.omarchy.mx.installer\n' ;;
+  old-apps) printf '/Applications/Omarchy MX Mac Installer.app\n' ;;
+  recheck) printf '%s\n' "${SHIM_RECHECK_NAME:-}" ;;
+  exists)
+    for absent in ${SHIM_ABSENT_UUIDS:-}; do
+      [[ $cmd == *"$absent"* ]] && exit 1
+    done
+    exit 0
+    ;;
+  delete-container|erase-volume|clear-app-support|remove-old-app)
+    printf '%s\t%s\n' "$op" "$cmd" >>"$SHIM_LOG" ;;
+  *) echo "shim: unexpected operation '$op'" >&2; exit 97 ;;
+esac
+SHIM
+chmod +x "$work/shim.sh"
+
+# Layout mirroring the M1 with TWO Omarchy installs: macOS (disk0s2),
+# Recovery (disk0s7), ISC (disk0s1), and per install one APFS stub, one
+# "EFI - OMARC" ESP, and boot+root Linux partitions.
+write_two_install_layout() {
+  local dir=$1
+  mkdir -p "$dir"
+  printf '%s\n' \
+    $'disk0s1\tApple_APFS_ISC\tiSCPreboot\tUUID-ISC-0001\t524288000' \
+    $'disk0s2\tApple_APFS\t-\tUUID-MACOS-0002\t494384795648' \
+    $'disk0s3\tApple_APFS\t-\tUUID-STUB-0003\t2500000000' \
+    $'disk0s4\tMicrosoft Basic Data\tEFI - OMARC\tUUID-ESP-0004\t524288000' \
+    $'disk0s5\tLinux Filesystem\t-\tUUID-BOOT-0005\t1073741824' \
+    $'disk0s6\tLinux Filesystem\t-\tUUID-ROOT-0006\t50000000000' \
+    $'disk0s8\tApple_APFS\t-\tUUID-STUB-0008\t2500000000' \
+    $'disk0s9\tMicrosoft Basic Data\tEFI - OMARC\tUUID-ESP-0009\t524288000' \
+    $'disk0s10\tLinux Filesystem\t-\tUUID-BOOT-0010\t1073741824' \
+    $'disk0s11\tLinux Filesystem\t-\tUUID-ROOT-0011\t50000000000' \
+    $'disk0s7\tApple_APFS_Recovery\t-\tUUID-RECOV-0007\t5368664064' \
+    >"$dir/partitions.tsv"
+  printf '%s\n' \
+    $'disk3\tCUUID-MACOS\tdisk0s2\tUUID-MACOS-0002\tMacintosh HD,Macintosh HD - Data,Preboot,Recovery,VM,Update,xART' \
+    $'disk4\tCUUID-STUB-A\tdisk0s3\tUUID-STUB-0003\tOmarchy' \
+    $'disk5\tCUUID-STUB-B\tdisk0s8\tUUID-STUB-0008\tOmarchy' \
+    >"$dir/containers.tsv"
+}
+
+run_preclean() {
+  local data_dir=$1 log=$2
+  shift 2
+  SHIM_DATA_DIR="$data_dir" SHIM_LOG="$log" \
+    OMARCHY_PRECLEAN_SSH_SHIM="$work/shim.sh" \
+    bash "$PRECLEAN" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Dry run with two installs: full plan, nothing executed
+# ---------------------------------------------------------------------------
+
+current_test="dry-run-two-installs"
+data="$work/two"; write_two_install_layout "$data"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+run_preclean "$data" "$log" >"$out" 2>&1
+status=$?
+[[ $status == 0 ]] || fail "expected exit 0, got $status"
+assert_contains "$out" "found 2 Omarchy APFS container(s)"
+assert_contains "$out" "WOULD RUN: /usr/sbin/diskutil apfs deleteContainer CUUID-STUB-A"
+assert_contains "$out" "WOULD RUN: /usr/sbin/diskutil apfs deleteContainer CUUID-STUB-B"
+assert_contains "$out" "targets=8"
+assert_contains "$out" "result=dry-run"
+assert_contains "$out" "UUID-MACOS-0002"
+assert_contains "$out" "UUID-RECOV-0007"
+assert_not_contains "$out" "WOULD RUN: /usr/sbin/diskutil eraseVolume free none UUID-MACOS-0002"
+assert_not_contains "$out" "WOULD RUN: /usr/sbin/diskutil eraseVolume free none UUID-RECOV-0007"
+[[ ! -s $log ]] || fail "dry run executed destructive commands: $(cat "$log")"
+
+# ---------------------------------------------------------------------------
+# 2. Confirmed run with two installs: both containers and all 8 partitions
+# ---------------------------------------------------------------------------
+
+current_test="confirm-two-installs"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+run_preclean "$data" "$log" --confirm >"$out" 2>&1
+status=$?
+[[ $status == 0 ]] || fail "expected exit 0, got $status"
+assert_contains "$out" "result=performed"
+assert_contains "$out" "destructive_commands_run=12"
+assert_line_count "$log" "delete-container" 2
+assert_line_count "$log" "erase-volume" 8
+assert_line_count "$log" "clear-app-support" 1
+assert_line_count "$log" "remove-old-app" 1
+assert_contains "$log" "deleteContainer CUUID-STUB-A"
+assert_contains "$log" "deleteContainer CUUID-STUB-B"
+for uuid in UUID-STUB-0003 UUID-ESP-0004 UUID-BOOT-0005 UUID-ROOT-0006 \
+            UUID-STUB-0008 UUID-ESP-0009 UUID-BOOT-0010 UUID-ROOT-0011; do
+  assert_contains "$log" "eraseVolume free none $uuid"
+done
+assert_not_contains "$log" "UUID-MACOS-0002"
+assert_not_contains "$log" "UUID-RECOV-0007"
+assert_not_contains "$log" "UUID-ISC-0001"
+
+# ---------------------------------------------------------------------------
+# 2b. Stores already removed by deleteContainer are skipped, not failed
+# ---------------------------------------------------------------------------
+
+current_test="confirm-store-already-removed"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+SHIM_ABSENT_UUIDS="UUID-STUB-0003 UUID-STUB-0008" \
+  run_preclean "$data" "$log" --confirm >"$out" 2>&1
+status=$?
+[[ $status == 0 ]] || fail "expected exit 0, got $status"
+assert_contains "$out" "result=performed"
+assert_contains "$out" "already freed Omarchy APFS stub store"
+assert_line_count "$log" "delete-container" 2
+assert_line_count "$log" "erase-volume" 6
+assert_not_contains "$log" "UUID-STUB-0003"
+assert_not_contains "$log" "UUID-STUB-0008"
+assert_contains "$out" "destructive_commands_run=10"
+
+# ---------------------------------------------------------------------------
+# 3. A container holding both Omarchy and Macintosh HD: hard abort
+# ---------------------------------------------------------------------------
+
+current_test="conflicted-container-aborts"
+data="$work/conflicted"; write_two_install_layout "$data"
+printf '%s\n' \
+  $'disk3\tCUUID-WEIRD\tdisk0s2\tUUID-MACOS-0002\tMacintosh HD,Omarchy,Preboot' \
+  $'disk4\tCUUID-STUB-A\tdisk0s3\tUUID-STUB-0003\tOmarchy' \
+  >"$data/containers.tsv"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+run_preclean "$data" "$log" --confirm >"$out" 2>&1
+status=$?
+[[ $status != 0 ]] || fail "expected a hard abort, got exit 0"
+assert_contains "$out" "HARD ABORT"
+assert_contains "$out" "holds both"
+[[ ! -s $log ]] || fail "abort still executed destructive commands: $(cat "$log")"
+
+# ---------------------------------------------------------------------------
+# 4. Single install still works (regression)
+# ---------------------------------------------------------------------------
+
+current_test="single-install"
+data="$work/single"; write_two_install_layout "$data"
+grep -v -e UUID-STUB-0008 -e UUID-ESP-0009 -e UUID-BOOT-0010 -e UUID-ROOT-0011 \
+  "$work/two/partitions.tsv" >"$data/partitions.tsv"
+grep -v CUUID-STUB-B "$work/two/containers.tsv" >"$data/containers.tsv"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+run_preclean "$data" "$log" >"$out" 2>&1
+status=$?
+[[ $status == 0 ]] || fail "expected exit 0, got $status"
+assert_contains "$out" "found 1 Omarchy APFS container(s)"
+assert_contains "$out" "targets=4"
+
+# ---------------------------------------------------------------------------
+# 5. No Omarchy at all: empty plan
+# ---------------------------------------------------------------------------
+
+current_test="no-omarchy"
+data="$work/none"; write_two_install_layout "$data"
+grep -Ev 'UUID-(STUB|ESP|BOOT|ROOT)-' "$work/two/partitions.tsv" >"$data/partitions.tsv"
+grep -v CUUID-STUB "$work/two/containers.tsv" >"$data/containers.tsv"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+run_preclean "$data" "$log" >"$out" 2>&1
+status=$?
+[[ $status == 0 ]] || fail "expected exit 0, got $status"
+assert_contains "$out" "No Omarchy partitions found"
+assert_contains "$out" "targets=0"
+
+# ---------------------------------------------------------------------------
+# 6. Pre-erase recheck sees a protected name: abort before any eraseVolume
+# ---------------------------------------------------------------------------
+
+current_test="recheck-guard"
+data="$work/two"
+log="$work/log.$current_test"; : >"$log"
+out="$work/out.$current_test"
+SHIM_RECHECK_NAME="Macintosh HD" \
+  run_preclean "$data" "$log" --confirm >"$out" 2>&1
+status=$?
+[[ $status != 0 ]] || fail "expected a hard abort, got exit 0"
+assert_contains "$out" "refusing to erase it"
+assert_line_count "$log" "delete-container" 2
+assert_line_count "$log" "erase-volume" 0
+
+# ---------------------------------------------------------------------------
+
+echo
+if (( failures == 0 )); then
+  echo "preclean-m1-test: all tests passed"
+  exit 0
+fi
+echo "preclean-m1-test: $failures assertion(s) failed" >&2
+exit 1

--- a/docs/apple-silicon-cloud-distribution-design.md
+++ b/docs/apple-silicon-cloud-distribution-design.md
@@ -1,0 +1,67 @@
+# Design: Cloud Distribution Seam — Multi-Part Payload + Progress
+
+(Authoritative design produced 2026-08-31; implement faithfully.)
+
+## 1. Multi-part payload
+
+### 1.1 Catalog schema (schemaVersion stays 2/3; additive, optional)
+`payloadArtifact` gains optional `parts` array; whole-file digest+sizeBytes remain authoritative; when parts present the whole sourceURL is informational, never fetched. Part record: {sourceURL, fileName, sizeBytes, sha256 ("sha256:<64hex>")}.
+Validation (fail-closed): parts allowed ONLY on payloadArtifact (elsewhere -> SupportCatalogError.invalidField); count 2...16; each part same rules as PinnedInstallerArtifact (https, non-empty host, no user/password/fragment, safe fileName <=255B, valid prefixed digest, sizeBytes>0); part fileNames pairwise unique AND != whole fileName; overflow-checked sum of part sizes == whole sizeBytes, rejected at parse time.
+
+### 1.2 Swift types — Sources/OmarchyAppleInstaller/VerifiedArtifactStager.swift
+public struct PinnedArtifactPart: Equatable, Sendable { sourceURL, fileName, expectedDigest, expectedSizeBytes; throwing init with same guards }
+PinnedInstallerArtifact: add `public let parts: [PinnedArtifactPart]` with `parts: [PinnedArtifactPart] = []` default in init (source-compatible). Init guards when non-empty: (2...16).contains(count), unique names, none == fileName, overflow-safe sum == expectedSizeBytes.
+New ArtifactStageError cases: invalidPartCount(Int), invalidPartFileName(String), partSizeSumMismatch(expected: UInt64, actual: UInt64).
+New ArtifactMaterialization case: assembledFromParts.
+
+### 1.3 Stager algorithm
+stage(_:in:progress:) branches after destination-exists check:
+1. Whole file already staged -> verify -> reuse (unchanged); wrong bytes -> destinationConflict. On successful reuse best-effort delete leftover part files.
+2. parts.isEmpty -> existing single-download path byte-for-byte (engine/metadata/repair stay here).
+3. Parts present — sequential:
+   - Factor current download->promote(.pending-<uuid>)->verify->rename body into: private func stageSingle(url:fileName:expectedDigest:expectedSizeBytes:in:onBytes:) async throws -> (fileURL, materialization, reused)
+   - Each part staged at stagingDirectory/<part.fileName>. Existing valid part -> skip download; existing wrong bytes -> destinationConflict(part.fileName) hard fail.
+   - Assembly: stream-concat all parts into stagingDirectory/.pending-<uuid> in 1 MiB chunks feeding ONE running SHA256 + size counter (no re-read, no double memory): private func assemble(parts:into:expectedDigest:expectedSizeBytes:) throws. Mismatch -> digestMismatch/sizeMismatch, delete pending (defer), KEEP verified parts.
+   - Promotion: moveItem(pending -> destination) with existing lost-race fallback. Pending lives inside stagingDirectory -> always same-volume, no EXDEV. (EXDEV remains only inside per-part promote, already handled by AtomicArtifactFilePromoter copy fallback.)
+   - Cleanup: on success try? delete all part files; result materialization=.assembledFromParts, reusedExistingFile=false.
+Disk peak ~2x payload during assembly (documented). Parts give coarse resume for free.
+
+## 2. Progress reporting
+
+### 2.1 Downloader — same file
+typealias ArtifactByteProgressHandler = @Sendable (_ bytesReceived: UInt64) -> Void
+protocol ArtifactDownloading: Sendable { func download(from:expectedSizeBytes:onBytes:) async throws -> URL }
+final class ProgressReportingArtifactDownloader: NSObject, ArtifactDownloading, URLSessionDownloadDelegate, @unchecked Sendable
+- Ephemeral URLSession(configuration:.ephemeral, delegate:, delegateQueue:nil) per call; withCheckedThrowingContinuation; invalidate on completion.
+- didWriteData: report totalBytesWritten throttled (>=250ms or >=16MiB delta); ENFORCE size cap: totalBytesWritten > expectedSizeBytes -> cancel task, fail sizeMismatch.
+- didFinishDownloadingTo: synchronously move system temp file to downloader-owned temp path BEFORE resuming continuation (URLSession pitfall).
+- Non-2xx -> unexpectedHTTPStatus. No resume in v1 (future: resumeData/Range per part).
+
+### 2.2 Progress model + threading
+public struct ArtifactStagingProgress: Equatable, Sendable { enum Phase { downloading, assembling, verified }; role: String; fileName: String; phase; partIndex: Int?; partCount: Int?; bytesCompleted: UInt64; totalBytes: UInt64 }
+public typealias ArtifactStagingProgressHandler = @Sendable (ArtifactStagingProgress) -> Void
+Signature changes, all with `= nil` defaults so existing callers/tests compile:
+- VerifiedArtifactStager.stage(_:in:progress:)
+- InstallerAssetPreparer.prepare(_:progress:)  (passes handler to its four concurrent async-let stage calls; events disambiguated by role)
+- InstallerReleaseAssetCoordinator.prepare(_:progress:) and prepareRelease(_:progress:)
+For parts: bytesCompleted = sum(finished/reused part sizes) + current part onBytes value (monotonic per role; reused parts appear as jumps). Final .verified event per role.
+App consumption: @State stagingProgress: [String: ArtifactStagingProgress] keyed by role, main-actor hop in the closure.
+
+## 3. Generator — scripts/make-unsigned-catalog.py (durable home, from v7 candidate copy)
+argparse: --base-url (no trailing slash; GitHub release download base), --validity-days default 90, --output, --assets-dir. Parts emission: discover "<PAYLOAD_NAME>.partNN" beside payload (sorted zero-padded); >=2 -> emit parts array (sourceURL=f"{base}/{name}") with SELF-CHECK: sum sizes == whole size AND sha256 over parts concatenated == whole digest, abort otherwise; exactly 1 part file -> error; 0 -> single-URL unchanged. sequence=int(issued.timestamp()) unchanged. Splitting happens in publisher, not here.
+
+## 4. Publisher — scripts/publish-m1-release (new bash, house style: #!/bin/bash, 2-space, [[ ]]/(( )))
+Subcommand `prepare --payload <zip> --engine <tar.gz> --metadata <json> [--repair-manifest <f>] --tag <TAG> --repo <owner/repo> --out-dir dist/m1-release/<TAG>`:
+1 validate inputs; 2 payload > 1992294400 bytes -> split -b 1900m then RENAME to <name>.part00/.part01... (avoids BSD/GNU suffix differences); <=16 parts; 3 shasum -a 256 all assets -> SHA256SUMS; 4 emit release-urls.env (BASE_URL=https://github.com/<repo>/releases/download/<tag> + asset names); 5 idempotent: re-run compares bytes, differing -> hard error without --force.
+Subcommand `publish --dir <out-dir> --app <app zip> --tag <TAG> --repo <repo> --notes-file <md>`:
+1 preconditions: gh active login == maralcbr (gh api user --jq .login), tag pushed (git ls-remote --exact-match origin refs/tags/$tag), interactive owner confirmation; 2 release absent -> gh release create "$tag" --verify-tag --title ... --notes-file, then gh release upload per asset (parts, engine, metadata, optional repair manifest, app zip, SHA256SUMS); 3 release exists -> per-asset compare via gh api (size + digest where populated): match->skip, missing->upload, mismatch->HARD ERROR never --clobber; 4 print final URLs and verify == release-urls.env.
+Pipeline order: prepare -> make-unsigned-catalog (URLs deterministic pre-release) -> sign catalog -> build+sign app with sealed catalog -> notarize -> publish. Tag frozen once catalog signed.
+
+## 5. Tests — Tests/OmarchyAppleInstallerTrustCoreTests/VerifiedArtifactStagerTests.swift
+RoutedFixtureDownloader actor (responses: [URL: Data], downloadCount, requestedURLs; invokes onBytes).
+Descriptor: 1 part rejected invalidPartCount(1); 17 rejected; 2 and 16 accepted; dup name + name==whole -> invalidPartFileName; unsafe names rejected; sum mismatch -> partSizeSumMismatch pre-network.
+Stager: happy 2-part (bytes==concat, .assembledFromParts, downloadCount==2, only whole file remains, progress monotonic ending .verified at total); part digest mismatch (part00 kept, no destination, no pendings); whole-digest mismatch w/ valid parts (parts kept); whole reuse (2nd call reused, count unchanged); partial part reuse (count==1); conflicting existing part (destinationConflict, zero downloads); single-URL regression (existing tests unchanged); size-cap (overfeed -> sizeMismatch, nothing staged); single-file progress events.
+Catalog tests: v2 payloadArtifact parts decode into PinnedInstallerArtifact.parts; parts on engineArtifact -> invalidField; malformed parts -> invalidField. Preparer: prepare(_:progress:) forwards; default-nil compiles.
+
+## Risks
+Disk peak ~7GiB staging; MainActor flooding (mitigated by throttle); ArtifactMaterialization new case — audit exhaustive switches; URLSession temp lifetime; tag/asset immutability procedural (publisher never-clobber); BSD split suffixes (rename step). Future hardening: host allowlist pin to github.com.

--- a/docs/apple-silicon-hardware-validation.md
+++ b/docs/apple-silicon-hardware-validation.md
@@ -1,0 +1,96 @@
+# Apple Silicon Hardware Validation
+
+Use this checklist only on an Apple Silicon machine running Asahi Linux. Record
+results in `changelog.md`. Package/install validation in the generic VM must be
+complete first so hardware failures are not confused with missing software.
+
+## Current reference machine
+
+Omarchy is already running successfully on the maintainer's Apple MacBook Pro
+(14-inch, M1 Pro, 2021). On 2026-08-24, read-only checks captured its `aarch64`
+and Apple `j314s/t6000` identity, Asahi kernel and boot packages, Mesa stack,
+and signed local Omarchy release. The maintainer confirms that the normal
+desktop and hardware functions are working.
+
+This checklist is therefore an evidence-capture and regression template for
+the current M1 Pro and future models, not a gate on the statement that Omarchy
+works on the current machine. Detailed command output and artifacts should
+still be retained when convenient so later updates can be compared against a
+known-good baseline.
+
+## Safety boundary
+
+- Save active work and keep a local login available before network or suspend
+  tests. Do not run suspend validation through an SSH-only session.
+- Keep the machine on external power for update checks, but test battery state
+  reporting separately.
+- Start with read-only checks. Do not install, remove, or update packages merely
+  to make a check pass; record the observed failure first.
+- Capture the current kernel, release, package-source, and boot-file hashes
+  before any later update transaction.
+
+## Platform and release identity
+
+- Confirm `uname -m` reports `aarch64`.
+- Confirm `/proc/device-tree/compatible` identifies an Apple platform.
+- Record `uname -r`, the installed `linux-asahi`, `linux-asahi-headers`, and
+  `m1n1` versions, and `/var/lib/omarchy/asahi-quattro-release`.
+- Confirm the configured repositories include `asahi-alarm`, `core`, `extra`,
+  `alarm`, and `aur`.
+- Compare the installed database with every non-comment entry in
+  `install/omarchy-base-asahi.packages` and
+  `install/omarchy-asahi-source.packages`; record any missing package exactly.
+
+## Desktop and graphics
+
+- Reboot and confirm SDDM offers the remembered `omarchy` user and Omarchy
+  session, then complete an interactive login.
+- Confirm the desktop shell, launcher, terminal, notifications, and screen lock
+  render without software-rendering artifacts.
+- Record the OpenGL and Vulkan renderer/device summaries. Apple GPU acceleration
+  must be reported; `llvmpipe` or another software renderer is a failure.
+- Exercise an external display if available and record resolution, refresh
+  rate, scaling, hotplug, and resume behavior.
+
+## Networking
+
+- Confirm NetworkManager is active and reports the Wi-Fi device as managed.
+- Confirm NetworkManager uses the iwd backend.
+- Connect to a known Wi-Fi network, verify DNS and IPv4/IPv6 connectivity, then
+  disconnect and reconnect once.
+- Test Bluetooth discovery and one paired device if hardware is available.
+- After suspend/resume, repeat Wi-Fi connectivity and DNS checks.
+
+## Audio
+
+- Record the PipeWire/WirePlumber device and default-route summary.
+- Play audio through internal speakers and verify volume and mute controls.
+- Record from the internal microphone and play the sample back.
+- Test the headphone jack, Bluetooth audio, or HDMI audio when available; mark
+  unavailable paths as not tested rather than passed.
+- Repeat internal speaker and microphone checks after suspend/resume.
+
+## Power and suspend
+
+- Record battery/AC state and available power profiles.
+- From a local session, suspend once on AC and once on battery when safe.
+- Verify wake input, display restoration, keyboard/trackpad, Wi-Fi, audio,
+  brightness controls, and clock state after each resume.
+- Inspect the current-boot journal for suspend, firmware, GPU, audio, and network
+  errors and retain the relevant timestamps.
+
+## Update safety
+
+- Run the Apple Silicon bundle updater in check-only mode and record its exact
+  exit status and proposed release, if any.
+- Confirm no pending Omarchy migrations remain.
+- Record SHA-256 hashes for `/boot/vmlinuz-linux-asahi` and
+  `/boot/grub/grub.cfg` before a separately approved update test.
+- If an update is later approved, verify the signed release identity, reboot,
+  repeat this checklist, and explain every protected boot/package change.
+
+## Evidence record
+
+For each check, record the date, hardware model, pass/fail/not-tested state,
+command or interaction used, concise output, and artifact path. Never mark a
+hardware path passed from generic VM evidence.

--- a/docs/apple-silicon-integration-roadmap.md
+++ b/docs/apple-silicon-integration-roadmap.md
@@ -121,15 +121,25 @@ implementation.
 created and maintained according to Asahi’s distribution contract.
 
 **Outputs.** An installer-owned Apple backend; an Omarchy-branded Asahi bridge;
-safe space selection; preservation of APFS and the paired System ESP; firmware
-handoff; recovery behavior; and integration with the complete Apple boot chain.
+a signed and notarized macOS `Omarchy Installer.app` with a guided welcome,
+compatibility and storage checks, backup and partitioning explanations, and a
+clear handoff to the required RecoveryOS authorization; safe space selection;
+preservation of APFS and the paired System ESP; firmware handoff; recovery
+behavior; and integration with the complete Apple boot chain. The macOS app
+must use Asahi's supported bootstrap interfaces and verified Omarchy release
+assets. It is not a conventional ISO launcher, and must not imply that Apple's
+physical shutdown, Startup Options, or volume-owner authorization can be
+bypassed.
 
 **Dependencies.** Official ARM packages, generic ARM media, Asahi policy and
 installer interfaces, and explicit review of Apple boot semantics.
 
-**Evidence required to advance.** Repeatable install, reboot, recovery, and
-macOS-coexistence tests on named devices; proof that Asahi-created state is
-preserved; and failure-safe behavior for unsupported layouts.
+**Evidence required to advance.** Repeatable guided installs from the macOS app,
+including cancellation and resumption across the RecoveryOS handoff; repeatable
+reboot, recovery, and macOS-coexistence tests on named devices; proof that
+Asahi-created state is preserved; and failure-safe behavior for unsupported
+layouts. The app must verify the signed payload identity before installation
+and display the exact manual steps required after shutdown.
 
 **Exit gate.** The Apple path can install and recover without overwriting macOS,
 Asahi repositories, firmware, boot policy, or the paired System ESP.

--- a/docs/apple-silicon-local-plan.md
+++ b/docs/apple-silicon-local-plan.md
@@ -1,0 +1,186 @@
+# Apple Silicon Local Execution Plan
+
+Updated: 2026-08-24
+
+## Operating constraints
+
+- Work only on local, AI-tool-agnostic branches.
+- Do not push or create upstream pull requests.
+- Update this plan and `changelog.md` as work progresses and before handoff.
+- Preserve Asahi-owned kernel, GPU, firmware, and boot state.
+
+## Current objective
+
+Preserve the proven M1 Pro implementation, its reproducible clean-install path,
+and sufficient evidence to present the completed work without generalizing one
+validated model into an unsupported all-model claim.
+
+## Roadmap alignment
+
+This plan executes the existing
+[`apple-silicon-integration-roadmap.md`](apple-silicon-integration-roadmap.md);
+it does not replace it. A phase is complete only when its documented exit gate
+is met. Local prototype evidence may reduce a later phase's uncertainty without
+advancing the official phase sequence.
+
+- **Phase 1 — Runtime boundary: locally proven; promotion gate open.** The fork
+  contains the Apple predicate, pre-mutation safety guards, neutral portability
+  fixes, transaction checks, and package-input evidence. The formal gate remains
+  open because these behaviors have not been reclassified against current
+  upstream as an independently reviewable PR0–PR4 series. Under the current
+  operating constraint, prepare the evidence locally but do not open PRs.
+- **Phase 2 — Official ARM packages: local substitute proven; infrastructure
+  blocked.** The signed bundle, ten pinned source recipes, empty-cache install,
+  and 141/141 runtime closure prove the required transaction. They do not meet
+  the gate requiring an official Omarchy-owned, signed aarch64 repository that
+  installs and updates without the MX channel.
+- **Phase 3 — Generic ARM64 media: seam demonstrated; build gate open.** The
+  separate `omarchy-iso` reference branch proves a small architecture-target
+  seam, but a reproducible generic ARM64 artifact cannot meet its official gate
+  until Phase 2 provides the package feed.
+- **Phase 4 — Apple backend and Asahi bridge: operational prototype; formal
+  gate open.** The current installer, update protections, VM workflow, and
+  working M1 Pro demonstrate the vertical path. Repeatable physical install,
+  recovery, macOS-coexistence, and unsupported-layout evidence are still needed
+  after the generic package/media foundations exist.
+- **Phase 5 — Model-gated preview: one candidate model; not release-ready.** The
+  M1 Pro is the first named reference device. A formal subsystem record,
+  destructive-step allowlist guard, recovery result, support policy, and more
+  representative hardware are required before an official preview claim.
+- **Phase 6 — Standard signed channel: not started.** Migration remains gated on
+  a stable official package channel and a successful model-gated preview. The
+  local signed channel supplies migration fixtures, not the final destination.
+
+Two lanes can therefore proceed without breaking the fixed dependency order:
+
+1. **Promotion lane:** finish local Phase 1 evidence, define the Phase 2
+   publication decision, then resume generic Phase 3 media work only when an
+   official package feed exists.
+2. **Incubation lane:** continue collecting Phase 4–5 M1 Pro install, recovery,
+   update, and hardware evidence without representing those official gates as
+   complete.
+
+## Next three tracked milestones
+
+- [ ] Produce the local Phase 1 promotion dossier.
+  - Pin the current upstream and MX revisions.
+  - Map each PR0–PR4 behavior to its current upstream owner, local implementation,
+    focused tests, and remaining test gap.
+  - Re-run the unchanged x86-64 baseline plus Apple and generic-aarch64 fixtures.
+  - Exit: the proposed changes are independently reviewable locally, with no
+    upstream branch, push, or PR.
+- [ ] Produce the Phase 2 publication decision pack.
+  - Convert the proven package closure into an official-channel contract:
+    package owners, rebuild inputs, provenance, signing responsibility,
+    repository metadata, update behavior, and CI publication requirements.
+  - Separate the six mandatory binary outputs, ten source recipes, official
+    repository packages, and optional transactions.
+  - Exit: the infrastructure owner can make a go/no-go decision, and the
+    acceptance command is a cold install and update using no MX repository.
+- [ ] Complete the named M1 Pro Phase 4–5 evidence baseline in parallel.
+  - Capture the structured subsystem checklist from the working machine.
+  - Record boot-chain preservation, macOS coexistence, update, rollback, and
+    recovery evidence; schedule any destructive reinstall test only in an
+    explicitly approved hardware window.
+  - Exit: one versioned device record states what passed, what was not tested,
+    and which claims remain unsupported.
+
+## Tracked steps
+
+- [x] Inventory aarch64 package availability and dependency resolution.
+  - Evidence: `docs/aarch64-package-parity.{md,json}`.
+- [x] Provide and verify the signed six-package Apple Silicon release bundle.
+  - Evidence: fresh installer and bundle-update tests.
+- [x] Make the ten pinned source builds an explicit checked-in manifest.
+  - Evidence: commit `8f102e88`; focused Asahi package tests pass.
+- [x] Audit the disposable fresh-Asahi VM harness against the current installer.
+  - Docker and KVM are present; Docker access needs approval in this sandbox.
+  - The published bundle predates `omarchy-asahi-source.packages`, so the
+    current candidate cannot be meaningfully tested against that payload
+    without a local fixture adapter.
+- [x] Add deterministic candidate/payload preflight to the VM harness.
+  - Preserve verification of the published bundle unchanged, then supply the
+    current source manifest only to the explicitly marked local candidate.
+  - Focused syntax and package/installer tests pass.
+- [x] Run the fresh package transaction from an empty package cache.
+  - Record the bundle identity, pinned source revision, package failures, and
+    complete command result in `changelog.md`.
+  - Attempt 1 stopped before guest creation on a transient loop allocation
+    error after successfully verifying and caching the ARM rootfs. A direct
+    privileged-container reproduction attached the same sparse disk normally.
+  - Attempt 2 installed all 664 repository packages, then the host lost SSH
+    during post-transaction system reload hook 6/24. The harness destroyed the
+    container before bundle/source validation because it had no out-of-band
+    completion status.
+  - Final evidence: signed sequence 18 completed all repository, bundle, and
+    ten pinned-source transactions under the 3-GiB guest profile; reboot and
+    safe-rerun verification passed.
+- [x] Make the VM guest workflow survive expected network reloads.
+  - Run it as a system-managed detached job and persist its full log plus an
+    atomic exit-status file in the guest.
+  - Reconnect and poll the explicit result; never infer success from transport
+    loss.
+  - Evidence: focused shell syntax/package/installer tests and
+    `git diff --check` pass.
+  - The first supervised execution proved failure propagation and log
+    retention when a stale `.13` assertion rejected the newly published signed
+    `.14` stable descriptor.
+  - The sequence-18 retry survived the repository hooks and completed the
+    signed bundle, but the host OOM killer terminated the 8 GiB QEMU guest
+    before source builds. The harness now defaults to a configurable 4-vCPU,
+    5-GiB guest and detects dead/zombie QEMU processes during result polling.
+  - A 5-GiB retry built two source packages before another host OOM at
+    `localsend`. Defaults are now 2 vCPUs/3 GiB, and a host-backed pacman cache
+    avoids repeating verified package downloads across clean overlays.
+- [x] Capture and compare the installed explicit package set with
+  `install/omarchy-base-asahi.packages`.
+  - Fail on missing required packages; explain permitted provider substitutions
+    and protected Asahi packages.
+  - Evidence: 141/141 runtime entries and 10/10 source entries are present in
+    the retained 972-package database; both missing-package reports are empty.
+  - Pacman selected `ardour` for `lv2-host`, `jack2` for `jack`, and
+    `qt6-multimedia-ffmpeg` for the Qt media backend.
+- [x] Verify first-boot essentials in the disposable VM.
+  - Desktop/session, networking, audio, GPU acceleration, suspend boundary, and
+    update safety each need evidence or a documented environment limitation.
+  - SDDM rendered the Omarchy password greeter after reboot; remembered user
+    and session state, NetworkManager+iwd, migrations, protected boot hashes,
+    and updater state all passed automated verification.
+  - Physical Apple GPU, Wi-Fi/audio devices, and suspend cannot be represented
+    by this generic virtio VM; the running M1 Pro provides the real-hardware
+    proof for the current implementation.
+- [x] Validate the current physical Apple Silicon reference system.
+  - Apple MacBook Pro (14-inch, M1 Pro, 2021), `aarch64`, Apple `j314s/t6000`.
+  - The maintainer confirms that Omarchy and the normal desktop and hardware
+    functions are working on this machine.
+  - Read-only evidence captured the device, kernel, Asahi package, Mesa, and
+    installed signed-release identity.
+  - Detailed per-subsystem transcripts remain useful as a regression baseline,
+    but are not a blocker to the current M1 Pro validation claim.
+- [x] Prepare a DHH-facing presentation pack for the completed work.
+  - Updated the executive status brief to reflect the completed clean install.
+  - Added speaking notes, likely questions, bounded claims, and a technical
+    evidence appendix.
+  - Kept other-model validation and official-infrastructure work explicitly
+    outside the completed M1 Pro claim.
+  - Validation: all presentation-local links resolve and `git diff --check`
+    passes.
+
+## Known blockers and risks
+
+- Official Omarchy aarch64 repository endpoints are unavailable; the local
+  signed bundle is the current mandatory-package source.
+- Source recipes may fail because of upstream changes even when their names are
+  stable; builds are pinned so any failure is reproducible.
+- A generic virtual machine cannot validate Apple hardware behavior. VM results
+  cover package/install correctness; the current physical proof is limited to
+  the validated M1 Pro and must not be generalized to every Apple model.
+- The unrelated automatic-interface case in `network-qr-test.sh` currently
+  fails in this environment and is outside the package transaction scope.
+
+## Next action
+
+Start the local Phase 1 promotion dossier by freezing the current upstream/MX
+revisions and mapping PR0–PR4 behaviors to code and tests. In parallel, review
+the DHH presentation pack for tone and capture non-destructive structured M1
+Pro evidence when convenient. Do not push or open an upstream pull request.

--- a/docs/apple-silicon-work-changelog-2026-08.md
+++ b/docs/apple-silicon-work-changelog-2026-08.md
@@ -1,0 +1,223 @@
+# Work Changelog
+
+This is the chronological engineering record for local work. Read it before
+starting, append notes while work is active, and include validation evidence,
+decisions, blockers, commits, and the next action. Keep entries tool agnostic.
+
+## 2026-08-24
+
+### Active — Align local execution with the six-phase roadmap
+
+- Reviewed the existing six-phase integration roadmap, detailed Phase 1 plan,
+  current package-validation record, physical M1 Pro evidence, and the original
+  engineering brief.
+- Decision: retain the roadmap's fixed Phase 1–6 dependency order and describe
+  current results as local evidence, not official phase completion.
+- Classified the current state as: Phase 1 locally proven but not extracted
+  against current upstream; Phase 2 transaction proven through the local signed
+  channel but blocked on official publication; Phase 3 seam demonstrated but
+  blocked on the official feed; Phase 4 operational as an M1 Pro prototype;
+  Phase 5 limited to one candidate model; and Phase 6 not started.
+- Expanded `docs/apple-silicon-local-plan.md` with a promotion lane for Phases
+  1–3 and a parallel evidence-incubation lane for Phases 4–5. This preserves the
+  formal phase gates while allowing useful local validation to continue.
+- Added three executable milestones: a local Phase 1 promotion dossier, a Phase
+  2 publication decision pack, and a named M1 Pro Phase 4–5 evidence baseline.
+- Constraint: keep all work local; do not push, create upstream branches, or
+  open pull requests.
+- Next: freeze the current upstream/MX revisions and map every PR0–PR4 behavior
+  to its implementation, focused tests, and remaining evidence gap.
+
+### Active — Prepare Apple Silicon presentation material
+
+- Clarification: the current Omarchy instance is already running successfully
+  on physical Apple Silicon, so the presentation must treat the M1 Pro as the
+  primary real-hardware validation and the disposable VM as clean-install and
+  package-reproducibility evidence.
+- Captured read-only physical identity: Apple MacBook Pro (14-inch, M1 Pro,
+  2021), `aarch64`, Apple `j314s/t6000`, kernel `7.1.6-1-1-ARCH`,
+  `linux-asahi 7.1.6.asahi1-1`, `m1n1 1.5.2-1`, Mesa `26.1.7-1`, and local
+  signed release sequence 17 (`asahi-quattro-59c188fa`).
+- The maintainer confirms that Omarchy and the machine's normal desktop and
+  hardware functions are working. This validates the current M1 Pro; it does
+  not by itself establish support for every Apple Silicon model.
+- The read-only documentation environment could not access the live display or
+  D-Bus sockets, so detailed renderer, network, audio, and power transcripts
+  remain optional evidence-capture follow-up rather than reported failures.
+- Updated `docs/dhh-aarch64-status.md` from its pre-validation milestone state
+  into an executive progress brief reflecting the completed sequence-18 clean
+  install and its evidence boundary.
+- Added `docs/dhh-apple-silicon-speaking-notes.md` with a five-minute narrative,
+  likely questions, direct answers, and claims that must remain out of scope.
+- Added `docs/dhh-apple-silicon-evidence.md` with tested revisions, package and
+  installed-closure results, harness failure history, validation evidence, and
+  the remaining physical-hardware and official-product dependencies.
+- Decision: presentation claims distinguish the validated physical M1 Pro and
+  reproducible software/package path from untested Apple models. The material
+  does not imply an approved upstream PR, official ARM release, wholesale fork
+  merge, or all-model hardware support promise.
+- Validation: every local link in the three presentation files resolves and
+  `git diff --check` passes.
+- Next: review the presentation pack for tone, then capture additional
+  structured M1 Pro subsystem evidence when convenient and apply the checklist
+  to any additional model proposed for support.
+
+### Active — Establish durable work records and continue package validation
+
+- Decision: all Apple Silicon work remains on local branches. Do not push or
+  create upstream pull requests unless this policy is explicitly changed.
+- Added repository guidance requiring every activity and note to be recorded
+  here and requiring a live tracked plan with status and evidence.
+- Added `docs/apple-silicon-local-plan.md` as the active execution plan.
+- Audited all scripts invoked by `test/vm/asahi-fresh/run` and ran a host
+  preflight. Docker and `/dev/kvm` are present, but sandboxed Docker access
+  requires explicit approval.
+- Found a sequencing blocker before starting the VM: the candidate installer
+  reads `omarchy-asahi-source.packages` from the bundled `omarchy-dev` archive,
+  while the harness intentionally downloads the previous published bundle whose
+  archive predates that manifest. An unadapted run would fail before package
+  resolution and would not test the intended candidate/payload pair.
+- Decision: add an early, deterministic payload preflight and make the local VM
+  candidate fixture supply the current manifest without modifying or
+  misrepresenting the verified published assets.
+- Updated the fresh installer to validate both runtime and source manifests
+  before its first persistent mutation. The source manifest now travels as an
+  explicit file in the verified bundle directory rather than being assumed to
+  exist inside an older package archive.
+- Updated the VM harness to copy the current manifest into only the local
+  candidate payload after verifying the published assets unchanged, and to
+  record the adapter hashes in `vm-adapter.log`.
+- Validation: shell syntax, both focused Asahi package/installer tests, and
+  `git diff --check` pass.
+- First full VM attempt verified and cached the signed 790 MiB Arch Linux ARM
+  rootfs, then stopped during base-disk construction because `losetup` reported
+  no usable loop device. No guest was started and no install transaction ran.
+- Host diagnosis: the loop kernel module, `/dev/loop-control`, and loop block
+  devices exist. A disposable privileged container subsequently attached and
+  detached the same retained 96 GiB sparse raw test disk successfully using
+  `/dev/loop0`, so the failure was transient rather than a missing capability.
+- The retry built the base disk, verified release sequence 17
+  (`asahi-quattro-59c188fa`), and passed the lock, build-account, sudo-rule,
+  and package-checkout collision tests.
+- The real repository transaction resolved and installed 664 packages
+  (1177.33 MiB download, 4802.37 MiB installed). Pacman selected `ardour` for
+  `lv2-host`, `jack2` for `jack`, and `qt6-multimedia-ffmpeg` for the Qt media
+  backend.
+- Blocker: post-transaction hook 6/24 reloaded system services and reset the
+  guest network connection. The installation continued independently of
+  pacman's completed transaction, but the host harness interpreted the SSH
+  transport loss as an installer failure and destroyed the disposable
+  container before bundle and source-build validation could run.
+- Decision: launch the guest workflow as a system-managed detached job, write
+  its complete log and exit status atomically inside the guest, and have the
+  host reconnect and poll that explicit result. An SSH reset alone must be
+  neither success nor failure.
+- Implemented the reconnect-safe runner with a guest wrapper that atomically
+  publishes the real workflow exit status. The host also detects a failed
+  system service and retains the detached install log on either outcome.
+- Validation: runner, guest workflow, and wrapper syntax pass; both focused
+  Asahi package/installer tests and `git diff --check` pass.
+- The first supervised run correctly returned and retained an explicit nonzero
+  guest result. The signed stable channel had advanced from
+  `4.0.0-mac.13` to `4.0.0-mac.14`, while the test paired its mutable `latest`
+  URL with a hard-coded `.13` assertion. No package transaction started.
+- Decision: validate the signature, descriptor format, stable track, numeric
+  sequence, and source hash without pinning a mutable latest-release URL to a
+  single version. The installed-version reboot check remains bound to the
+  exact signed descriptor downloaded by that run.
+- The corrected sequence-18 run installed all 664 repository packages and the
+  complete signed nine-package bundle, including all package hooks. The host
+  kernel OOM killer then killed QEMU at 03:28:29 UTC with about 8.16 GiB guest
+  RSS on a 16 GiB, no-swap workstation. This occurred before the ten pinned
+  source builds and before the guest could record an exit status.
+- Offline, read-only recovery of the retained overlay confirmed the install log
+  ends after the signed bundle post-hooks. The guest journal contains no
+  shutdown, panic, or guest OOM event; host kernel logs explicitly identify
+  `qemu-system-aarch64` as the killed process.
+- Decision: lower the disposable default to 4 vCPUs and 5 GiB RAM, keep both
+  values overridable, periodically retain the guest log, and fail promptly if
+  QEMU exits or becomes a zombie while SSH is unavailable.
+- The 5 GiB run completed the repository and signed-bundle transactions, then
+  successfully built `aether` and `cliamp`. While resolving `localsend` build
+  dependencies, the host OOM killer again selected QEMU at about 5.17 GiB RSS;
+  the new liveness check failed promptly and the periodic log snapshot retained
+  the exact boundary.
+- Decision: use 2 vCPUs and 3 GiB by default to reduce both resident guest
+  memory and build parallelism. Expose the VM's host-backed pacman cache through
+  virtio 9p so clean-overlay retries reuse packages while pacman still verifies
+  their integrity and signatures.
+- Recovered 1,600 pacman cache files (1.8 GiB) read-only from the retained
+  failed overlay. The temporary raw conversion used for recovery was deleted;
+  the original qcow2 and periodic install log remain as evidence.
+- The 3 GiB cached run completed successfully against signed package release
+  sequence 18 (`asahi-quattro-5318aed5`, Omarchy source
+  `5318aed577928f6fc228d80d3c6893ce81281c1f`, package source
+  `2f683cb2d5384eea001f005e77b15b605fd1002d`).
+- Result: all 664 repository packages, the signed nine-package transaction,
+  and all ten pinned source packages installed. The direct Omarchy 4 reboot
+  verification passed, protected Asahi packages and boot files remained
+  unchanged, no migrations were pending, the updater accepted the installed
+  release state, and the completed rerun was rejected without state changes.
+- Exact installed-database audit: 972 total packages were installed; all 141
+  explicit entries from `omarchy-base-asahi.packages` and all ten entries from
+  `omarchy-asahi-source.packages` are present. Retained missing-package reports
+  are empty.
+- Visual evidence: the retained 1280x800 desktop frame renders the Omarchy SDDM
+  password greeter after reboot. Automated checks also prove the remembered
+  `omarchy` user/session, NetworkManager with iwd, and enabled SDDM.
+- Environment boundary: the generic virtio VM cannot prove Apple GPU, physical
+  Wi-Fi/audio, or suspend behavior. Those remain explicit hardware-validation
+  items rather than package blockers.
+- Local commit: `cbc62158 Harden fresh Asahi package validation`. It contains
+  the installer preflight, candidate adapter, detached/reconnect-safe runner,
+  QEMU liveness checks, conservative configurable resources, retained pacman
+  cache, documentation, and focused tests. It was not pushed.
+- Added `docs/apple-silicon-hardware-validation.md` as the next-stage physical
+  test checklist. It separates read-only identity/package evidence from local
+  interactive graphics, Wi-Fi, audio, suspend, and update-safety checks and
+  forbids treating generic VM evidence as a hardware pass.
+- Local records commit subject: `Record Apple Silicon validation work`. Do not
+  push it.
+- Final validation: shell syntax, focused Asahi package and fresh-installer
+  tests, the complete CLI suite, and `git diff --check` pass. The CLI suite
+  emitted its existing headless read-only `/run/user/1001` theme-lock warning
+  but completed successfully.
+- Next: commit the durable records locally, then execute the checklist on
+  physical Apple Silicon hardware when a safe local test window is available.
+  Do not open an upstream pull request.
+
+### Completed — Make the Asahi source package boundary explicit
+
+- Commit: `8f102e88 Make Asahi source package boundary explicit`.
+- Moved the ten packages built from pinned `omarchy-pkgs` recipes out of a
+  hard-coded installer array and into `install/omarchy-asahi-source.packages`.
+- Updated the fresh installer to read the manifest from the verified Omarchy
+  package archive and fail if it is missing or empty.
+- Added tests proving the source set is exact, duplicate-free, and contained in
+  the Apple Silicon runtime closure.
+- Validation: installer syntax, focused Asahi shell tests, checkout-dependent
+  package-ownership tests, and `git diff --check` passed.
+- Known unrelated issue: `test/shell.d/network-qr-test.sh` fails when its
+  automatic interface case receives no output; explicit-interface cases pass.
+
+### Completed — Package parity research and repository conventions
+
+- Commit: `5e3d1d92 Document Omarchy aarch64 package parity`.
+- Recorded 450 direct inputs: 323 available in tested ARM repositories, 322
+  dependency-resolving, with 354 GREEN, 92 YELLOW, and four RED mandatory
+  official Omarchy artifacts.
+- Confirmed the current local Apple Silicon path uses a signed six-package
+  bundle to supply the mandatory runtime while official aarch64 repository
+  endpoints remain unavailable.
+- Commit: `8e1bcc64 Require tool-agnostic branch names`.
+- Renamed the working branch to `aarch64-package-parity` and the local ISO
+  reference branch to `aarch64-target-config`.
+- Added the rule that branch names must never use an AI tool or agent name.
+
+### Completed — Local architecture target reference
+
+- Local `omarchy-iso` commit: `85d0bb4 Add explicit ISO architecture target`.
+- Added an explicit architecture target, profile propagation, matching artifact
+  selection, and early rejection of unsupported targets while preserving x86
+  defaults.
+- This branch is reference-only and will not be pushed upstream.

--- a/docs/dhh-aarch64-status.md
+++ b/docs/dhh-aarch64-status.md
@@ -1,0 +1,145 @@
+# Omarchy on Apple Silicon: progress brief
+
+Prepared: 2026-08-24
+
+## The headline
+
+Omarchy is already running successfully on a physical 14-inch M1 Pro MacBook
+Pro as the maintainer's working system.
+
+The physical machine proves the real Apple Silicon experience. A separate clean
+disposable aarch64 installation proves that the package and installation path
+is reproducible. Together, these move the work beyond feasibility: the product
+runs on real M1 Pro hardware and its software transaction completes from a
+clean state.
+
+## Physical M1 Pro validation
+
+The current system reports:
+
+- Apple MacBook Pro (14-inch, M1 Pro, 2021)
+- `aarch64`
+- Apple device-tree identifiers `apple,j314s` and `apple,t6000`
+- `linux-asahi 7.1.6.asahi1-1`
+- `m1n1 1.5.2-1`
+- Mesa `26.1.7-1`
+- Signed local Omarchy release sequence 17, `asahi-quattro-59c188fa`
+
+The maintainer confirms that Omarchy and the machine's normal desktop and
+hardware functions are working. This is sufficient to validate the claim that
+Omarchy works on this M1 Pro. Broader support across other Apple models remains
+a separate product and test-matrix question.
+
+## What is complete
+
+### Package feasibility is measured, not estimated
+
+- Traced 450 direct inputs across Omarchy, `omarchy-iso`, optional installs,
+  package recipes, and the Apple Silicon reference manifests.
+- Found 323 inputs in the tested Arch Linux ARM and Asahi indexes; 322 resolve
+  with their complete dependency closure.
+- Classified 354 inputs as usable as-is or correctly excluded from ARM.
+- Identified the real official-distribution blocker: the official Omarchy
+  aarch64 repository endpoints do not exist. The four mandatory official
+  packages therefore have no official aarch64 source today.
+- Separated genuine blockers from x86-only hardware packages and optional
+  applications that do not determine whether the desktop can run.
+
+### The local Apple Silicon install path is deterministic
+
+- The runtime manifest contains 141 explicit packages.
+- Ten source-built packages now live in a checked-in manifest rather than a
+  hard-coded installer array.
+- Source builds use a pinned `omarchy-pkgs` revision so upstream recipe changes
+  cannot silently alter a validation run.
+- Release artifacts are signature-verified before use.
+- The installer validates its runtime and source manifests before its first
+  persistent mutation.
+- Asahi-owned kernel, GPU, firmware, repository, and boot state remain outside
+  Omarchy's ownership boundary.
+
+### A reproducible fresh installation completed end to end
+
+The separate disposable-VM run used signed release sequence 18,
+`4.0.0-mac.14`:
+
+- 664 repository packages installed.
+- The complete signed nine-package release transaction installed.
+- All ten pinned source packages built and installed.
+- The final package database contained 972 packages.
+- All 141 runtime-manifest entries and all ten source-manifest entries were
+  present; both missing-package reports were empty.
+- Reboot verification, migrations, updater state, protected-package checks,
+  protected boot-file hashes, and safe rerun behavior passed.
+- SDDM rendered the Omarchy password greeter after reboot and retained the
+  expected user and session.
+
+### The validation harness now survives realistic failures
+
+The first runs exposed issues in the test environment rather than package
+closure: network reloads broke SSH supervision, and larger QEMU guests caused
+host out-of-memory kills. The harness was hardened to:
+
+- run the guest workflow as a detached system-managed job;
+- persist the full log and an atomic exit status in the guest;
+- reconnect after expected network reloads;
+- detect dead or zombie QEMU processes;
+- use a conservative 2-vCPU, 3-GiB default;
+- retain a host-backed package cache while still verifying package integrity.
+
+Those changes turned a fragile smoke test into a repeatable failure-reporting
+and validation workflow.
+
+## What this means
+
+The core Omarchy desktop is not the architectural problem. Most of it already
+resolves on ARM. The remaining work divides cleanly into three different
+ownership areas:
+
+1. **Current Apple Silicon product:** preserve and regression-test the working
+   M1 Pro experience.
+2. **Official ARM distribution:** choose an ARM base, publish and sign the
+   mandatory Omarchy aarch64 packages, and define the supported application
+   set.
+3. **Installation media and Apple boot integration:** finish generic ARM media
+   first, then integrate with the boot environment owned by Asahi rather than
+   recreating it inside Omarchy.
+
+The fork demonstrates a working product path. It should be used as an evidence
+and test source, not merged wholesale into Basecamp Omarchy.
+
+## What remains outside the current proof
+
+- Repeatable validation across other Apple Silicon models and SoC generations.
+- A structured evidence capture for each physical subsystem on the current M1
+  Pro; the system is working, but not every observation has a retained command
+  transcript or artifact yet.
+- Installation and recovery across supported Apple models.
+- An official signed Omarchy aarch64 repository and release channel.
+- A generic ARM64 installer artifact built by official infrastructure.
+- A product decision on whether ARM must reproduce every x86 preinstalled app
+  or may use an explicit supported subset.
+
+## Recommended next move
+
+Treat the current M1 Pro as the first validated reference machine. Capture its
+working state with the checked-in hardware checklist so the existing success is
+auditable and repeatable, not because hardware functionality is still blocking
+the central claim.
+
+In parallel, decide whether the goal is:
+
+- a maintained local Apple Silicon edition using the current signed bundle; or
+- an official Omarchy ARM product, which requires repository, signing, media,
+  application-parity, and support-policy commitments.
+
+No upstream pull request or push is part of the current work policy.
+
+## Supporting material
+
+- [Presentation speaking notes](dhh-apple-silicon-speaking-notes.md)
+- [Validation evidence appendix](dhh-apple-silicon-evidence.md)
+- [Package parity report](aarch64-package-parity.md)
+- [Machine-readable package matrix](aarch64-package-parity.json)
+- [Physical hardware checklist](apple-silicon-hardware-validation.md)
+- [Tracked local execution plan](apple-silicon-local-plan.md)

--- a/docs/dhh-apple-silicon-evidence.md
+++ b/docs/dhh-apple-silicon-evidence.md
@@ -1,0 +1,186 @@
+# Apple Silicon validation evidence appendix
+
+Evidence snapshot: 2026-08-24
+
+This appendix supports the claims in
+[`dhh-aarch64-status.md`](dhh-aarch64-status.md). It distinguishes completed
+proof on the current physical M1 Pro, reproducible VM proof, and work that
+would be required for broader model or official-product support.
+
+## Physical M1 Pro reference system
+
+Read-only identity captured on 2026-08-24:
+
+- Model: Apple MacBook Pro (14-inch, M1 Pro, 2021)
+- Architecture: `aarch64`
+- Device tree: `apple,j314s`, `apple,t6000`, `apple,arm-platform`
+- Kernel: `7.1.6-1-1-ARCH`
+- `linux-asahi`: `7.1.6.asahi1-1`
+- `linux-asahi-headers`: `7.1.6.asahi1-1`
+- `m1n1`: `1.5.2-1`
+- Mesa: `26.1.7-1`
+- Installed local release sequence: 17
+- Installed release tag: `asahi-quattro-59c188fa`
+- Installed source revision:
+  `59c188fa9cc70afed21344074d49d7ff6f2ea802`
+
+The maintainer confirms that this is the current running Omarchy system and
+that its normal desktop and hardware functions are working. This is the
+physical validation for the current M1 Pro implementation.
+
+The read-only command environment used while preparing this appendix could
+read kernel, device-tree, package, and release identity. Its sandbox could not
+connect to the live display or D-Bus sockets, so renderer, NetworkManager,
+PipeWire, and power-service transcripts were not captured in that pass. That is
+an evidence-retention limitation, not a reported failure of the running system.
+
+## Revisions under test
+
+- Signed local release: sequence 18, `asahi-quattro-5318aed5`
+- Omarchy version: `4.0.0-mac.14`
+- Omarchy source:
+  `5318aed577928f6fc228d80d3c6893ce81281c1f`
+- Package-recipe source:
+  `2f683cb2d5384eea001f005e77b15b605fd1002d`
+- Current local validation records: `e986dd06`
+- Fresh-install hardening: `cbc62158`
+- Explicit source-package boundary: `8f102e88`
+- Package-parity research: `5e3d1d92`
+- Reference `omarchy-iso` architecture seam: `85d0bb4` on the separate local
+  `aarch64-target-config` branch
+
+## Package research evidence
+
+The package inventory traces 450 direct inputs from the current Omarchy
+runtime, current ISO inputs, optional transactions, package recipes, and the
+Apple Silicon reference manifests.
+
+- 323 lead packages are present in the tested Arch Linux ARM and Asahi indexes.
+- 322 lead packages resolve with their dependency closure.
+- 354 inputs are usable as-is or correctly excluded as architecture-specific.
+- Four mandatory official packages lack an official aarch64 repository source:
+  `omarchy`, `omarchy-settings`, `omarchy-keyring`, and `omarchy-nvim`.
+- One dependency trap was confirmed: `winetricks` is present, but its
+  transaction cannot resolve because `wine` is absent.
+
+Canonical artifacts:
+
+- [`aarch64-package-parity.md`](aarch64-package-parity.md)
+- [`aarch64-package-parity.json`](aarch64-package-parity.json)
+
+## Fresh-install transaction evidence
+
+The successful run started with a clean overlay and an empty guest package
+state. A host-backed cache reused downloads from earlier attempts, but pacman
+still verified integrity and signatures before installation.
+
+Completed transaction:
+
+- 664 repository packages installed.
+- All nine packages in the signed release transaction installed.
+- All ten packages in `install/omarchy-asahi-source.packages` built from the
+  pinned recipe revision and installed.
+- 972 packages were present in the final package database.
+- Every one of the 141 explicit runtime entries was installed.
+- Every one of the ten explicit source entries was installed.
+- Runtime and source missing-package reports were empty.
+
+Provider choices recorded by pacman:
+
+- `ardour` provided `lv2-host`.
+- `jack2` provided `jack`.
+- `qt6-multimedia-ffmpeg` provided the Qt media backend.
+
+## Reboot and state evidence
+
+After the completed installation:
+
+- SDDM rendered the Omarchy password greeter at 1280x800.
+- The expected `omarchy` user and session were remembered.
+- NetworkManager with the iwd backend was enabled.
+- No Omarchy migrations remained pending.
+- The updater accepted the installed signed release state.
+- Protected Asahi package versions and boot-file hashes were unchanged.
+- Re-running the completed installer was rejected without state changes.
+
+These checks establish reproducible installation and correct installed state in
+a generic aarch64 VM. Physical behavior is established separately by the
+working M1 Pro reference machine above.
+
+## Harness reliability evidence
+
+Three failure boundaries were captured before the successful run:
+
+1. A transient loop-device allocation error stopped before guest creation.
+2. A repository hook reloaded services and interrupted SSH after the repository
+   transaction, revealing that transport status was not workflow status.
+3. QEMU guests configured with 8 GiB and then 5 GiB were killed by host memory
+   pressure during later stages.
+
+The resulting controls are checked into the harness:
+
+- detached, system-managed guest execution;
+- complete persistent guest log;
+- atomic guest exit-status file;
+- reconnect and explicit-result polling;
+- QEMU dead/zombie detection;
+- periodic log retention;
+- configurable resources with 2 vCPUs and 3 GiB as defaults;
+- host-backed verified pacman cache.
+
+The final run completed under the 3-GiB profile.
+
+## Automated validation
+
+Recorded passing checks include:
+
+- Bash syntax for the installer and VM workflow scripts.
+- Focused Asahi package tests.
+- Focused fresh-installer tests.
+- The complete CLI test suite.
+- `git diff --check`.
+
+The CLI suite emitted an existing headless read-only warning for the
+`/run/user/1001` theme lock and still completed successfully.
+
+An unrelated automatic-interface case in `network-qr-test.sh` fails in this
+environment. Explicit-interface cases pass. This issue is outside the Apple
+Silicon package transaction and is not counted as a package blocker.
+
+## Evidence still worth retaining
+
+The M1 Pro system is working. The following detailed transcripts and artifacts
+should still be captured so that success can be repeated and compared over
+time:
+
+- A renderer transcript documenting the working Apple GPU acceleration.
+- Display summaries documenting scaling, hotplug, and resume behavior.
+- Network transcripts documenting Wi-Fi, DNS, IPv4/IPv6, reconnection, and
+  Bluetooth.
+- PipeWire/WirePlumber summaries documenting working speakers, microphone, and
+  available external audio paths.
+- Timestamped suspend/resume records on AC and battery.
+- Post-resume records for graphics, input, network, audio, brightness, and
+  clock behavior.
+- Installation, recovery, and macOS-coexistence evidence for any additional
+  model proposed for support.
+
+Use [`apple-silicon-hardware-validation.md`](apple-silicon-hardware-validation.md)
+for this evidence. The current M1 Pro is the physical reference; the generic VM
+must remain package/install evidence only.
+
+## Official product dependencies
+
+The local signed-bundle path is proven, but an official Omarchy ARM product
+would additionally require:
+
+- official aarch64 package repository ownership, publication, and signing;
+- a supported generic ARM base environment;
+- an official generic ARM media build and boot pipeline;
+- an explicit mandatory and optional application policy;
+- an Apple installation bridge that preserves Asahi's ownership boundary;
+- named device validation and a support policy;
+- a migration and release-channel strategy for existing local installations.
+
+None of those official-product dependencies is represented as approved or
+complete by the local validation work.

--- a/docs/dhh-apple-silicon-speaking-notes.md
+++ b/docs/dhh-apple-silicon-speaking-notes.md
@@ -1,0 +1,150 @@
+# Apple Silicon presentation speaking notes
+
+Prepared: 2026-08-24
+
+## Suggested opening
+
+“Omarchy is not merely a package experiment on Apple Silicon. It is already
+running as a working system on a physical 14-inch M1 Pro MacBook Pro. We also
+completed a clean disposable installation, so we have both real-hardware proof
+and reproducible package proof. The remaining question is how far we want to
+turn that success into an official ARM product.”
+
+## Five-minute walkthrough
+
+### 1. Start with the real machine
+
+The current machine is a 14-inch 2021 MacBook Pro with an M1 Pro. It runs the
+Asahi kernel and boot stack with the local signed Omarchy release. The
+maintainer uses the system and confirms that Omarchy and its normal hardware
+functions are working.
+
+That validates the central statement: Omarchy works on this Apple Silicon Mac.
+
+### 2. Add the reproducibility proof
+
+The clean disposable validation run installed the repository-backed runtime,
+the signed Omarchy release, and all pinned source packages. It rebooted to the
+Omarchy login screen and passed package-closure, protected-state, migration,
+updater, and rerun checks.
+
+Use these numbers:
+
+- 664 repository packages
+- 9 signed release packages
+- 10 pinned source-built packages
+- 972 installed packages in total
+- 141 of 141 runtime requirements present
+- 10 of 10 source requirements present
+
+The simple conclusion is: the software package path works end to end.
+
+### 3. Explain what was learned
+
+The original package inventory looked larger and more alarming than the real
+problem. It mixed core runtime requirements with x86-only kernels, microcode,
+GPU drivers, PC boot tooling, optional applications, and live-media packages.
+
+After tracing 450 direct inputs and resolving their dependency transactions,
+the core desktop stack proved healthy on ARM. The official blocker is narrower:
+Omarchy does not currently publish its mandatory packages through an official
+aarch64 repository.
+
+The Apple platform must also stay distinct from generic ARM. Generic aarch64
+can use an ARM kernel and UEFI media; Apple Silicon must retain Asahi's kernel,
+GPU, firmware, device-tree, and boot ownership.
+
+### 4. Show the engineering quality of the proof
+
+This is more than “it booted once.” The installer now has explicit runtime and
+source manifests, pinned inputs, signature verification, pre-mutation checks,
+and exact installed-package auditing.
+
+The disposable VM workflow survived repository hooks that reload networking.
+It records its real result independently of SSH, retains logs on failure, and
+runs within a conservative memory profile. Earlier failures were preserved and
+used to improve the harness rather than being hidden.
+
+### 5. State the boundary honestly
+
+The current M1 Pro proves a working physical implementation. The VM separately
+proves package and installation correctness. Neither result alone establishes
+support for every M1, M2, M3, or M4 model.
+
+The physical-hardware checklist should now capture the already-working M1 Pro
+state as durable evidence and become the template for testing additional
+models. It is no longer a blocker to saying the current machine works.
+
+### 6. End on the decision
+
+There are two viable directions:
+
+1. Keep improving a maintained local Apple Silicon edition using the existing
+   signed-bundle path.
+2. Treat ARM as an official Omarchy product, which requires ownership of ARM
+   repository publication, signing, generic ARM media, application policy, and
+   hardware support boundaries.
+
+The technical work supports either direction. The next strategic decision is
+which product commitment is intended.
+
+## Likely questions
+
+### “Does Omarchy work on an Apple Silicon Mac now?”
+
+Yes. It is running on a physical 14-inch M1 Pro MacBook Pro and the maintainer
+confirms the system works. The clean disposable installation independently
+proves that the package path is reproducible. What we are not claiming is
+automatic support for every Apple Silicon model.
+
+### “Why not just merge the fork?”
+
+The fork contains useful working behavior, but it also owns local release,
+package, and Apple-specific integration choices. The safer architecture is to
+use it as evidence, extract coherent behavior at current code boundaries, and
+keep Asahi-owned platform state outside Omarchy.
+
+### “What is actually blocking an official release?”
+
+Official aarch64 repository publication and signing, a supported ARM base and
+generic ARM media pipeline, a multi-model support policy, and a decision about
+the supported application set. The desktop and this M1 Pro implementation are
+not the main blockers.
+
+### “Do all x86 applications need to be ported first?”
+
+No, not for a usable desktop. Some optional or preinstalled applications lack
+ready ARM packages. Product policy must decide whether identical app parity is
+required or whether ARM ships an explicit supported subset.
+
+### “Are we replacing Asahi?”
+
+No. Asahi remains the owner of the Apple kernel, GPU stack, firmware, device
+trees, and boot environment. Omarchy should own the desktop payload and its
+release behavior above that boundary.
+
+### “What failed during testing?”
+
+One run lost SSH while package hooks reloaded networking. Two larger QEMU runs
+were killed by host memory pressure. These failures produced durable fixes:
+out-of-band completion status, reconnect-safe supervision, QEMU liveness
+checks, lower resource defaults, retained logs, and a verified package cache.
+The final 3-GiB run completed.
+
+### “What happens next?”
+
+Capture the working M1 Pro state in the physical evidence checklist, use that
+record as the baseline for future regressions and other models, and decide
+whether official ARM distribution is a product goal. The current branch
+remains local; no upstream PR is planned.
+
+## Claims to avoid
+
+- Do say Omarchy is working on the validated M1 Pro reference machine.
+- Do not generalize one M1 Pro result to every Apple Silicon model.
+- Do not use the VM as physical-device evidence; the real M1 Pro is that
+  evidence.
+- Do not say official Omarchy aarch64 repositories exist.
+- Do not imply the fork will be merged wholesale.
+- Do not promise every optional x86 application on ARM.
+- Do not present an upstream PR or release schedule as approved.

--- a/docs/file-layout.md
+++ b/docs/file-layout.md
@@ -26,6 +26,28 @@ Two other packages live in `omarchy-pkgs/` but stand alone:
 `omarchy-keyring` (GPG keys for pacman) and `omarchy-nvim` (the Neovim
 setup; independently seeds `/etc/skel`).
 
+## Fork-only areas
+
+These directories exist only in the Mac fork and are not built into either
+Arch package. Keep new Mac-only material inside them so upstream-bound
+changes stay cleanly separable (see
+`.opencode/skills/update-omarchy-quattro/SKILL.md` for the upstream-merge
+runbook):
+
+- **`apps/omarchy-apple-installer/`** — the macOS installer application
+  (SwiftPM). Ships to users as its own signed and notarized `.pkg` built by
+  `apps/omarchy-apple-installer/Packaging/`, never via pacman.
+- **`evidence/`** — Apple Silicon acceptance and hardware-run evidence
+  records referenced by release decisions.
+- **`scripts/`** — repo maintenance helpers (`build-stable-release`,
+  `cleanup-tonights-extras.py`); run from a checkout, not installed.
+- **`docs/apple-silicon-*`, `docs/releases/`** — fork planning, design, and
+  release records.
+
+Interleaved changes to upstream files are gated behind
+`omarchy-hw-apple-silicon` so they stay inert off-platform and merge
+cleanly.
+
 Three layers populate `$HOME`:
 
 1. **Seed** — `omarchy-settings` ships static defaults to `/etc/skel/`.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -10,7 +10,7 @@ Release preparation must:
 2. Add the release to `CHANGELOG.md`.
 3. Add `docs/releases/vX.Y.Z-mac.N.md` with user-facing changes, validation,
    known limitations when applicable, and a full-diff link.
-4. Run `tests/stable-release-test.sh` before creating the tag.
+4. Run `test/shell.d/stable-release-test.sh` before creating the tag.
 
 The notes file must exist in the tagged commit. The publishing workflow reads
 it with `git show`, validates its title and required sections, and passes the

--- a/docs/releases/release-notes-v8.md
+++ b/docs/releases/release-notes-v8.md
@@ -1,0 +1,111 @@
+# Omarchy for Apple Silicon — M1 Pro installer
+
+This release installs **Omarchy**, an Arch Linux desktop built on Asahi Linux,
+onto a MacBook Pro with an M1 Pro chip, alongside macOS. You keep macOS. You
+choose which one to boot.
+
+Everything you need is in this release: a Mac app that does the install, and
+the operating system it writes.
+
+---
+
+## What you need
+
+- **A 14-inch MacBook Pro (2021), M1 Pro** — model identifier `apple,j314s`.
+  The installer refuses to run on any other machine. To check yours:
+  Apple menu → About This Mac.
+- **macOS up to date.** Install pending macOS updates first and reboot.
+- **137 GB of free disk space.** The installer will not shrink your macOS
+  partition; it needs genuinely free space to work with.
+- **Mains power, and keep it plugged in.** The install takes 15-25 minutes and
+  must not be interrupted.
+- **An internet connection.** The app downloads about 3.6 GB.
+- **Your Mac's login password**, and one restart into Recovery mode. Only you
+  can do those two things.
+
+Back up anything you care about before you start. This writes to your disk.
+
+---
+
+## Installing
+
+1. **Download** `Omarchy-MX-Mac-Installer-0.8.0.zip` from the Assets list
+   below.
+2. **Unzip it** by double-clicking. You get
+   `Omarchy MX Mac Installer.app`.
+3. **Open the app.** It is signed and notarized by Apple, so it opens
+   normally — no security warning, no right-click trick.
+4. **Follow the six screens:**
+   - **Check** — confirms your Mac is supported.
+   - **Plan** — downloads and verifies the operating system, showing progress.
+     This is the long part.
+   - **Authorize** — asks for your password. It is used once and kept only in
+     memory, never written anywhere.
+   - **Install** — writes the system and reads every write back to confirm it.
+   - **Recovery** — tells you to finish in Recovery mode. **This step is
+     yours:** shut down, then hold the power button until "Loading startup
+     options" appears, choose Options, log in, and follow the instructions.
+     Apple requires a human here; no app can do it for you.
+   - **Boot** — confirms the system is ready.
+5. **Restart.** Hold the power button to choose between macOS and Omarchy at
+   any time.
+
+Once you are in Omarchy, `asahi-bless` and `startup-disk` let you pick the
+next boot OS from Linux, without Recovery mode.
+
+---
+
+## What is fixed since v7
+
+- **Audio works.** v7 installed without the Apple audio profiles, so the sound
+  system fell back to the raw hardware device and the speakers were unusable.
+  This release ships `alsa-ucm-conf-asahi`, so the speakers come up on the
+  proper Asahi DSP profile, with `speakersafetyd` running to protect them.
+- **WiFi works on its own.** In v7, WiFi only came up after running a command
+  by hand, because the machine's own WiFi firmware was not copied into the
+  installed system. A first-boot service now does that copy, so WiFi is
+  available from the first login and stays working across reboots.
+- **Bluetooth and boot tools are installed.** Bluetooth is active out of the
+  box, and `asahi-bless` plus `startup-disk` are included so you can switch
+  boot OS from Linux.
+- **A redesigned installer app.** The old build was one dense screen of
+  technical detail. It is now six clear screens with one decision each, real
+  progress during the download and install, a live activity feed, and the
+  technical detail tucked into Details panels for anyone who wants it.
+- **You can download it.** v7 had to be hand-carried onto the machine over a
+  cable — it could not be given to anyone. The operating system now ships with
+  this release and the app fetches it, so this is the first version a person
+  other than the author can actually install.
+
+---
+
+## About integrity
+
+Every file this installer uses is pinned by its SHA-256 digest in a catalog,
+the catalog is cryptographically signed, and the signed catalog and its trust
+root are sealed inside the app bundle at build time.
+
+That means the app will only accept the exact bytes it was built to expect. If
+a download is corrupted, truncated, or substituted, verification fails and the
+install stops before anything is written to your disk. The large OS payload is
+delivered in parts; each part is checked on its own, and the reassembled whole
+is checked again.
+
+The app itself is signed with an Apple Developer ID and notarized by Apple.
+
+`SHA256SUMS` is attached to this release if you want to verify the downloads
+yourself:
+
+```bash
+shasum -a 256 -c SHA256SUMS
+```
+
+---
+
+## Known limits
+
+- One model only: M1 Pro 14-inch (`apple,j314s`). Other Apple Silicon Macs are
+  rejected on the first screen, deliberately.
+- The Recovery-mode step cannot be automated. Apple requires it.
+- This is a fresh install into free space. It does not upgrade or repair an
+  existing Omarchy installation.

--- a/scripts/cleanup-tonights-extras.py
+++ b/scripts/cleanup-tonights-extras.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Reviewed cleanup of tonight's superseded build checkpoints.
+
+Authorized by the owner ("A", 2026-08-30). Policy:
+- Never touches anything completed before 2026-08-30 (the legacy store).
+- Keeps, per stage and per build mode, the newest generation from today.
+- Deletes only today's superseded checkpoint directories, plus objects that
+  are referenced by deleted checkpoints and by NOTHING kept (reference walk
+  over every remaining manifest in the whole store), and that were created
+  today.
+- `plan` writes cleanup-manifest.json beside this script and prints a
+  summary. `apply` re-scans, refuses on any drift from the manifest, then
+  deletes exactly the listed paths and re-verifies every keeper.
+Evidence directories, release/, mirrors, node cache, rollback checkpoints
+and /private/tmp candidates are never in scope.
+"""
+
+import datetime
+import json
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+STORE = Path(os.path.expanduser("~/.cache/omarchy/asahi-checkpoints"))
+TODAY = datetime.date(2026, 8, 31)
+MANIFEST = Path(__file__).with_name("cleanup-manifest.json")
+
+
+def scan():
+    keep, delete, errors = [], [], []
+    for stage_dir in sorted((STORE / "checkpoints").iterdir()):
+        if stage_dir.name.startswith("."):
+            errors.append(f"blocked entry left alone: {stage_dir.name}")
+            continue
+        if not stage_dir.is_dir() or stage_dir.is_symlink():
+            errors.append(f"unexpected entry left alone: {stage_dir}")
+            continue
+        rows = []
+        for ident in sorted(stage_dir.iterdir()):
+            if not ident.is_dir() or ident.is_symlink():
+                errors.append(f"unexpected entry left alone: {ident}")
+                continue
+            try:
+                man = json.loads((ident / "manifest.json").read_text())
+            except Exception as exc:
+                errors.append(f"unreadable manifest kept safe: {ident}: {exc}")
+                continue
+            day = datetime.date.fromtimestamp(ident.stat().st_mtime)
+            rows.append(
+                {
+                    "stage": stage_dir.name,
+                    "identity": ident.name,
+                    "mode": man.get("mode"),
+                    "completed_at": man.get("completed_at", ""),
+                    "day": day,
+                    "path": ident,
+                    "outputs": [
+                        o["sha256"]
+                        for o in man.get("outputs", [])
+                        if o.get("kind") == "file"
+                    ],
+                }
+            )
+        todays = [r for r in rows if r["day"] >= TODAY]
+        keep.extend(r for r in rows if r["day"] < TODAY)
+        newest = {}
+        for r in todays:
+            k = r["mode"]
+            if k not in newest or r["completed_at"] > newest[k]["completed_at"]:
+                newest[k] = r
+        for r in todays:
+            (keep if r is newest.get(r["mode"]) else delete).append(r)
+
+    kept_refs = {sha for r in keep for sha in r["outputs"]}
+    del_refs = {sha for r in delete for sha in r["outputs"]}
+    orphans, reclaim = [], 0
+    for sha in sorted(del_refs - kept_refs):
+        op = STORE / "objects" / "sha256" / sha[:2] / sha
+        if op.is_file() and not op.is_symlink():
+            if datetime.date.fromtimestamp(op.stat().st_mtime) >= TODAY:
+                reclaim += op.stat().st_blocks * 512
+                orphans.append(str(op))
+            else:
+                errors.append(f"pre-existing orphan left alone: {sha[:16]}")
+    for r in delete:
+        for f in r["path"].rglob("*"):
+            if f.is_file():
+                reclaim += f.stat().st_blocks * 512
+    return keep, delete, orphans, reclaim, errors
+
+
+def plan():
+    keep, delete, orphans, reclaim, errors = scan()
+    doc = {
+        "authorized_by": 'owner reply "A", 2026-08-30',
+        "keep_count": len(keep),
+        "delete_checkpoints": sorted(
+            f'{r["stage"]}/{r["identity"]} mode={r["mode"]} completed={r["completed_at"]}'
+            for r in delete
+        ),
+        "delete_checkpoint_paths": sorted(str(r["path"]) for r in delete),
+        "orphan_objects": orphans,
+        "estimated_reclaim_gb": round(reclaim / 2**30, 1),
+        "errors": errors,
+    }
+    MANIFEST.write_text(json.dumps(doc, indent=2) + "\n")
+    print(f"keep {len(keep)} checkpoints; delete {len(delete)} checkpoints "
+          f"and {len(orphans)} orphaned objects")
+    print(f"estimated reclaim: {doc['estimated_reclaim_gb']} GB")
+    for line in doc["delete_checkpoints"]:
+        print("  DEL", line)
+    if errors:
+        print("notes:")
+        for e in errors:
+            print("  ", e)
+    print(f"manifest written: {MANIFEST}")
+
+
+def apply():
+    if not MANIFEST.is_file():
+        sys.exit("no cleanup-manifest.json — run plan first")
+    doc = json.loads(MANIFEST.read_text())
+    keep, delete, orphans, _, _ = scan()
+    fresh_paths = sorted(str(r["path"]) for r in delete)
+    if fresh_paths != doc["delete_checkpoint_paths"] or orphans != doc["orphan_objects"]:
+        sys.exit("store drifted since plan — re-run plan and review again")
+    freed_before = shutil.disk_usage("/System/Volumes/Data").free
+    for p in doc["delete_checkpoint_paths"]:
+        path = Path(p)
+        if not path.is_dir() or path.is_symlink() or STORE not in path.parents:
+            sys.exit(f"refusing unexpected path: {p}")
+        for node in [*path.rglob("*"), path]:
+            os.chmod(node, stat.S_IMODE(node.lstat().st_mode) | stat.S_IWUSR)
+        shutil.rmtree(path)
+    for p in doc["orphan_objects"]:
+        path = Path(p)
+        if not path.is_file() or path.is_symlink() or STORE not in path.parents:
+            sys.exit(f"refusing unexpected path: {p}")
+        os.chmod(path, stat.S_IMODE(path.lstat().st_mode) | stat.S_IWUSR)
+        path.unlink()
+    missing = [str(r["path"]) for r in keep if not (r["path"] / "manifest.json").is_file()]
+    if missing:
+        sys.exit(f"POST-CHECK FAILURE — kept checkpoints missing: {missing[:3]}")
+    freed = shutil.disk_usage("/System/Volumes/Data").free - freed_before
+    print(f"done; kept {len(keep)} checkpoints verified; freed ~{freed / 2**30:.1f} GB")
+
+
+LEGACY_MANIFEST = Path(__file__).with_name("cleanup-manifest-legacy.json")
+
+
+def scan_legacy():
+    """Owner-authorized second pass: delete every checkpoint completed before
+    today (the pre-existing legacy store, proven unbound and rekey-ineligible),
+    keep all of today's survivors, and remove objects referenced by nothing
+    kept. Evidence directories are outside the store and untouched."""
+    keep, delete, errors = [], [], []
+    for stage_dir in sorted((STORE / "checkpoints").iterdir()):
+        if stage_dir.name.startswith(".") or not stage_dir.is_dir() or stage_dir.is_symlink():
+            errors.append(f"anomalous entry left alone: {stage_dir.name}")
+            continue
+        for ident in sorted(stage_dir.iterdir()):
+            if not ident.is_dir() or ident.is_symlink():
+                errors.append(f"anomalous entry left alone: {ident}")
+                continue
+            try:
+                man = json.loads((ident / "manifest.json").read_text())
+            except Exception as exc:
+                errors.append(f"unreadable manifest kept safe: {ident}: {exc}")
+                continue
+            day = datetime.date.fromtimestamp(ident.stat().st_mtime)
+            row = {
+                "stage": stage_dir.name, "identity": ident.name,
+                "mode": man.get("mode"), "completed_at": man.get("completed_at", ""),
+                "path": ident,
+                "outputs": [o["sha256"] for o in man.get("outputs", []) if o.get("kind") == "file"],
+            }
+            (keep if day >= TODAY else delete).append(row)
+    kept_refs = {sha for r in keep for sha in r["outputs"]}
+    del_refs = {sha for r in delete for sha in r["outputs"]}
+    orphans, reclaim = [], 0
+    for sha in sorted(del_refs - kept_refs):
+        op = STORE / "objects" / "sha256" / sha[:2] / sha
+        if op.is_file() and not op.is_symlink():
+            reclaim += op.stat().st_blocks * 512
+            orphans.append(str(op))
+    for r in delete:
+        for f in r["path"].rglob("*"):
+            if f.is_file():
+                reclaim += f.stat().st_blocks * 512
+    return keep, delete, orphans, reclaim, errors
+
+
+def plan_legacy():
+    keep, delete, orphans, reclaim, errors = scan_legacy()
+    doc = {
+        "authorized_by": 'owner reply "clean legacy too", 2026-08-30',
+        "keep_count": len(keep),
+        "delete_checkpoints": sorted(
+            f'{r["stage"]}/{r["identity"]} mode={r["mode"]} completed={r["completed_at"]}'
+            for r in delete),
+        "delete_checkpoint_paths": sorted(str(r["path"]) for r in delete),
+        "orphan_objects": orphans,
+        "estimated_reclaim_gb": round(reclaim / 2**30, 1),
+        "errors": errors,
+    }
+    LEGACY_MANIFEST.write_text(json.dumps(doc, indent=2) + "\n")
+    print(f"keep {len(keep)} (all of today's); delete {len(delete)} legacy checkpoints "
+          f"and {len(orphans)} orphaned objects")
+    print(f"estimated reclaim: {doc['estimated_reclaim_gb']} GB")
+    by_stage = {}
+    for r in delete:
+        by_stage[r["stage"]] = by_stage.get(r["stage"], 0) + 1
+    for s_, n in sorted(by_stage.items()):
+        print(f"  {s_}: {n} legacy identities")
+    for e in errors:
+        print("  note:", e)
+    print(f"manifest written: {LEGACY_MANIFEST}")
+
+
+def apply_legacy():
+    if not LEGACY_MANIFEST.is_file():
+        sys.exit("no legacy manifest — run plan-legacy first")
+    doc = json.loads(LEGACY_MANIFEST.read_text())
+    keep, delete, orphans, _, _ = scan_legacy()
+    if sorted(str(r["path"]) for r in delete) != doc["delete_checkpoint_paths"] \
+            or orphans != doc["orphan_objects"]:
+        sys.exit("store drifted since plan-legacy — re-run plan-legacy and review")
+    for p_ in doc["delete_checkpoint_paths"]:
+        path = Path(p_)
+        if not path.is_dir() or path.is_symlink() or STORE not in path.parents:
+            sys.exit(f"refusing unexpected path: {p_}")
+        for node in [*path.rglob("*"), path]:
+            os.chmod(node, stat.S_IMODE(node.lstat().st_mode) | stat.S_IWUSR)
+        shutil.rmtree(path)
+    for p_ in doc["orphan_objects"]:
+        path = Path(p_)
+        if not path.is_file() or path.is_symlink() or STORE not in path.parents:
+            sys.exit(f"refusing unexpected path: {p_}")
+        os.chmod(path, stat.S_IMODE(path.lstat().st_mode) | stat.S_IWUSR)
+        path.unlink()
+    missing = []
+    for r in keep:
+        if not (r["path"] / "manifest.json").is_file():
+            missing.append(str(r["path"]))
+        for sha in r["outputs"]:
+            if not (STORE / "objects" / "sha256" / sha[:2] / sha).is_file():
+                missing.append(f"object {sha[:16]}")
+    if missing:
+        sys.exit(f"POST-CHECK FAILURE: {missing[:5]}")
+    print(f"done; all {len(keep)} kept checkpoints and every kept object verified present")
+
+
+if __name__ == "__main__":
+    {"plan": plan, "apply": apply,
+     "plan-legacy": plan_legacy, "apply-legacy": apply_legacy}.get(
+        sys.argv[1] if len(sys.argv) > 1 else "",
+        lambda: sys.exit("usage: plan|apply|plan-legacy|apply-legacy"),
+    )()

--- a/test/shell.d/stable-release-test.sh
+++ b/test/shell.d/stable-release-test.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
 version=$(<"$ROOT/version")
 notes="$ROOT/docs/releases/v$version.md"
 [[ -s $notes ]]


### PR DESCRIPTION
Second consolidation PR (follows #67). Imports the previously unversioned workspace material into fork-only paths and finishes the layout hygiene:

- Installer release tooling from iteration2/: preclean-m1 with its test, candidate assembly, engine re-signing, the .pkg builder and postinstall, e2e/docker runbooks
- Installer UI design canvas (artboards + layout) and the UX redesign plan
- Workspace design docs: cloud distribution seam, aarch64 status/hardware validation records, expanded integration roadmap, v8 release notes, checkpoint-store GC tool
- tests/stable-release-test.sh folded into test/shell.d/ (single test directory; workflow and checklist updated)
- docs/file-layout.md documents the fork-only areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)