### PR TITLE
Keep the VM interruption window testable with a full repository

### DIFF
--- a/test/vm/asahi-fresh/guest/install
+++ b/test/vm/asahi-fresh/guest/install
@@ -173,6 +173,17 @@ touch /var/tmp/omarchy-vm-build-active
 while :; do sleep 60; done
 EOF
 chmod +x /usr/local/bin/makepkg
+# The signed repository now provides every source package, so the installer's
+# build path never runs on its own. Hide one package from -Q so the pinned
+# build window (and its interruption) still gets exercised.
+cat >/usr/local/bin/pacman <<'EOF'
+#!/bin/bash
+if [[ $1 == "-Q" && $2 == "localsend" ]]; then
+  exit 1
+fi
+exec /usr/bin/pacman "$@"
+EOF
+chmod +x /usr/local/bin/pacman
 interrupted=0
 for attempt in {1..3}; do
   rm -f /var/tmp/omarchy-vm-installer.pid /var/tmp/omarchy-vm-build-active
@@ -231,7 +242,7 @@ done
 [[ -f /var/cache/omarchy-fresh-pkgbuilds/.omarchy-fresh-install-owner ]]
 getent passwd omarchy-fresh-build >/dev/null
 [[ " $(id -nG alarm) " == *" wheel "* ]]
-rm -f /usr/local/bin/makepkg
+rm -f /usr/local/bin/makepkg /usr/local/bin/pacman
 usermod --home /home/omarchy-replaced omarchy
 expect <<EOF
 set timeout -1


### PR DESCRIPTION
With all 33 source packages published, the installer's pinned-build path is skipped entirely and the interruption fixture ran three complete installs without ever triggering. A scoped fake pacman hides localsend from -Q during the interruption loop only, reopening the makepkg window the fixture kills, with the fake removed before the resumed install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)