### PR TITLE
Derive the pkg daemon plist with an absolute Program and fail closed

### DIFF
--- a/apps/omarchy-apple-installer/Packaging/pkg/build-pkg.sh
+++ b/apps/omarchy-apple-installer/Packaging/pkg/build-pkg.sh
@@ -5,14 +5,21 @@
 # postinstall — so the recipient enters one admin password (the macOS installer
 # prompt) and never touches Login Items.
 #
-# Usage: build-pkg.sh --app <signed .app> --plist <helper-launchdaemon.plist> \
-#          --version <x.y.z> --out <output.pkg>
+# Usage: build-pkg.sh --app <signed .app> --version <x.y.z> --out <output.pkg> \
+#          [--plist <daemon plist>]
+#
+# The system daemon plist is derived from the plist the app embeds
+# (Contents/Library/LaunchDaemons), rewriting its bundle-relative BundleProgram
+# into an absolute Program under /Applications. Pass --plist only to supply a
+# daemon plist that already carries an absolute Program; it is validated the
+# same way.
 set -euo pipefail
 
 APP="" PLIST="" VERSION="" OUT=""
 INSTALLER_ID="Developer ID Installer: MARCELO DE BARROS ALCANTARA (T2C384FJBD)"
 PKG_IDENTIFIER="com.omarchy.mx.installer.pkg"
