### PR TITLE
Provision jq in the VM harness base image

### DIFF
--- a/test/vm/asahi-fresh/container/build-base
+++ b/test/vm/asahi-fresh/container/build-base
@@ -125,6 +125,7 @@ chroot "$mount_dir" pacman -Syu --needed --noconfirm \
   gnupg \
   grub \
   iwd \
+  jq \
   linux-aarch64 \
   networkmanager \
   openssh \


### PR DESCRIPTION
The modern install-asahi-quattro (published with numbered channel releases) hard-requires jq for channel discovery; the harness's minimal ALARM base image did not include it, so acceptance run 7 failed with "Required command 'jq' is unavailable" right after all signatures verified. Adds jq to the base package set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)