### PR TITLE
Create the cups-browsed account before hardening CUPS on upgrade

### DIFF
--- a/migrations/1787815267.sh
+++ b/migrations/1787815267.sh
@@ -40,8 +40,9 @@ fi
 # /etc/sysusers.d entry creates. Pacman only triggers systemd-sysusers for
 # /usr/lib/sysusers.d, so on an upgrade the account does not exist until the
 # next boot and cupsd refuses its configuration. Create it now, idempotently.
-if omarchy-pkg-present cups && [[ -f /etc/sysusers.d/omarchy-cups-browsed.conf ]]; then
-  sudo systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
+sysusers_conf="${OMARCHY_CUPS_SYSUSERS_CONF:-/etc/sysusers.d/omarchy-cups-browsed.conf}"
+if omarchy-pkg-present cups && [[ -f $sysusers_conf ]]; then
+  sudo systemd-sysusers "$sysusers_conf"
 fi
 
 # Stop the root-running daemon before changing the authorization it relies on.

--- a/migrations/1787815267.sh
+++ b/migrations/1787815267.sh
@@ -36,6 +36,14 @@ if omarchy-pkg-present cups; then
   omarchy-pkg-add cups-pk-helper
 fi
 
+# The hardened cups-files.conf names the cups-browsed group, which the shipped
+# /etc/sysusers.d entry creates. Pacman only triggers systemd-sysusers for
+# /usr/lib/sysusers.d, so on an upgrade the account does not exist until the
+# next boot and cupsd refuses its configuration. Create it now, idempotently.
+if omarchy-pkg-present cups && [[ -f /etc/sysusers.d/omarchy-cups-browsed.conf ]]; then
+  sudo systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
+fi
+
 # Stop the root-running daemon before changing the authorization it relies on.
 if systemctl is-active --quiet cups-browsed.service 2>/dev/null; then
   sudo systemctl stop cups-browsed.service

--- a/test/shell.d/cups-hardening-test.sh
+++ b/test/shell.d/cups-hardening-test.sh
@@ -134,6 +134,10 @@ cat >"$mock_bin/sudo" <<'SH'
 printf 'sudo\t%s\n' "$*" >>"$OMARCHY_CUPS_TEST_LOG"
 exec "$@"
 SH
+cat >"$mock_bin/systemd-sysusers" <<'SH'
+#!/bin/bash
+printf 'systemd-sysusers\t%s\n' "$*" >>"$OMARCHY_CUPS_TEST_LOG"
+SH
 chmod +x "$mock_bin"/*
 
 log="$test_tmp/actions.log"
@@ -171,8 +175,11 @@ marker="$test_tmp/var/lib/omarchy/migrations/1787815267"
 PATH="$mock_bin:$PATH" \
   OMARCHY_PATH="$ROOT" \
   OMARCHY_CUPS_MIGRATION_MARKER="$marker" \
+  OMARCHY_CUPS_SYSUSERS_CONF="$sysusers_conf" \
   bash -euo pipefail "$ROOT/migrations/1787815267.sh"
 
+grep -qxF $'systemd-sysusers\t'"$sysusers_conf" "$log" ||
+  fail "the migration creates the cups-browsed account before hardening CUPS"
 grep -qxF $'omarchy-pkg-drop\tcups-pdf' "$log" ||
   fail "the migration removes CUPS-PDF"
 grep -qxF $'omarchy-pkg-add\tcups-pk-helper' "$log" ||


### PR DESCRIPTION
Observed on the M1 after `omarchy update` to 4.0.2-mac.1: cupsd failed with `Unknown SystemGroup "cups-browsed"`, cups-browsed.service failed its dependency, migration 1787815267 aborted, and five later migrations stayed pending.

Root cause: the shipped `/etc/sysusers.d/omarchy-cups-browsed.conf` is only processed by systemd-sysusers at boot — pacman's hook watches `/usr/lib/sysusers.d` only — so an in-place upgrade references a group that does not exist yet. This is not Apple-specific; any upgrade without a reboot in between hits it. The migration now runs `systemd-sysusers` on that entry (idempotent) before reloading CUPS. Candidate for an upstream PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)