### PR TITLE
Repoint the Apple Silicon package repository at the newest signed stable snapshot

### DIFF
--- a/bin/omarchy-update
+++ b/bin/omarchy-update
@@ -57,6 +57,18 @@ if [[ ${1:-} == "-y" ]] || omarchy-update-confirm; then
     elif (( bundle_status != 0 )); then
       exit "$bundle_status"
     fi
+    # The [omarchy] repository the ISO pinned stays on its install-time snapshot
+    # otherwise; move it to the newest promoted snapshot before the package sync
+    # so the system upgrade below reads current packages.
+    set +e
+    omarchy-update-asahi-repository --yes
+    repository_status=$?
+    set -e
+    if (( repository_status == 3 )); then
+      echo "Apple Silicon package repository update deferred because its release listing is unavailable." >&2
+    elif (( repository_status != 0 )); then
+      exit "$repository_status"
+    fi
   fi
   omarchy-update-keyring
 

--- a/bin/omarchy-update-asahi-repository
+++ b/bin/omarchy-update-asahi-repository
@@ -1,0 +1,268 @@
+#!/bin/bash
+
+# omarchy:summary=Repoint the Apple Silicon package repository at the newest signed stable snapshot
+# omarchy:args=[--check] [--yes]
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# The ISO bakes an immutable asahi-packages-stable-<commit> snapshot into the
+# [omarchy] Server line of /etc/pacman.conf and nothing revisits it, so an
+# installed Mac keeps reading the snapshot it was installed from while newer
+# promoted snapshots accumulate. This follows the runtime bundle updater: it
+# discovers the newest promoted stable release, proves the release's signed
+# descriptor was produced by the shipped Omarchy ARM repository subkey for that
+# exact source commit, refuses rollbacks, and rewrites only the Server line of
+# the existing [omarchy] block. Every other repository, boot, GRUB, mkinitcpio,
+# and NetworkManager path stays untouched.
+
+set -euo pipefail
+
+repo="${OMARCHY_ASAHI_REPOSITORY_REPO:-maralcbr/omarchy-pkgs}"
+state_file="${OMARCHY_ASAHI_REPOSITORY_STATE:-/var/lib/omarchy/asahi-package-repository}"
+trusted_key=C81AC3E2A99556F9B21D5FEA3DD49BC9F8360BDC
+trusted_subkey=CAB18E175BFB9ACCE185234474DE0C737AC186E4
+trusted_key_file="${OMARCHY_ASAHI_PACKAGE_KEY_FILE:-/usr/share/omarchy/default/omarchy-arm-repository.asc}"
+mode=update
+yes=0
+
+fail() {
+  echo "Apple Silicon package repository update: $*" >&2
+  exit 2
+}
+
+while (($#)); do
+  case "$1" in
+    --check) mode=check ;;
+    -y|--yes) yes=1 ;;
+    -h|--help)
+      echo "Usage: omarchy-update-asahi-repository [--check] [--yes]"
+      exit 0
+      ;;
+    *) fail "unknown option '$1'" ;;
+  esac
+  shift
+done
+
+omarchy-hw-apple-silicon || exit 1
+
+root_path() {
+  printf '%s%s\n' "${OMARCHY_ASAHI_ROOT:-}" "$1"
+}
+
+for command in curl gpg jq sha256sum; do
+  omarchy-cmd-present "$command" || fail "$command is required"
+done
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+gnupg_dir="$workdir/gnupg"
+mkdir -m 0700 "$gnupg_dir"
+[[ -r $trusted_key_file ]] || fail "trusted Omarchy ARM repository key is not installed"
+actual_fingerprint=$(gpg --batch --show-keys --with-colons "$trusted_key_file" 2>/dev/null |
+  awk -F: '$1 == "fpr" { print $10; exit }')
+[[ $actual_fingerprint == "$trusted_key" ]] || fail "trusted Omarchy ARM repository key fingerprint does not match"
+gpg --batch --homedir "$gnupg_dir" --import "$trusted_key_file" >/dev/null 2>&1 || fail "could not load the trusted Omarchy ARM repository key"
+subkey_kind=$(gpg --batch --homedir "$gnupg_dir" --with-colons --list-keys 2>/dev/null |
+  awk -F: -v wanted="$trusted_subkey" '
+    $1 == "pub" || $1 == "sub" { kind=$1; next }
+    $1 == "fpr" && $10 == wanted { print kind; exit }
+  ')
+[[ $subkey_kind == "sub" ]] || fail "trusted Omarchy ARM repository key does not carry the signing subkey"
+
+download() {
+  curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 "$1" --output "$2" || {
+    echo "Apple Silicon package repository update: could not download $1" >&2
+    exit 3
+  }
+}
+
+verify_signature() {
+  local file="$1" signature="$2" status
+  [[ -s $file && -s $signature ]] || fail "missing signed asset $(basename "$file")"
+  status=$(gpg --batch --homedir "$gnupg_dir" --status-fd 1 --verify "$signature" "$file" 2>/dev/null) ||
+    fail "signature verification failed for $(basename "$file")"
+  awk -v key="$trusted_subkey" '$2 == "VALIDSIG" && $3 == key { valid=1 } END { exit !valid }' <<<"$status" ||
+    fail "$(basename "$file") was not signed by the Omarchy ARM repository signing subkey"
+}
+
+# The stable snapshot is the accepted candidate promoted byte for byte, so its
+# descriptor is the candidate's CANDIDATE file, and the stable tag carries the
+# same source commit. Draft, prerelease, and mutable releases are not stable.
+releases_api_url="${OMARCHY_ASAHI_RELEASES_API_URL:-https://api.github.com/repos/$repo/releases?per_page=100}"
+download "$releases_api_url" "$workdir/releases.json"
+tag=$(jq -er '
+  [
+    .[]
+    | select(.draft == false and .prerelease == false and .immutable == true)
+    | select(.tag_name | test("^asahi-packages-stable-[0-9a-f]{40}$"))
+    | select(.published_at | type == "string")
+  ]
+  | max_by(.published_at).tag_name
+' "$workdir/releases.json" 2>/dev/null) || fail "could not discover a promoted Apple Silicon package snapshot"
+[[ $tag =~ ^asahi-packages-stable-([0-9a-f]{40})$ ]] || fail "invalid stable release tag"
+source_commit=${BASH_REMATCH[1]}
+server="https://github.com/$repo/releases/download/$tag"
+
+pacman_conf=$(root_path /etc/pacman.conf)
+[[ -r $pacman_conf ]] || fail "pacman configuration is missing"
+for repository in asahi-alarm core extra alarm aur; do
+  grep -Eq "^[[:space:]]*\[$repository\][[:space:]]*$" "$pacman_conf" || fail "required [$repository] repository is missing"
+done
+block_count=$(grep -Ec '^[[:space:]]*\[omarchy\][[:space:]]*$' "$pacman_conf" || true)
+(( block_count == 1 )) || fail "pacman configuration must contain exactly one [omarchy] repository"
+current_servers=$(awk '
+  /^[[:space:]]*\[omarchy\][[:space:]]*$/ { inside = 1; next }
+  inside && /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { inside = 0 }
+  inside && /^[[:space:]]*Server[[:space:]]*=/ { sub(/^[[:space:]]*Server[[:space:]]*=[[:space:]]*/, ""); print }
+' "$pacman_conf")
+[[ -n $current_servers ]] || fail "[omarchy] repository must have exactly one Server"
+(( $(wc -l <<<"$current_servers") == 1 )) || fail "[omarchy] repository must have exactly one Server"
+current_server=$current_servers
+
+installed_tag="" installed_run=0 installed_source=""
+if [[ -e $state_file ]]; then
+  if [[ ${OMARCHY_ASAHI_TESTING:-0} != 1 ]]; then
+    permissions=$(stat -c '%a' "$state_file")
+    [[ $(stat -c '%u' "$state_file") == 0 ]] || fail "repository state is not root-owned"
+    (( (8#$permissions & 8#022) == 0 )) || fail "repository state is writable by non-root users"
+  fi
+  state_format="" state_descriptor=""
+  while IFS= read -r line; do
+    case "$line" in
+      format=*) state_format=${line#format=} ;;
+      tag=*) installed_tag=${line#tag=} ;;
+      source_commit=*) installed_source=${line#source_commit=} ;;
+      workflow_run=*) installed_run=${line#workflow_run=} ;;
+      descriptor_sha256=*) state_descriptor=${line#descriptor_sha256=} ;;
+      "") ;;
+      *) fail "repository state is malformed" ;;
+    esac
+  done <"$state_file"
+  [[ $state_format == "1" && $installed_tag =~ ^asahi-packages-stable-[0-9a-f]{40}$ ]] || fail "repository state is malformed"
+  [[ $installed_source =~ ^[0-9a-f]{40}$ && $installed_run =~ ^[1-9][0-9]*$ && $state_descriptor =~ ^[0-9a-f]{64}$ ]] ||
+    fail "repository state is malformed"
+fi
+
+if [[ $current_server == "$server" ]]; then
+  [[ $mode != "check" ]] || exit 1
+  echo "Apple Silicon package repository is up to date"
+  exit 0
+fi
+
+base="${OMARCHY_ASAHI_RELEASE_BASE_URL:-$server}"
+base=${base%/}
+download "$base/CANDIDATE" "$workdir/CANDIDATE"
+download "$base/CANDIDATE.sig" "$workdir/CANDIDATE.sig"
+verify_signature "$workdir/CANDIDATE" "$workdir/CANDIDATE.sig"
+descriptor_sha256=$(sha256sum "$workdir/CANDIDATE" | cut -d' ' -f1)
+
+format="" channel="" release_tag="" descriptor_source="" workflow_run="" runner_arch=""
+signing_fingerprint="" package_count="" package_records=0
+declare -A seen_headers=() assets=()
+set_header() {
+  local name=$1 value=$2
+  [[ -z ${seen_headers[$name]:-} ]] || fail "duplicate descriptor header '$name'"
+  printf -v "$name" '%s' "$value"
+  seen_headers[$name]=1
+}
+while IFS= read -r line; do
+  case "$line" in
+    format=*) set_header format "${line#format=}" ;;
+    channel=*) set_header channel "${line#channel=}" ;;
+    release_tag=*) set_header release_tag "${line#release_tag=}" ;;
+    source_commit=*) set_header descriptor_source "${line#source_commit=}" ;;
+    workflow_run=*) set_header workflow_run "${line#workflow_run=}" ;;
+    runner_arch=*) set_header runner_arch "${line#runner_arch=}" ;;
+    signing_fingerprint=*) set_header signing_fingerprint "${line#signing_fingerprint=}" ;;
+    package_count=*) set_header package_count "${line#package_count=}" ;;
+    package=*)
+      IFS='|' read -r index package version architecture filename archive_sha signature_filename signature_sha extra <<<"${line#package=}"
+      [[ -z $extra && $index =~ ^[1-9][0-9]*$ ]] || fail "invalid package record index"
+      (( index == package_records + 1 )) || fail "invalid package record index"
+      [[ $package =~ ^[a-z0-9@._+-]+$ && -n $version && $architecture =~ ^(aarch64|any)$ ]] || fail "invalid package record"
+      [[ $filename =~ ^[A-Za-z0-9._+@-]+\.pkg\.tar\.[A-Za-z0-9.]+$ && $signature_filename == "$filename.sig" ]] || fail "invalid package filename"
+      [[ $archive_sha =~ ^[0-9a-f]{64}$ && $signature_sha =~ ^[0-9a-f]{64}$ ]] || fail "invalid package checksum"
+      ((package_records += 1))
+      ;;
+    asset=*)
+      IFS='|' read -r filename asset_sha extra <<<"${line#asset=}"
+      [[ -z $extra && $filename =~ ^[A-Za-z0-9._-]+$ && $asset_sha =~ ^[0-9a-f]{64}$ ]] || fail "invalid asset record"
+      [[ -z ${assets[$filename]:-} ]] || fail "duplicate asset record"
+      assets[$filename]=$asset_sha
+      ;;
+    "") ;;
+    *) fail "unknown descriptor entry" ;;
+  esac
+done <"$workdir/CANDIDATE"
+
+[[ $format == "1" && $channel == "candidate" ]] || fail "unsupported release descriptor"
+[[ $release_tag == "asahi-packages-candidate-$source_commit" ]] || fail "release descriptor was not promoted from the candidate for $source_commit"
+[[ $descriptor_source == "$source_commit" ]] || fail "release descriptor source commit does not match the stable tag"
+[[ $workflow_run =~ ^[1-9][0-9]*$ && $runner_arch == "aarch64" ]] || fail "invalid build identity"
+[[ $signing_fingerprint == "$trusted_subkey" ]] || fail "release descriptor names a different signing subkey"
+[[ $package_count =~ ^[1-9][0-9]*$ ]] || fail "release descriptor package count is invalid"
+(( package_records == package_count )) || fail "release descriptor package count is invalid"
+for asset in omarchy.db omarchy.db.sig omarchy.files omarchy.files.sig; do
+  [[ -n ${assets[$asset]:-} ]] || fail "release descriptor is missing $asset"
+done
+
+# GitHub workflow run numbers only grow, and the descriptor signs the run that
+# built it, so a promoted snapshot with a lower run than the one already
+# installed is a rollback no matter what the release listing says.
+if [[ -n $installed_tag ]]; then
+  (( workflow_run >= installed_run )) || fail "refusing package repository rollback from $installed_tag to $tag"
+  if (( workflow_run == installed_run )); then
+    [[ $source_commit == "$installed_source" ]] || fail "build $workflow_run was reused for a different source"
+  fi
+fi
+
+if [[ $mode == "check" ]]; then
+  echo "Apple Silicon package repository $tag is available"
+  exit 0
+fi
+
+download "$base/omarchy.db" "$workdir/omarchy.db"
+download "$base/omarchy.db.sig" "$workdir/omarchy.db.sig"
+[[ $(sha256sum "$workdir/omarchy.db" | cut -d' ' -f1) == "${assets[omarchy.db]}" ]] || fail "omarchy.db does not match the signed descriptor"
+[[ $(sha256sum "$workdir/omarchy.db.sig" | cut -d' ' -f1) == "${assets[omarchy.db.sig]}" ]] || fail "omarchy.db.sig does not match the signed descriptor"
+verify_signature "$workdir/omarchy.db" "$workdir/omarchy.db.sig"
+
+if (( ! yes )); then
+  gum confirm "Switch the Apple Silicon package repository to $tag?" </dev/tty || exit 0
+fi
+
+backup="$(root_path /var/lib/omarchy/backups)/asahi-repository-$(date +%Y%m%d%H%M%S)"
+backup_tmp=$(mktemp -d)
+cp "$pacman_conf" "$backup_tmp/pacman.conf"
+config_paths=("$pacman_conf")
+[[ ! -d $(root_path /etc/pacman.d) ]] || config_paths+=("$(root_path /etc/pacman.d)")
+sudo find "${config_paths[@]}" -type f -exec sha256sum {} + >"$backup_tmp/config-sha256.txt"
+sudo install -d -o root -g root -m 0700 "$backup"
+sudo cp -a "$backup_tmp"/. "$backup/"
+rm -rf "$backup_tmp"
+
+if ! sudo pacman-key --finger "$trusted_key" >/dev/null 2>&1; then
+  sudo pacman-key --add "$trusted_key_file"
+  sudo pacman-key --lsign-key "$trusted_key"
+fi
+
+# Only the Server line inside [omarchy] changes; every other byte is copied.
+awk -v server="$server" '
+  /^[[:space:]]*\[omarchy\][[:space:]]*$/ { inside = 1; print; next }
+  inside && /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { inside = 0 }
+  inside && /^[[:space:]]*Server[[:space:]]*=/ { print "Server = " server; next }
+  { print }
+' "$pacman_conf" >"$workdir/pacman.conf"
+sudo install -o root -g root -m 0644 "$workdir/pacman.conf" "$pacman_conf"
+
+if ! sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Sy --noconfirm; then
+  sudo install -o root -g root -m 0644 "$backup/pacman.conf" "$pacman_conf"
+  fail "pacman could not read $tag; restored the previous repository (backup: $backup)"
+fi
+
+state_tmp=$(mktemp)
+printf 'format=1\ntag=%s\nsource_commit=%s\nworkflow_run=%s\ndescriptor_sha256=%s\n' \
+  "$tag" "$source_commit" "$workflow_run" "$descriptor_sha256" >"$state_tmp"
+sudo install -D -o root -g root -m 0644 "$state_tmp" "$state_file"
+rm -f "$state_tmp"
+echo "Switched the Apple Silicon package repository to $tag (backup: $backup)"

