### PR TITLE
Record the 4.0.2-mac.1.10.090226 installer release

### DIFF
--- a/docs/releases/v4.0.2-mac.1.10.090226.md
+++ b/docs/releases/v4.0.2-mac.1.10.090226.md
@@ -1,0 +1,41 @@
+# Omarchy MX Mac Installer 4.0.2-mac.1.10.090226
+
+Signed and notarized macOS installer package (`.pkg`) that installs Omarchy MX Mac 4.0.2-mac.1
+on Apple Silicon. Release assets are served from Cloudflare R2 at
+`https://downloads.aicodelabs.com.au/releases/v4.0.2-mac.1.10.090226/` as a single OS package
+(no split parts).
+
+## Contents
+
+- OS package `omarchy-2026.09.02-aarch64-apple-silicon-asahi-os-package.zip`
+  (3,638,729,568 bytes, SHA-256
+  `b1f0338f269eef86f4cd605faef656f229c20cb55153f68f321470f641bd089e`), built by
+  the omarchy-iso qualification pipeline (run `20260902T033320Z-88169`) with sparse image
+  storage.
+- Pinned Asahi engine `installer-v0.9.0-omarchy.7.tar.gz` (SHA-256
+  `063fd0765fb2057384d9653f7bf547b0471af31fc764e039d578d4fef6dce4d5`).
+- Runtime: Quattro channel sequence 26 (`asahi-quattro-37bc77f1`, stable release
+  `v4.0.2-mac.1`); package repository pinned at
+  `asahi-packages-stable-901e39bdc0dd42a93644bce14a07eeb9bb18a12c` (33 packages, the full
+  declared set, including localsend, aether, cliamp, xdg-terminal-exec and yay).
+- Catalog sealed with an ephemeral Ed25519 trust root, fingerprint
+  `sha256:a8850aebeb0cec1c98d73ae963965dcb045eb59b5e1e681c08574d9b3193a746`; the private key was
+  destroyed after signing.
+
+## Validation
+
+- Package repository candidate `asahi-packages-candidate-901e39bd` accepted on the M1 Pro in the
+  native aarch64 VM harness (fresh install, reboot, interruption recovery, completed-rerun
+  rejection); see `asahi-packages-candidate-901e39bd-acceptance.txt`.
+- Installed-system configuration validated in-build and re-checked on the host against the
+  finalized image pair (`asahi-installed-system-config-v1`, result passed, no failed checks).
+- Application and package are Developer ID signed, notarized and stapled.
+
+## Known Limitations
+
+- The sealed OS package is not yet independently rebuilt with identical bytes (the
+  `configured-target` root image is not byte-stable across rebuilds), so the build report marks
+  catalog admission as not independently reproduced. Same status as the 4.0.1-mac.2.9.090126
+  release.
+- Fresh installs on a bare Asahi system through `install-omarchy-mx-mac` still read the legacy
+  channel pointer until stable release `v4.0.2-mac.2` ships the numbered-channel resolution.


### PR DESCRIPTION
Release notes for the signed installer tag v4.0.2-mac.1.10.090226: single-file 4.0.2 OS package served from R2, pinned engine, channel 26 runtime, the 33-package stable repository, trust-root fingerprint, and the validation trail (VM acceptance, in-build and host installed-config checks). Binary assets live on R2, not GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)