### PR TITLE
Pin the catalog generator and engine metadata to the 4.0.2 payload

### DIFF
--- a/apps/omarchy-apple-installer/Engine/installer_data.json
+++ b/apps/omarchy-apple-installer/Engine/installer_data.json
@@ -7,7 +7,7 @@
       "name": "Omarchy MX Mac",
       "next_object": "m1n1/boot.bin",
       "omarchy_target": "apple-silicon-full-os",
-      "package": "omarchy-2026.09.01-aarch64-apple-silicon-asahi-os-package.zip",
+      "package": "omarchy-2026.09.02-aarch64-apple-silicon-asahi-os-package.zip",
       "partitions": [
         {
           "copy_firmware": true,

--- a/apps/omarchy-apple-installer/scripts/make-unsigned-catalog.py
+++ b/apps/omarchy-apple-installer/scripts/make-unsigned-catalog.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 ENGINE_NAME = "installer-v0.9.0-omarchy.7.tar.gz"
 METADATA_NAME = "installer_data.json"
-PAYLOAD_NAME = "omarchy-2026.09.01-aarch64-apple-silicon-asahi-os-package.zip"
+PAYLOAD_NAME = "omarchy-2026.09.02-aarch64-apple-silicon-asahi-os-package.zip"
 
 DEVICE_IDENTIFIER = "apple,j314s"
 ASAHI_INSTALLER_TAG = "v0.9.0"
@@ -33,7 +33,7 @@ ASAHI_INSTALLER_REVISION = "f0469cea0899f3efed8efead604174c7a53c4451"
 ASAHI_INSTALLER_DATA_REVISION = "42648e71423eba308d2e3e6228253eff679b068b"
 DOWNSTREAM_REVISION = "dff6311446439e1f29f0f2e6c0cf82a9a190e5bc"
 ENGINE_VERSION = "v0.9.0-omarchy.7"
-EVIDENCE_REVISION = "4.0.1-mac.2.9.090126"
+EVIDENCE_REVISION = "4.0.2-mac.1.10.090226"
 
 MAXIMUM_PART_COUNT = 16
 PART_PATTERN = re.compile(r"\.part(\d{2})$")


### PR DESCRIPTION
Points make-unsigned-catalog.py (PAYLOAD_NAME, EVIDENCE_REVISION=4.0.2-mac.1.10.090226) and Engine/installer_data.json at omarchy-2026.09.02-aarch64-apple-silicon-asahi-os-package.zip, the 4.0.2 Apple Silicon OS package built from the accepted 33-package repository and Quattro channel 26 runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)