### PR TITLE
Resolve the newest numbered Quattro channel release

### DIFF
--- a/install-omarchy-mx-mac
+++ b/install-omarchy-mx-mac
@@ -3,7 +3,22 @@
 set -euo pipefail
 
 package_repo="${OMARCHY_PACKAGE_REPO:-maralcbr/omarchy-pkgs}"
-release_base_url="${OMARCHY_PACKAGE_RELEASE_BASE_URL:-https://github.com/$package_repo/releases/download/asahi-quattro-channel}"
+resolve_channel_release_tag() {
+  # The un-numbered asahi-quattro-channel release is an immutable legacy
+  # pointer; the live channel is the highest-numbered asahi-quattro-channel-N.
+  curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --silent \
+    "https://api.github.com/repos/$package_repo/releases?per_page=100" |
+    grep -oE '"tag_name": *"asahi-quattro-channel-[1-9][0-9]*"' |
+    grep -oE 'asahi-quattro-channel-[0-9]+' | sort -t- -k4,4n | tail -1
+}
+if [[ -n ${OMARCHY_PACKAGE_RELEASE_BASE_URL:-} ]]; then
+  release_base_url=$OMARCHY_PACKAGE_RELEASE_BASE_URL
+else
+  channel_release_tag=$(resolve_channel_release_tag)
+  [[ $channel_release_tag =~ ^asahi-quattro-channel-[1-9][0-9]*$ ]] ||
+    channel_release_tag=asahi-quattro-channel
+  release_base_url="https://github.com/$package_repo/releases/download/$channel_release_tag"
+fi
 fingerprint=5983B1CA32CB778F4D74D24ECFF35022CA5B5959
 key_url="${OMARCHY_RELEASE_KEY_URL:-https://raw.githubusercontent.com/maralcbr/omarchy-mx-mac/main/default/omarchy-release.gpg}"
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/omarchy-mx-mac-install.XXXXXXXX")

--- a/test/vm/asahi-fresh/guest/install
+++ b/test/vm/asahi-fresh/guest/install
@@ -3,7 +3,14 @@
 set -euo pipefail
 
 stable=https://github.com/maralcbr/omarchy-mx-mac/releases/latest/download
-channel=https://github.com/maralcbr/omarchy-pkgs/releases/download/asahi-quattro-channel
+# The un-numbered asahi-quattro-channel release is an immutable legacy pointer;
+# the live channel is the highest-numbered asahi-quattro-channel-N release.
+channel_tag=$(curl --fail --location --connect-timeout 15 --max-time 60 --retry 3 --retry-all-errors \
+  "https://api.github.com/repos/maralcbr/omarchy-pkgs/releases?per_page=100" |
+  grep -oE '"tag_name": *"asahi-quattro-channel-[1-9][0-9]*"' |
+  grep -oE 'asahi-quattro-channel-[0-9]+' | sort -t- -k4,4n | tail -1)
+[[ $channel_tag =~ ^asahi-quattro-channel-[1-9][0-9]*$ ]]
+channel=https://github.com/maralcbr/omarchy-pkgs/releases/download/$channel_tag
 fingerprint=5983B1CA32CB778F4D74D24ECFF35022CA5B5959
 work=/root/omarchy-fresh-vm
 


### PR DESCRIPTION
The un-numbered asahi-quattro-channel release on omarchy-pkgs is an immutable legacy pointer frozen at sequence 21 (Aug 26 installer copy). Channel promotions publish asahi-quattro-channel-N (now 26 = the 4.0.2-mac.1 runtime), and the modern install-asahi-quattro already discovers the highest sequence — but both consumers still fetched the installer from the legacy pointer, so they installed the sequence-21 runtime.

- VM harness guest: resolve the highest asahi-quattro-channel-N before downloading install-asahi-quattro (this is why the acceptance run's installed-version check failed against stable v4.0.2-mac.1).
- install-omarchy-mx-mac bootstrap: same resolution, with OMARCHY_PACKAGE_RELEASE_BASE_URL still an explicit override and the legacy pointer as fallback. Ships to users with the next stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)