-SCRIPTS="$(cd "$(dirname "$0")" && pwd)/scripts"
+PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS="$PKG_DIR/scripts"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,10 +31,11 @@ while [[ $# -gt 0 ]]; do
     *) echo "unknown arg: $1" >&2; exit 64 ;;
   esac
 done
-[[ -d "$APP" && -f "$PLIST" && -n "$VERSION" && -n "$OUT" ]] || {
-  echo "usage: build-pkg.sh --app <app> --plist <plist> --version <v> --out <pkg>" >&2
+[[ -d "$APP" && -n "$VERSION" && -n "$OUT" ]] || {
+  echo "usage: build-pkg.sh --app <app> --version <v> --out <pkg> [--plist <plist>]" >&2
   exit 64
 }
+[[ -z "$PLIST" || -f "$PLIST" ]] || { echo "build-pkg.sh: --plist is not a file: $PLIST" >&2; exit 64; }
 
 work="$(mktemp -d /tmp/omarchy-pkg.XXXXXX)"
 trap 'rm -rf "$work"' EXIT
@@ -36,10 +44,27 @@ mkdir -p "$root/Applications" "$root/Library/LaunchDaemons"
 
 # Payload: the notarized app and the system daemon plist.
 /usr/bin/ditto "$APP" "$root/Applications/$(basename "$APP")"
-/usr/bin/install -m 0644 "$PLIST" "$root/Library/LaunchDaemons/com.omarchy.mx.installer.helper.plist"
 
-# Confirm the plist's Program points at where the app actually lands.
-prog="$(/usr/bin/plutil -extract Program raw -o - "$PLIST" 2>/dev/null || true)"
+# Derive the daemon plist from the app's embedded copy (absolute Program under
+# /Applications), or validate a supplied one the same way. A daemon whose
+# Program is missing, relative, or points at nothing inside the staged app
+# cannot be loaded by launchd, so that is a build failure, not a warning.
+daemon_plist="$work/com.omarchy.mx.installer.helper.plist"
+if [[ -n "$PLIST" ]]; then
+  /bin/cp "$PLIST" "$daemon_plist"
+else
+  "$PKG_DIR/derive-daemon-plist" "$APP" "$daemon_plist" /Applications >/dev/null
+fi
+prog="$(/usr/bin/plutil -extract Program raw -o - "$daemon_plist" 2>/dev/null || true)"
+[[ $prog == /Applications/* ]] || {
+  echo "build-pkg.sh: daemon Program must be an absolute path under /Applications (got '${prog:-<missing>}')" >&2
+  exit 65
+}
+[[ -f "$root$prog" ]] || {
+  echo "build-pkg.sh: daemon Program does not exist inside the staged app: $prog" >&2
+  exit 65
+}
+/usr/bin/install -m 0644 "$daemon_plist" "$root/Library/LaunchDaemons/com.omarchy.mx.installer.helper.plist"
 echo "daemon Program: $prog"
 
 # Pin the app to /Applications. Without this, PackageKit "relocates" the

--- a/apps/omarchy-apple-installer/Packaging/pkg/derive-daemon-plist
+++ b/apps/omarchy-apple-installer/Packaging/pkg/derive-daemon-plist
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Derive the system LaunchDaemon plist that build-pkg.sh installs into
+# /Library/LaunchDaemons from the plist the app embeds under
+# Contents/Library/LaunchDaemons. The embedded copy uses BundleProgram (a path
+# relative to the bundle, the SMAppService form); a daemon in
+# /Library/LaunchDaemons needs an absolute Program path, or launchd cannot load
+# it and the app reports the privileged helper as unreachable.
+#
+# Usage: derive-daemon-plist <app bundle> <output plist> [install location]
+#   install location defaults to /Applications.
+set -euo pipefail
+
+app=${1:-}
+output=${2:-}
+install_location=${3:-/Applications}
+[[ -d $app && -n $output ]] || {
+  echo "usage: derive-daemon-plist <app bundle> <output plist> [install location]" >&2
+  exit 64
+}
+[[ $install_location == /* ]] || {
+  echo "derive-daemon-plist: install location must be absolute: $install_location" >&2
+  exit 65
+}
+
+embedded="$app/Contents/Library/LaunchDaemons/com.omarchy.mx.installer.helper.plist"
+[[ -f $embedded ]] || {
+  echo "derive-daemon-plist: embedded daemon plist is missing: $embedded" >&2
+  exit 66
+}
+
+app_name=$(basename "$app")
+python3 - "$embedded" "$output" "$app" "$install_location/$app_name" <<'PY'
+import plistlib, sys, os
+embedded, output, app, installed_app = sys.argv[1:5]
+with open(embedded, "rb") as handle:
+    plist = plistlib.load(handle)
+relative = plist.pop("BundleProgram", None)
+program = plist.get("Program")
+if relative:
+    if os.path.isabs(relative) or relative.startswith(".."):
+        sys.exit("derive-daemon-plist: BundleProgram must be a bundle-relative path: %s" % relative)
+    program = os.path.join(installed_app, relative)
+    if not os.path.isfile(os.path.join(app, relative)):
+        sys.exit("derive-daemon-plist: helper is missing inside the app: %s" % relative)
+if not program or not os.path.isabs(program):
+    sys.exit("derive-daemon-plist: daemon Program must be an absolute path (got %r)" % program)
+if not program.startswith(installed_app + "/"):
+    sys.exit("derive-daemon-plist: daemon Program must live inside the installed app: %s" % program)
+plist["Program"] = program
+for key in ("Label", "MachServices", "UserName"):
+    if key not in plist:
+        sys.exit("derive-daemon-plist: embedded plist lacks %s" % key)
+with open(output, "wb") as handle:
+    plistlib.dump(plist, handle, sort_keys=True)
+print(program)
+PY

--- a/apps/omarchy-apple-installer/Packaging/pkg/scripts/postinstall
+++ b/apps/omarchy-apple-installer/Packaging/pkg/scripts/postinstall
@@ -9,10 +9,23 @@ LABEL=com.omarchy.mx.installer.helper
 if [[ -f "$PLIST" ]]; then
   /usr/sbin/chown root:wheel "$PLIST"
   /bin/chmod 0644 "$PLIST"
-  # Replace any stale registration, then load fresh.
+  # Replace any stale registration, then load fresh. A daemon that fails to
+  # load leaves the app unable to reach its privileged helper, so surface the
+  # failure through the installer instead of hiding it: PackageKit records
+  # this script's output in /var/log/install.log and fails the package.
   /bin/launchctl bootout system/"$LABEL" 2>/dev/null || true
-  /bin/launchctl bootstrap system "$PLIST" 2>/dev/null || \
-    /bin/launchctl load -w "$PLIST" 2>/dev/null || true
+  if ! bootstrap_error="$(/bin/launchctl bootstrap system "$PLIST" 2>&1)"; then
+    echo "postinstall: failed to load $LABEL from $PLIST: $bootstrap_error" >&2
+    /usr/bin/logger -t omarchy-installer-pkg "failed to load $LABEL: $bootstrap_error" || true
+    exit 1
+  fi
+  if ! /bin/launchctl print system/"$LABEL" >/dev/null 2>&1; then
+    echo "postinstall: $LABEL did not register with launchd" >&2
+    exit 1
+  fi
+else
+  echo "postinstall: daemon plist is missing: $PLIST" >&2
+  exit 1
 fi
 
 APP="/Applications/Omarchy MX Mac Installer.app"

--- a/test/shell.d/apple-installer-pkg-daemon-plist-test.sh
+++ b/test/shell.d/apple-installer-pkg-daemon-plist-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+pkg_dir=$ROOT/apps/omarchy-apple-installer/Packaging/pkg
+derive=$pkg_dir/derive-daemon-plist
+
+make_app() {
+  local app=$1 bundle_program=$2 helper=${3:-Contents/Resources/omarchy-apple-installer-helper}
+  mkdir -p "$app/Contents/Library/LaunchDaemons" "$app/$(dirname "$helper")"
+  printf '#!/bin/sh\n' >"$app/$helper"
+  python3 - "$app/Contents/Library/LaunchDaemons/com.omarchy.mx.installer.helper.plist" "$bundle_program" <<'PY'
+import plistlib, sys
+plistlib.dump({
+    "Label": "com.omarchy.mx.installer.helper",
+    "BundleProgram": sys.argv[2],
+    "MachServices": {"com.omarchy.mx.installer.helper": True},
+    "UserName": "root",
+    "KeepAlive": False,
+    "EnvironmentVariables": {"OMARCHY_CLIENT_CODE_SIGNING_REQUIREMENT": "anchor apple generic"},
+}, open(sys.argv[1], "wb"))
+PY
+}
+
+read_plist() {
+  python3 -c 'import plistlib, sys, json; print(json.dumps(plistlib.load(open(sys.argv[1], "rb")), sort_keys=True))' "$1"
+}
+
+app="$test_tmp/Omarchy MX Mac Installer.app"
+make_app "$app" Contents/Resources/omarchy-apple-installer-helper
+out=$test_tmp/daemon.plist
+program=$("$derive" "$app" "$out" /Applications)
+[[ $program == "/Applications/Omarchy MX Mac Installer.app/Contents/Resources/omarchy-apple-installer-helper" ]] ||
+  fail "the derived daemon Program is the helper's absolute path under /Applications"
+derived=$(read_plist "$out")
+grep -Fq '"Program": "/Applications/Omarchy MX Mac Installer.app/Contents/Resources/omarchy-apple-installer-helper"' <<<"$derived" ||
+  fail "the derived plist records the absolute Program"
+! grep -Fq '"BundleProgram"' <<<"$derived" || fail "the derived plist drops the bundle-relative BundleProgram"
+grep -Fq '"Label": "com.omarchy.mx.installer.helper"' <<<"$derived" || fail "the derived plist keeps the Label"
+grep -Fq '"com.omarchy.mx.installer.helper": true' <<<"$derived" || fail "the derived plist keeps the Mach service"
+grep -Fq '"UserName": "root"' <<<"$derived" || fail "the derived plist keeps the root UserName"
+grep -Fq 'OMARCHY_CLIENT_CODE_SIGNING_REQUIREMENT' <<<"$derived" || fail "the derived plist keeps the client requirement"
+pass "the system daemon plist is derived with an absolute Program inside the installed app"
+
+app_missing="$test_tmp/Missing.app"
+make_app "$app_missing" Contents/Resources/omarchy-apple-installer-helper
+rm "$app_missing/Contents/Resources/omarchy-apple-installer-helper"
+if "$derive" "$app_missing" "$test_tmp/missing.plist" /Applications >/dev/null 2>&1; then
+  fail "derivation rejects a helper that is missing inside the app"
+fi
+app_escape="$test_tmp/Escape.app"
+make_app "$app_escape" ../../../usr/bin/true
+if "$derive" "$app_escape" "$test_tmp/escape.plist" /Applications >/dev/null 2>&1; then
+  fail "derivation rejects a BundleProgram that escapes the bundle"
+fi
+app_absolute="$test_tmp/Absolute.app"
+make_app "$app_absolute" /usr/bin/true
+if "$derive" "$app_absolute" "$test_tmp/absolute.plist" /Applications >/dev/null 2>&1; then
+  fail "derivation rejects an absolute BundleProgram"
+fi
+pass "derivation fails closed on missing, escaping, or absolute helper paths"
+
+! grep -Eq 'launchctl bootstrap system "\$PLIST" 2>/dev/null \|\|' "$pkg_dir/scripts/postinstall" ||
+  fail "postinstall no longer hides launchctl bootstrap failures"
+grep -Fq 'exit 1' "$pkg_dir/scripts/postinstall" || fail "postinstall fails the package when the daemon cannot load"
+grep -Fq 'derive-daemon-plist' "$pkg_dir/build-pkg.sh" || fail "build-pkg.sh derives the daemon plist"
+grep -Fq 'daemon Program must be an absolute path' "$pkg_dir/build-pkg.sh" || fail "build-pkg.sh fails on a non-absolute daemon Program"
+pass "the package builder and postinstall fail closed on an unloadable daemon"


### PR DESCRIPTION
The shipped 4.0.2-mac.1.10.090226 package installed the app-embedded LaunchDaemon plist (bundle-relative `BundleProgram`) into /Library/LaunchDaemons; launchd could not load it, the postinstall swallowed the error, and the app reported "privileged helper is not reachable" (hotfixed on the M1 by hand).

- New `Packaging/pkg/derive-daemon-plist` (portable, plistlib) rewrites the embedded plist's `BundleProgram` into an absolute `Program` under `/Applications/<app>/`, keeping Label/MachServices/UserName/EnvironmentVariables, and fails closed on missing, escaping, or absolute helper paths.
- `build-pkg.sh` derives the daemon plist by default (`--plist` becomes an optional, validated override) and refuses to build unless `Program` is absolute under /Applications and exists in the staged app.
- `postinstall` no longer hides `launchctl bootstrap` failures: it logs them and fails the package.
- Shell test covers the derivation and the fail-closed rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)