--- a/bin/omarchy-update-available
+++ b/bin/omarchy-update-available
@@ -9,17 +9,19 @@ updates=()
 asahi=0
 if omarchy-hw-apple-silicon; then
   asahi=1
-  set +e
-  update=$(omarchy-update-asahi-bundle --check)
-  asahi_status=$?
-  set -e
-  if (( asahi_status == 0 )); then
-    updates+=("$update")
-  elif (( asahi_status == 3 )); then
-    : # Transport outages must not hide unrelated package updates.
-  elif (( asahi_status != 1 )); then
-    exit "$asahi_status"
-  fi
+  for asahi_check in omarchy-update-asahi-bundle omarchy-update-asahi-repository; do
+    set +e
+    update=$("$asahi_check" --check)
+    asahi_status=$?
+    set -e
+    if (( asahi_status == 0 )); then
+      updates+=("$update")
+    elif (( asahi_status == 3 )); then
+      : # Transport outages must not hide unrelated package updates.
+    elif (( asahi_status != 1 )); then
+      exit "$asahi_status"
+    fi
+  done
 fi
 
 if [[ $OMARCHY_PATH != "/usr/share/omarchy" ]]; then

--- a/docs/apple-silicon-x86-parity-gaps.md
+++ b/docs/apple-silicon-x86-parity-gaps.md
@@ -112,6 +112,18 @@ at the new stable tag and rebuild the image.
 **Priority: highest.** Everything else in this document is a robustness
 improvement; this one is the actual parity difference.
 
