### PR TITLE
Answer default Y/n prompts in the VM harness

### DIFF
--- a/test/vm/asahi-fresh/guest/install
+++ b/test/vm/asahi-fresh/guest/install
@@ -85,6 +85,10 @@ expect {
     send "omarchy\r"
     exp_continue
   }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
+    exp_continue
+  }
   eof
 }
 catch wait result
@@ -112,6 +116,10 @@ expect {
     send "omarchy\r"
     exp_continue
   }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
+    exp_continue
+  }
   eof
 }
 catch wait result
@@ -131,6 +139,10 @@ expect {
     send "omarchy\r"
     expect "Retype new password:"
     send "omarchy\r"
+    exp_continue
+  }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
     exp_continue
   }
   eof
@@ -154,6 +166,10 @@ expect {
     send "omarchy\r"
     expect "Retype new password:"
     send "omarchy\r"
+    exp_continue
+  }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
     exp_continue
   }
   eof
@@ -219,6 +235,10 @@ expect {
     send "omarchy\r"
     exp_continue
   }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
+    exp_continue
+  }
   eof
 }
 catch wait result
@@ -253,6 +273,10 @@ expect {
     send "omarchy\r"
     expect "Retype new password:"
     send "omarchy\r"
+    exp_continue
+  }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
     exp_continue
   }
   eof
@@ -295,6 +319,10 @@ expect {
     send "omarchy\r"
     expect "Retype new password:"
     send "omarchy\r"
+    exp_continue
+  }
+  -re {\[Y/n\]:? ?$} {
+    send "\r"
     exp_continue
   }
   eof


### PR DESCRIPTION
The 4.0.2 installer's mkinitcpio -P triggers limine-mkinitcpio's interactive [Y/n] prompt, hanging the acceptance run. All seven expect spawns now send the default answer for any Y/n prompt (passwords stay explicitly answered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)