+**Installed systems no longer wait for a rebuilt image.** `omarchy update`
+now runs `omarchy-update-asahi-repository` on Apple Silicon, right after the
+runtime bundle and before the package sync. It reads the `omarchy-pkgs`
+release listing, picks the newest non-draft, non-prerelease, immutable
+`asahi-packages-stable-<commit>` release, verifies that release's signed
+`CANDIDATE` descriptor against the shipped
+`default/omarchy-arm-repository.asc` signing subkey and the tag's own source
+commit, refuses to move to a lower signed workflow run, and then rewrites only
+the `Server` line of the existing `[omarchy]` block after backing the file up
+under `/var/lib/omarchy/backups/`. The ISO pin above is still worth updating so
+fresh installs start current, but it is no longer the only way forward.
+
 ---
 
 ## Gap 2 — a long build outlives the sudo credential cache

--- a/test/shell.d/asahi-repository-update-test.sh
+++ b/test/shell.d/asahi-repository-update-test.sh
@@ -1,0 +1,364 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/base-test.sh"
+
+require_command jq
+require_command sha256sum
+
+updater="$ROOT/bin/omarchy-update-asahi-repository"
+update="$ROOT/bin/omarchy-update"
+update_available="$ROOT/bin/omarchy-update-available"
+certificate="$ROOT/default/omarchy-arm-repository.asc"
+primary_fingerprint=C81AC3E2A99556F9B21D5FEA3DD49BC9F8360BDC
+subkey_fingerprint=CAB18E175BFB9ACCE185234474DE0C737AC186E4
+repo=maralcbr/omarchy-pkgs
+
+[[ -s $certificate ]] || fail "Omarchy ARM repository certificate ships with the runtime"
+if command -v gpg >/dev/null; then
+  colons=$(gpg --batch --show-keys --with-colons "$certificate" 2>/dev/null || true)
+  grep -Fxq "fpr:::::::::$primary_fingerprint:" <<<"$colons" ||
+    fail "Omarchy ARM repository certificate has the pinned primary fingerprint"
+  grep -Fxq "fpr:::::::::$subkey_fingerprint:" <<<"$colons" ||
+    fail "Omarchy ARM repository certificate carries the pinned signing subkey"
+fi
+grep -Fq "trusted_subkey=$subkey_fingerprint" "$updater" || fail "repository updater pins the signing subkey"
+grep -Fq '$2 == "VALIDSIG" && $3 == key' "$updater" || fail "repository updater requires the descriptor signature from the subkey itself"
+grep -Fq '# omarchy:hidden=true' "$updater" || fail "repository updater is hidden from command listings"
+grep -Fq '# omarchy:requires-sudo=true' "$updater" || fail "repository updater declares its sudo requirement"
+grep -Fq 'omarchy-update-asahi-repository --yes' "$update" || fail "normal updates repoint the Apple Silicon package repository"
+grep -Fq 'repository_status == 3' "$update" || fail "repository listing outages do not block platform package updates"
+awk '/omarchy-update-asahi-repository --yes/ { seen = 1 } seen && /omarchy-update-system-pkgs$/ { ordered = 1 } END { exit !ordered }' "$update" ||
+  fail "the repository is repointed before the system package upgrade"
+grep -Fq 'omarchy-update-asahi-repository' "$update_available" || fail "availability checks include the package repository"
+pass "Apple Silicon package repository updates are wired into the update flow"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+stub_bin="$test_tmp/bin"
+assets="$test_tmp/assets"
+state="$test_tmp/state"
+calls="$test_tmp/calls"
+root="$test_tmp/root"
+pacman_conf="$root/etc/pacman.conf"
+old_commit=afd72814b7b29dddef2e07c7ed125101de34d4f4
+new_commit=901e39bdc0dd42a93644bce14a07eeb9bb18a12c
+old_tag="asahi-packages-stable-$old_commit"
+new_tag="asahi-packages-stable-$new_commit"
+mkdir -p "$stub_bin" "$assets" "$root/etc/pacman.d" "$root/proc/device-tree"
+: >"$test_tmp/omarchy-arm-repository.asc"
+printf 'apple,j314s\0apple,arm-platform\0' >"$root/proc/device-tree/compatible"
+
+write_pacman_conf() {
+  local tag="$1"
+  cat >"$pacman_conf" <<CONF
+[options]
+Architecture = aarch64
+SigLevel = Required DatabaseOptional
+
+[asahi-alarm]
+Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/\$arch
+
+[omarchy]
+SigLevel = Required DatabaseOptional
+Server = https://github.com/$repo/releases/download/$tag
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+[alarm]
+Include = /etc/pacman.d/mirrorlist
+
+[aur]
+Include = /etc/pacman.d/mirrorlist
+CONF
+  printf 'Server = http://mirror.archlinuxarm.org/$arch/$repo\n' >"$root/etc/pacman.d/mirrorlist"
+}
+
+write_release_listing() {
+  cat >"$assets/releases.json" <<EOF
+[
+  {"tag_name":"asahi-packages-candidate-$new_commit","draft":false,"prerelease":true,"immutable":true,"published_at":"2026-09-01T09:20:52Z"},
+  {"tag_name":"asahi-packages-stable-ffffffffffffffffffffffffffffffffffffffff","draft":true,"prerelease":false,"immutable":true,"published_at":"2026-09-03T00:00:00Z"},
+  {"tag_name":"asahi-packages-stable-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","draft":false,"prerelease":false,"immutable":false,"published_at":"2026-09-03T00:00:00Z"},
+  {"tag_name":"asahi-packages-stable-dddddddddddddddddddddddddddddddddddddddd","draft":false,"prerelease":true,"immutable":true,"published_at":"2026-09-03T00:00:00Z"},
+  {"tag_name":"$new_tag","draft":false,"prerelease":false,"immutable":true,"published_at":"2026-09-02T02:14:02Z"},
+  {"tag_name":"$old_tag","draft":false,"prerelease":false,"immutable":true,"published_at":"2026-08-25T05:11:46Z"},
+  {"tag_name":"asahi-packages-784daa3efaecfa81b5b4da888b524e6ec4574d24","draft":false,"prerelease":false,"immutable":true,"published_at":"2026-09-04T00:00:00Z"},
+  {"tag_name":"asahi-quattro-channel-26","draft":false,"prerelease":false,"immutable":true,"published_at":"2026-09-04T00:00:00Z"}
+]
+EOF
+}
+
+write_descriptor() {
+  local commit="$1" workflow_run="$2" release_dir
+  release_dir="$assets/asahi-packages-stable-$commit"
+  mkdir -p "$release_dir"
+  printf 'omarchy database for %s\n' "$commit" >"$release_dir/omarchy.db"
+  printf 'signature\n' >"$release_dir/omarchy.db.sig"
+  cat >"$release_dir/CANDIDATE" <<EOF
+format=1
+channel=candidate
+release_tag=asahi-packages-candidate-$commit
+source_commit=$commit
+workflow_run=$workflow_run
+runner_arch=aarch64
+signing_fingerprint=$subkey_fingerprint
+package_count=2
+asset=omarchy.db|$(sha256sum "$release_dir/omarchy.db" | cut -d' ' -f1)
+asset=omarchy.db.sig|$(sha256sum "$release_dir/omarchy.db.sig" | cut -d' ' -f1)
+asset=omarchy.files|$(printf '%064d' 1)
+asset=omarchy.files.sig|$(printf '%064d' 2)
+package=1|aether|4.27.2-1|aarch64|aether-4.27.2-1-aarch64.pkg.tar.zst|$(printf '%064d' 3)|aether-4.27.2-1-aarch64.pkg.tar.zst.sig|$(printf '%064d' 4)
+package=2|yay|12.6.0-1|aarch64|yay-12.6.0-1-aarch64.pkg.tar.zst|$(printf '%064d' 5)|yay-12.6.0-1-aarch64.pkg.tar.zst.sig|$(printf '%064d' 6)
+EOF
+  printf 'signature\n' >"$release_dir/CANDIDATE.sig"
+}
+
+cat >"$stub_bin/omarchy-hw-apple-silicon" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$stub_bin/curl" <<'SH'
+#!/bin/bash
+output=""
+url=""
+while (($#)); do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    http*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "$url" >>"$TEST_CURL_LOG"
+[[ ${TEST_CURL_OFFLINE:-0} != 1 ]] || exit 7
+if [[ $url == */releases\?per_page=100 ]]; then
+  cp "$TEST_ASSETS/releases.json" "$output"
+else
+  path=${url#https://github.com/maralcbr/omarchy-pkgs/releases/download/}
+  [[ -f $TEST_ASSETS/$path ]] || exit 22
+  cp "$TEST_ASSETS/$path" "$output"
+fi
+SH
+cat >"$stub_bin/gpg" <<'SH'
+#!/bin/bash
+primary=C81AC3E2A99556F9B21D5FEA3DD49BC9F8360BDC
+subkey=CAB18E175BFB9ACCE185234474DE0C737AC186E4
+if [[ " $* " == *" --show-keys "* ]]; then
+  printf 'pub:-:255:22:%s:::::::cSC::::::::0:\nfpr:::::::::%s:\n' "${primary:24}" "$primary"
+  exit 0
+fi
+if [[ " $* " == *" --import "* ]]; then
+  exit 0
+fi
+if [[ " $* " == *" --list-keys "* ]]; then
+  printf 'pub:-:255:22:%s:::::::cSC::::::::0:\nfpr:::::::::%s:\nsub:-:255:22:%s:::::::s::::::::0:\nfpr:::::::::%s:\n' \
+    "${primary:24}" "$primary" "${subkey:24}" "$subkey"
+  exit 0
+fi
+[[ ${TEST_GPG_FAIL:-0} != 1 ]] || exit 1
+signer=$subkey
+[[ ${TEST_GPG_SIGNER:-subkey} == "subkey" ]] || signer=$primary
+echo "[GNUPG:] VALIDSIG $signer 2026-01-01 0 4 0 1 22 00 $primary"
+SH
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo:%s\n' "$*" >>"$TEST_CALLS"
+if [[ $1 == "env" ]]; then
+  shift
+  while [[ $1 == *=* ]]; do export "$1"; shift; done
+fi
+exec "$@"
+SH
+cat >"$stub_bin/install" <<'SH'
+#!/bin/bash
+args=()
+while (($#)); do
+  case "$1" in
+    -o|-g) shift 2 ;;
+    *) args+=("$1"); shift ;;
+  esac
+done
+exec /usr/bin/install "${args[@]}"
+SH
+cat >"$stub_bin/pacman-key" <<'SH'
+#!/bin/bash
+printf 'pacman-key:%s\n' "$*" >>"$TEST_CALLS"
+if [[ $1 == "--finger" ]]; then
+  [[ -f $TEST_KEY_STATE ]]
+elif [[ $1 == "--add" ]]; then
+  : >"$TEST_KEY_STATE"
+fi
+SH
+cat >"$stub_bin/pacman" <<'SH'
+#!/bin/bash
+printf 'pacman:%s OMARCHY_UPDATE_PACMAN=%s\n' "$*" "${OMARCHY_UPDATE_PACMAN:-}" >>"$TEST_CALLS"
+[[ ${TEST_PACMAN_FAIL:-0} != 1 ]]
+SH
+cat >"$stub_bin/gum" <<'SH'
+#!/bin/bash
+echo "gum must not prompt under --yes" >&2
+exit 1
+SH
+chmod +x "$stub_bin"/*
+
+run_updater() {
+  TEST_ASSETS="$assets" \
+    TEST_CURL_LOG="$test_tmp/curl.log" \
+    TEST_CALLS="$calls" \
+    TEST_KEY_STATE="$test_tmp/key-trusted" \
+    OMARCHY_ASAHI_TESTING=1 \
+    OMARCHY_ASAHI_ROOT="$root" \
+    OMARCHY_ASAHI_REPOSITORY_STATE="$state" \
+    OMARCHY_ASAHI_PACKAGE_KEY_FILE="$test_tmp/omarchy-arm-repository.asc" \
+    OMARCHY_ASAHI_RELEASES_API_URL="https://api.github.test/repos/example/releases?per_page=100" \
+    PATH="$stub_bin:$PATH" \
+    "$updater" "$@"
+}
+
+run_status() {
+  local out="$1" err="$2"
+  shift 2
+  set +e
+  run_updater "$@" >"$out" 2>"$err"
+  status=$?
+  set -e
+}
+
+reset_run() {
+  : >"$test_tmp/curl.log"
+  : >"$calls"
+  rm -f "$state" "$test_tmp/key-trusted"
+}
+
+write_release_listing
+write_descriptor "$old_commit" 33000000000
+write_descriptor "$new_commit" 33487927893
+write_pacman_conf "$old_tag"
+
+reset_run
+run_status "$test_tmp/check.out" "$test_tmp/check.err" --check
+(( status == 0 )) || fail "newer stable snapshot is reported as available" "status $status: $(cat "$test_tmp/check.err")"
+grep -Fxq "Apple Silicon package repository $new_tag is available" "$test_tmp/check.out" ||
+  fail "availability names the selected stable snapshot" "$(cat "$test_tmp/check.out")"
+grep -Fxq 'https://api.github.test/repos/example/releases?per_page=100' "$test_tmp/curl.log" ||
+  fail "stable discovery reads the GitHub releases listing"
+grep -Fxq "https://github.com/$repo/releases/download/$new_tag/CANDIDATE" "$test_tmp/curl.log" ||
+  fail "stable discovery downloads the signed descriptor of the newest promoted snapshot"
+grep -Fxq "https://github.com/$repo/releases/download/$new_tag/CANDIDATE.sig" "$test_tmp/curl.log" ||
+  fail "stable discovery downloads the descriptor signature"
+! grep -Fq 'omarchy.db' "$test_tmp/curl.log" || fail "availability checks do not download the repository database"
+[[ ! -s $calls ]] || fail "availability checks do not touch the system" "$(cat "$calls")"
+pass "drafts, prereleases, mutable releases, candidates, and legacy tags are ignored in favour of the newest promoted stable snapshot"
+
+write_pacman_conf "$new_tag"
+reset_run
+run_status "$test_tmp/current.out" "$test_tmp/current.err" --check
+(( status == 1 )) || fail "current stable snapshot uses the no-update status" "status $status: $(cat "$test_tmp/current.err")"
+! grep -Fq CANDIDATE "$test_tmp/curl.log" || fail "a current repository skips the descriptor download"
+run_status "$test_tmp/current-apply.out" "$test_tmp/current-apply.err" --yes
+(( status == 0 )) || fail "current stable snapshot is a successful no-op" "status $status: $(cat "$test_tmp/current-apply.err")"
+grep -Fxq 'Apple Silicon package repository is up to date' "$test_tmp/current-apply.out" || fail "current snapshot reports up to date"
+[[ ! -s $calls ]] || fail "a current repository is not rewritten" "$(cat "$calls")"
+pass "a repository already on the newest snapshot is left alone"
+
+write_pacman_conf "$old_tag"
+reset_run
+sed -i "s/^source_commit=.*/source_commit=$old_commit/" "$assets/$new_tag/CANDIDATE"
+run_status "$test_tmp/source.out" "$test_tmp/source.err" --check
+(( status == 2 )) || fail "descriptor for another source fails closed" "status $status"
+grep -Fq 'source commit does not match the stable tag' "$test_tmp/source.err" ||
+  fail "descriptor source mismatch explains the refusal" "$(cat "$test_tmp/source.err")"
+write_descriptor "$new_commit" 33487927893
+pass "a stable tag whose descriptor names another source is rejected"
+
+reset_run
+TEST_GPG_SIGNER=primary run_status "$test_tmp/primary.out" "$test_tmp/primary.err" --check
+(( status == 2 )) || fail "descriptor signed by the primary key fails closed" "status $status"
+grep -Fq 'was not signed by the Omarchy ARM repository signing subkey' "$test_tmp/primary.err" ||
+  fail "primary key signature explains the refusal" "$(cat "$test_tmp/primary.err")"
+TEST_GPG_FAIL=1 run_status "$test_tmp/badsig.out" "$test_tmp/badsig.err" --check
+(( status == 2 )) || fail "invalid descriptor signature fails closed" "status $status"
+grep -Fq 'signature verification failed for CANDIDATE' "$test_tmp/badsig.err" ||
+  fail "invalid signature explains the refusal" "$(cat "$test_tmp/badsig.err")"
+pass "only descriptors signed by the shipped repository subkey are accepted"
+
+reset_run
+cat >"$state" <<EOF
+format=1
+tag=asahi-packages-stable-0123456789abcdef0123456789abcdef01234567
+source_commit=0123456789abcdef0123456789abcdef01234567
+workflow_run=33500000000
+descriptor_sha256=$(printf '%064d' 9)
+EOF
+run_status "$test_tmp/rollback.out" "$test_tmp/rollback.err" --check
+(( status == 2 )) || fail "older build than the installed snapshot fails closed" "status $status"
+grep -Fq "refusing package repository rollback from asahi-packages-stable-0123456789abcdef0123456789abcdef01234567 to $new_tag" "$test_tmp/rollback.err" ||
+  fail "rollback refusal names both snapshots" "$(cat "$test_tmp/rollback.err")"
+pass "signed workflow runs prevent repository rollback"
+
+reset_run
+TEST_CURL_OFFLINE=1 run_status "$test_tmp/offline.out" "$test_tmp/offline.err" --check
+(( status == 3 )) || fail "listing outages use the transport status" "status $status"
+pass "release listing outages are reported as transport failures"
+
+reset_run
+sed -i '/^\[aur\]$/d' "$pacman_conf"
+run_status "$test_tmp/aur.out" "$test_tmp/aur.err" --yes
+(( status == 2 )) || fail "missing platform repository fails closed" "status $status"
+grep -Fq 'required [aur] repository is missing' "$test_tmp/aur.err" || fail "missing repository is named" "$(cat "$test_tmp/aur.err")"
+write_pacman_conf "$old_tag"
+printf '\n[omarchy]\nServer = https://example.test/other\n' >>"$pacman_conf"
+run_status "$test_tmp/twice.out" "$test_tmp/twice.err" --yes
+(( status == 2 )) || fail "duplicate [omarchy] blocks fail closed" "status $status"
+grep -Fq 'exactly one [omarchy] repository' "$test_tmp/twice.err" || fail "duplicate block refusal is explained" "$(cat "$test_tmp/twice.err")"
+[[ ! -s $calls ]] || fail "malformed pacman configuration is never rewritten" "$(cat "$calls")"
+pass "protected pacman configuration is validated before any change"
+
+write_pacman_conf "$old_tag"
+reset_run
+before=$(sed "s|$old_tag|$new_tag|" "$pacman_conf")
+run_status "$test_tmp/apply.out" "$test_tmp/apply.err" --yes
+(( status == 0 )) || fail "repository switch succeeds" "status $status: $(cat "$test_tmp/apply.err")"
+grep -Fq "Switched the Apple Silicon package repository to $new_tag" "$test_tmp/apply.out" ||
+  fail "repository switch reports the new snapshot" "$(cat "$test_tmp/apply.out")"
+[[ $(cat "$pacman_conf") == "$before" ]] || fail "only the [omarchy] Server line changes" "$(diff <(echo "$before") "$pacman_conf" || true)"
+grep -Fxq "https://github.com/$repo/releases/download/$new_tag/omarchy.db" "$test_tmp/curl.log" ||
+  fail "the repository database is downloaded before switching"
+grep -Fq 'sudo:pacman-key --finger C81AC3E2A99556F9B21D5FEA3DD49BC9F8360BDC' "$calls" || fail "the repository key trust is checked"
+grep -Fxq "pacman-key:--add $test_tmp/omarchy-arm-repository.asc" "$calls" || fail "a missing repository key is imported into pacman"
+grep -Fxq 'pacman-key:--lsign-key C81AC3E2A99556F9B21D5FEA3DD49BC9F8360BDC' "$calls" || fail "the imported repository key is locally signed"
+grep -Fxq 'pacman:-Sy --noconfirm OMARCHY_UPDATE_PACMAN=1' "$calls" || fail "the new repository is synced through the update guard"
+grep -Eq "^sudo:install -d -o root -g root -m 0700 $root/var/lib/omarchy/backups/asahi-repository-[0-9]{14}\$" "$calls" ||
+  fail "a root-owned backup directory is created" "$(cat "$calls")"
+[[ -f $(ls -d "$root"/var/lib/omarchy/backups/asahi-repository-*/pacman.conf) ]] || fail "the previous pacman.conf is backed up"
+[[ -f $state ]] || fail "repository state is recorded"
+grep -Fxq "tag=$new_tag" "$state" || fail "repository state records the snapshot"
+grep -Fxq 'workflow_run=33487927893' "$state" || fail "repository state records the signed build"
+grep -Fxq "descriptor_sha256=$(sha256sum "$assets/$new_tag/CANDIDATE" | cut -d' ' -f1)" "$state" ||
+  fail "repository state records the descriptor digest"
+pass "the [omarchy] repository is repointed at the verified stable snapshot"
+
+reset_run
+run_status "$test_tmp/again.out" "$test_tmp/again.err" --check
+(( status == 1 )) || fail "the switched repository is current" "status $status: $(cat "$test_tmp/again.err")"
+pass "a switched repository is not offered again"
+
+write_pacman_conf "$old_tag"
+reset_run
+: >"$test_tmp/key-trusted"
+TEST_PACMAN_FAIL=1 run_status "$test_tmp/sync.out" "$test_tmp/sync.err" --yes
+(( status == 2 )) || fail "a failed repository sync fails closed" "status $status"
+grep -Fq 'restored the previous repository' "$test_tmp/sync.err" || fail "sync failure explains the restore" "$(cat "$test_tmp/sync.err")"
+grep -Fxq "Server = https://github.com/$repo/releases/download/$old_tag" "$pacman_conf" || fail "a failed sync restores the previous Server"
+! grep -Fq 'pacman-key:--add' "$calls" || fail "an already trusted key is not re-imported"
+[[ ! -f $state ]] || fail "a failed sync records no state"
+pass "a snapshot pacman cannot read leaves the previous repository in place"


### PR DESCRIPTION
Existing Apple Silicon installs kept the [omarchy] Server pin baked at install time (e.g. asahi-packages-stable-afd72814, the 21-package Aug-26 snapshot) and never saw newer promoted snapshots such as asahi-packages-stable-901e39bd (33 packages). Adds omarchy-update-asahi-repository, gated by omarchy-hw-apple-silicon, which resolves the newest asahi-packages-stable-<sha> release whose descriptor verifies against the shipped repository signing key and repoints /etc/pacman.conf, wired into the update-available path, with a shell test and a parity-gap note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)