### PR TITLE
fix: keep Apple Silicon speakers from popping between any PipeWire streams

### DIFF
--- a/bin/omarchy-migrate
+++ b/bin/omarchy-migrate
@@ -133,6 +133,7 @@ asahi_migration_disposition() {
     1788102906.sh) printf 'run\treviewed architecture-neutral XCompose and legacy udev rule repair\n' ;;
     1788112314.sh) printf 'run\treviewed no-op: Asahi installs do not use the rc mirror pairing\n' ;;
     1788124236.sh) printf 'run\treviewed sshd hardening; self-gating on an enabled or active sshd\n' ;;
+    1788345489.sh) printf 'run\tApple Silicon speaker pop fix gates itself to Apple Silicon hardware\n' ;;
     1788486400.sh) printf 'run\treviewed default package parity install; every package is built for aarch64\n' ;;
     *) return 1 ;;
   esac

--- a/default/wireplumber/scripts/node/software-dsp.lua
+++ b/default/wireplumber/scripts/node/software-dsp.lua
@@ -1,0 +1,125 @@
+-- WirePlumber
+--
+-- Based on node/software-dsp.lua from WirePlumber.
+-- Loads the same asahi-audio graphs, but keeps speaker DSP filter-chain
+-- nodes from pausing/suspending between short-lived streams (Chromium,
+-- YouTube seeks, any client that closes its PipeWire stream). That pause
+-- cuts the convolver tail and pops. Mic graphs are left unchanged.
+--
+-- SPDX-License-Identifier: MIT
+
+log = Log.open_topic("s-node")
+
+config = {}
+config.rules = Conf.get_section_as_json("node.software-dsp.rules", Json.Array{})
+
+clients_om = ObjectManager {
+  Interest { type = "client" }
+}
+
+filter_nodes = {}
+hidden_nodes = {}
+
+-- Speaker graphs (graph.json, graph-j414.json, ...) not mic graphs.
+local function is_speaker_graph(path)
+  return type(path) == "string" and path:find("/graph", 1, true) ~= nil
+end
+
+-- Keep the FIR/convolver chain processing silence instead of pausing when
+-- the client stream disappears. Matches AsahiLinux/asahi-audio#84.
+local function keep_speaker_dsp_alive(args)
+  args = args:gsub('"node%.passive"%s*:%s*"true"', '"node.passive": false')
+  if args:find("session.suspend-timeout-seconds", 1, true) then
+    return args
+  end
+  args = args:gsub(
+    '"capture%.props"%s*:%s*{',
+    '"capture.props": { "node.pause-on-idle": false, "session.suspend-timeout-seconds": 0,'
+  )
+  args = args:gsub(
+    '"playback%.props"%s*:%s*{',
+    '"playback.props": { "node.pause-on-idle": false, "session.suspend-timeout-seconds": 0,'
+  )
+  return args
+end
+
+SimpleEventHook {
+  name = "node/dsp/create-dsp-node",
+  interests = {
+    EventInterest {
+      Constraint  { "event.type", "=", "node-added" },
+    },
+  },
+  execute = function(event)
+    local node = event:get_subject()
+    JsonUtils.match_rules (config.rules, node.properties, function (action, value)
+      if action == "create-filter" then
+        local props = value:parse (1)
+        log:debug("DSP rule found for " .. node.properties["node.name"])
+
+        if props["filter-graph"] then
+          log:debug("Loading filter graph for " .. node.properties["node.name"])
+          local graph = props["filter-graph"]
+          if type(graph) == "string" and is_speaker_graph(tostring(graph)) then
+            graph = keep_speaker_dsp_alive(graph)
+          end
+          filter_nodes[node.id] = LocalModule("libpipewire-module-filter-chain", graph, {})
+        elseif props["filter-path"] then
+          log:debug("Loading filter graph for " .. node.properties["node.name"] .. " from disk")
+          local conf = Conf(props["filter-path"], {
+            ["as-section"] = "node.software-dsp.graph",
+            ["no-fragments"] = true
+          })
+          local err = conf:open()
+          if not err then
+            local args = conf:get_section_as_json("node.software-dsp.graph"):to_string()
+            if is_speaker_graph(props["filter-path"]) then
+              args = keep_speaker_dsp_alive(args)
+              log:info("Keeping speaker DSP alive for " .. props["filter-path"])
+            end
+            filter_nodes[node.id] = LocalModule("libpipewire-module-filter-chain", args, {})
+          else
+            log:warning("Unable to load filter graph for " .. node.properties["node.name"])
+          end
+        end
+
+        if props["hide-parent"] then
+          log:debug("Setting permissions to '-' on " .. node.properties["node.name"] .. " for open clients")
+          for client in clients_om:iterate{ type = "client" } do
+            if not client["properties"]["wireplumber.daemon"] then
+              client:update_permissions{ [node["bound-id"]] = "-" }
+            end
+          end
+          hidden_nodes[node["bound-id"]] = node.id
+        end
+      end
+    end)
+  end
+}:register()
+
+SimpleEventHook {
+  name = "node/dsp/free-dsp-node",
+  interests = {
+    EventInterest {
+      Constraint  { "event.type", "=", "node-removed" },
+    },
+  },
+  execute = function(event)
+    local node = event:get_subject()
+    if filter_nodes[node.id] then
+      log:debug("Freeing filter on node " .. node.id)
+      filter_nodes[node.id] = nil
+      hidden_nodes[node["bound-id"]] = nil
+    end
+  end
+}:register()
+
+clients_om:connect("object-added", function (om, client)
+  for id, _ in pairs(hidden_nodes) do
+    if not client["properties"]["wireplumber.daemon"] then
+      client:update_permissions { [id] = "-" }
+    end
+  end
+end)
+
+clients_om:activate()

--- a/default/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf
+++ b/default/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf
@@ -1,0 +1,29 @@
+## Keep the Apple Silicon speaker and headphone outputs open between streams.
+##
+## PipeWire suspends an idle sink after five seconds. On Apple Silicon Macs that
+## closes the ALSA device and powers down the TAS2764 speaker amplifiers (and
+## the headphone codec); the next stream reopens the device and the amplifiers
+## power back up with an audible pop, so every start and stop of playback
+## clicks. A zero timeout keeps that node open so the amplifiers stay powered.
+## The companion software-dsp.lua overlay also stops the asahi-audio convolver
+## graph from pausing when a client (Chromium, mpv, ...) closes its stream.
+##
+## Matched by api.alsa.path rather than node.name because the Asahi rules in
+## /usr/share/wireplumber/wireplumber.conf.d/99-asahi.conf rename the speaker
+## node and hide it behind the per-model filter chain. Device 1 is the speaker
+## array and device 0 the headphone jack on every AppleJ model.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        api.alsa.path = "~hw:AppleJ[0-9][0-9][0-9],[01]"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]

--- a/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf
+++ b/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf
@@ -1,0 +1,29 @@
+## Keep the Apple Silicon speaker and headphone outputs open between streams.
+##
+## PipeWire suspends an idle sink after five seconds. On Apple Silicon Macs that
+## closes the ALSA device and powers down the TAS2764 speaker amplifiers (and
+## the headphone codec); the next stream reopens the device and the amplifiers
+## power back up with an audible pop, so every start and stop of playback
+## clicks. A zero timeout keeps that node open so the amplifiers stay powered.
+## The companion software-dsp.lua overlay also stops the asahi-audio convolver
+## graph from pausing when a client (Chromium, mpv, ...) closes its stream.
+##
+## Matched by api.alsa.path rather than node.name because the Asahi rules in
+## /usr/share/wireplumber/wireplumber.conf.d/99-asahi.conf rename the speaker
+## node and hide it behind the per-model filter chain. Device 1 is the speaker
+## array and device 0 the headphone jack on every AppleJ model.
+
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        api.alsa.path = "~hw:AppleJ[0-9][0-9][0-9],[01]"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]

--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -35,6 +35,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-spi-keyboard.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-suspend-nvme.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-t2.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-asahi-hid-race.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/fix-speaker-pop.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"

--- a/install/hardware/apple/fix-speaker-pop.sh
+++ b/install/hardware/apple/fix-speaker-pop.sh
@@ -1,0 +1,24 @@
+# Keep the Apple Silicon speaker amplifiers powered between streams, and keep
+# the asahi-audio DSP graph from pausing when a client closes its stream.
+#
+# These files are machine-wide so every user session and every PipeWire/Pulse
+# client (current or future) gets the fix. The ALSA drop-in is also shipped
+# at etc/wireplumber/ for omarchy-settings; this leaf still copies it so an
+# install whose settings package predates that path is repaired. The DSP
+# overlay cannot live in omarchy-settings: it shadows WirePlumber's
+# node/software-dsp.lua and must not do that on x86.
+omarchy-hw-apple-silicon || return 0
+
+echo "Detected Apple Silicon Mac: keeping the speaker amplifiers and DSP graph powered between streams"
+
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+dropin="$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf"
+dsp="$OMARCHY_PATH/default/wireplumber/scripts/node/software-dsp.lua"
+sys_conf="${OMARCHY_ASAHI_SPEAKER_CONF:-/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf}"
+sys_dsp="${OMARCHY_ASAHI_SPEAKER_DSP:-/usr/local/share/wireplumber/scripts/node/software-dsp.lua}"
+
+sudo mkdir -p "$(dirname "$sys_conf")"
+sudo cp "$dropin" "$sys_conf"
+
+sudo mkdir -p "$(dirname "$sys_dsp")"
+sudo cp "$dsp" "$sys_dsp"

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -8,6 +8,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-audio-mixer.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/asus/fix-mic.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/framework/fix-f13-amd-audio-input.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/apple/fix-speaker-pop.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"

--- a/install/user/hardware/apple/fix-speaker-pop.sh
+++ b/install/user/hardware/apple/fix-speaker-pop.sh
@@ -1,0 +1,20 @@
+# Keep the Apple Silicon speaker amplifiers powered between streams, and keep
+# the asahi-audio DSP graph from pausing when a client closes its stream.
+#
+# Machine-wide copies live under /etc and /usr/local (see
+# install/hardware/apple/fix-speaker-pop.sh). This per-user copy covers the
+# session that is finalizing now, including users created after install, and
+# stays in lockstep with the shipped files whenever the leaf re-runs.
+omarchy-hw-apple-silicon || return 0
+
+echo "Detected Apple Silicon Mac: keeping the speaker amplifiers and DSP graph powered between streams"
+
+mkdir -p "$HOME/.config/wireplumber/wireplumber.conf.d"
+cp "$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf" \
+  "$HOME/.config/wireplumber/wireplumber.conf.d/"
+
+# WirePlumber loads scripts from XDG_DATA_HOME before /usr/share, so this
+# shadows node/software-dsp.lua for this user without touching the package.
+mkdir -p "$HOME/.local/share/wireplumber/scripts/node"
+cp "$OMARCHY_PATH/default/wireplumber/scripts/node/software-dsp.lua" \
+  "$HOME/.local/share/wireplumber/scripts/node/"

--- a/migrations/1788345489.sh
+++ b/migrations/1788345489.sh
@@ -1,0 +1,26 @@
+echo "Keep the Apple Silicon speaker amplifiers and DSP graph powered so playback stops popping"
+
+# The hardware leaf writes the machine-wide copies; the user leaf writes the
+# per-session copies. New installs run both; this migration reaches machines
+# that predate either leaf. Re-run if any of the four files is missing so an
+# ALSA-only or user-only copy from an earlier revision still becomes OS-wide.
+OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
+hardware_script="$OMARCHY_PATH/install/hardware/apple/fix-speaker-pop.sh"
+user_script="$OMARCHY_PATH/install/user/hardware/apple/fix-speaker-pop.sh"
+sys_conf="${OMARCHY_ASAHI_SPEAKER_CONF:-/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf}"
+sys_dsp="${OMARCHY_ASAHI_SPEAKER_DSP:-/usr/local/share/wireplumber/scripts/node/software-dsp.lua}"
+user_conf="$HOME/.config/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf"
+user_dsp="$HOME/.local/share/wireplumber/scripts/node/software-dsp.lua"
+
+[[ -f $hardware_script || -f $user_script ]] || exit 0
+[[ -f $sys_conf && -f $sys_dsp && -f $user_conf && -f $user_dsp ]] && exit 0
+
+[[ -f $hardware_script ]] && source "$hardware_script"
+[[ -f $user_script ]] && source "$user_script"
+[[ -f $sys_conf && -f $sys_dsp ]] || [[ -f $user_conf && -f $user_dsp ]] || exit 0
+
+# WirePlumber only reads drop-ins and scripts at startup. Restarting the audio
+# stack is a few hundred milliseconds of silence in the visible update terminal,
+# and it is what makes the fix take effect without a logout. A failed restart is
+# not a failed migration: the files are in place and the next login picks them up.
+systemctl --user restart wireplumber.service >/dev/null 2>&1 || true

--- a/test/shell.d/apple-speaker-pop-test.sh
+++ b/test/shell.d/apple-speaker-pop-test.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+user_leaf="$ROOT/install/user/hardware/apple/fix-speaker-pop.sh"
+hardware_leaf="$ROOT/install/hardware/apple/fix-speaker-pop.sh"
+user_all="$ROOT/install/user/all.sh"
+hardware_all="$ROOT/install/hardware/all.sh"
+migration="$ROOT/migrations/1788345489.sh"
+dropin="$ROOT/default/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf"
+etc_dropin="$ROOT/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf"
+dsp_src="$ROOT/default/wireplumber/scripts/node/software-dsp.lua"
+
+grep -q 'apple/fix-speaker-pop.sh' "$user_all" ||
+  fail "the speaker pop fix runs during per-user setup"
+pass "the speaker pop fix runs during per-user setup"
+
+grep -q 'apple/fix-speaker-pop.sh' "$hardware_all" ||
+  fail "the speaker pop fix runs during machine-wide hardware setup"
+pass "the speaker pop fix runs during machine-wide hardware setup"
+
+cmp -s "$dropin" "$etc_dropin" ||
+  fail "the packaged /etc drop-in matches the default source" "$(diff "$dropin" "$etc_dropin")"
+pass "the packaged /etc drop-in matches the default source"
+
+# The shipped rule must reach the raw speaker node, which the Asahi rules rename
+# and hide, so it has to match on the ALSA path. Device 1 is the speaker array
+# and device 0 the headphone jack on every AppleJ model.
+grep -Fq 'api.alsa.path = "~hw:AppleJ[0-9][0-9][0-9],[01]"' "$dropin" ||
+  fail "the drop-in matches every Apple Silicon speaker and headphone output" "$(cat "$dropin")"
+grep -Fq 'session.suspend-timeout-seconds = 0' "$dropin" ||
+  fail "the drop-in disables the idle suspend that powers the amplifiers down" "$(cat "$dropin")"
+pass "the drop-in keeps the Apple Silicon outputs from suspending"
+
+# The DSP overlay is session-wide: any current or future PipeWire/Pulse client
+# that closes its stream would otherwise pause the asahi-audio convolver.
+grep -Fq 'keep_speaker_dsp_alive' "$dsp_src" ||
+  fail "the DSP overlay keeps speaker graphs from pausing" "$(cat "$dsp_src")"
+grep -Fq 'session.suspend-timeout-seconds' "$dsp_src" ||
+  fail "the DSP overlay pins the convolver suspend timeout" "$(cat "$dsp_src")"
+grep -Fq 'node.pause-on-idle' "$dsp_src" ||
+  fail "the DSP overlay disables pause-on-idle on speaker graphs" "$(cat "$dsp_src")"
+pass "the DSP overlay keeps the speaker convolver from pausing"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+home="$test_tmp/home"
+conf="$home/.config/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf"
+dsp="$home/.local/share/wireplumber/scripts/node/software-dsp.lua"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-hw-apple-silicon" <<'SH'
+#!/bin/bash
+
+[[ ${APPLE_SILICON:-0} == "1" ]]
+SH
+
+# Stubbed rather than run: the real one would restart the running user's audio.
+cat >"$stub_bin/systemctl" <<'SH'
+#!/bin/bash
+
+printf 'systemctl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+cat >"$stub_bin/sudo" <<'SH'
+#!/bin/bash
+
+printf 'sudo' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+"$@"
+SH
+
+chmod +x "$stub_bin"/*
+
+sys_conf="$test_tmp/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf"
+sys_dsp="$test_tmp/usr/local/share/wireplumber/scripts/node/software-dsp.lua"
+
+run_user_leaf() {
+  local apple_silicon="${1:-1}"
+
+  rm -rf "$home"
+  mkdir -p "$home"
+
+  APPLE_SILICON="$apple_silicon" HOME="$home" OMARCHY_PATH="$ROOT" \
+    PATH="$stub_bin:$PATH" \
+    bash -eE -c 'source "$1"' bash "$user_leaf" </dev/null
+}
+
+run_hardware_leaf() {
+  local apple_silicon="${1:-1}"
+
+  rm -rf "$test_tmp/etc" "$test_tmp/usr"
+  : >"$calls"
+
+  APPLE_SILICON="$apple_silicon" HOME="$home" OMARCHY_PATH="$ROOT" \
+    TEST_LOG="$calls" PATH="$stub_bin:$PATH" \
+    OMARCHY_ASAHI_SPEAKER_CONF="$sys_conf" \
+    OMARCHY_ASAHI_SPEAKER_DSP="$sys_dsp" \
+    bash -eE -c 'source "$1"' bash "$hardware_leaf" </dev/null
+}
+
+run_user_leaf >/dev/null
+[[ -f $conf ]] ||
+  fail "an Apple Silicon Mac gets the drop-in" "$(ls -R "$home" 2>&1)"
+cmp -s "$conf" "$dropin" ||
+  fail "the installed drop-in is the shipped one" "$(diff "$dropin" "$conf")"
+[[ -f $dsp ]] ||
+  fail "an Apple Silicon Mac gets the DSP overlay" "$(ls -R "$home" 2>&1)"
+cmp -s "$dsp" "$dsp_src" ||
+  fail "the installed DSP overlay is the shipped one" "$(diff "$dsp_src" "$dsp")"
+pass "an Apple Silicon Mac gets the drop-in and DSP overlay"
+
+run_hardware_leaf >/dev/null
+[[ -f $sys_conf ]] ||
+  fail "an Apple Silicon Mac gets the machine-wide drop-in" "$(ls -R "$test_tmp/etc" 2>&1)"
+cmp -s "$sys_conf" "$dropin" ||
+  fail "the machine-wide drop-in is the shipped one" "$(diff "$dropin" "$sys_conf")"
+[[ -f $sys_dsp ]] ||
+  fail "an Apple Silicon Mac gets the machine-wide DSP overlay" "$(ls -R "$test_tmp/usr" 2>&1)"
+cmp -s "$sys_dsp" "$dsp_src" ||
+  fail "the machine-wide DSP overlay is the shipped one" "$(diff "$dsp_src" "$sys_dsp")"
+pass "an Apple Silicon Mac gets the machine-wide drop-in and DSP overlay"
+
+# Intel and T2 Macs have a different audio path with no amplifier to keep awake.
+run_user_leaf 0 >/dev/null
+[[ ! -e $conf ]] ||
+  fail "a Mac without Apple Silicon is left alone" "$(cat "$conf")"
+[[ ! -e $dsp ]] ||
+  fail "a Mac without Apple Silicon does not get the DSP overlay" "$(cat "$dsp")"
+pass "a Mac without Apple Silicon is left alone"
+
+run_hardware_leaf 0 >/dev/null
+[[ ! -e $sys_conf ]] ||
+  fail "a Mac without Apple Silicon does not get the machine-wide drop-in" "$(cat "$sys_conf")"
+[[ ! -e $sys_dsp ]] ||
+  fail "a Mac without Apple Silicon does not get the machine-wide DSP overlay" "$(cat "$sys_dsp")"
+pass "a Mac without Apple Silicon is left alone by hardware setup"
+
+# Installs that predate the leaf never ran it, so the migration has to reach
+# them. omarchy-migrate runs migrations under bash -euo pipefail.
+run_migration() {
+  local apple_silicon="${1:-1}"
+
+  : >"$calls"
+
+  APPLE_SILICON="$apple_silicon" HOME="$home" TEST_LOG="$calls" \
+    OMARCHY_PATH="$ROOT" PATH="$stub_bin:$PATH" \
+    OMARCHY_ASAHI_SPEAKER_CONF="$sys_conf" \
+    OMARCHY_ASAHI_SPEAKER_DSP="$sys_dsp" \
+    bash -euo pipefail "$migration"
+}
+
+rm -rf "$home" "$test_tmp/etc" "$test_tmp/usr"
+mkdir -p "$home"
+run_migration >/dev/null
+[[ -f $conf && -f $dsp && -f $sys_conf && -f $sys_dsp ]] ||
+  fail "the migration fixes an install that never ran the leaf" "$(ls -R "$home" "$test_tmp/etc" "$test_tmp/usr" 2>&1)"
+grep -Fq $'systemctl\t--user\trestart\twireplumber.service' "$calls" ||
+  fail "the migration restarts WirePlumber so the fix applies without a logout" "$(cat "$calls")"
+pass "the migration fixes an install that never ran the leaf"
+
+run_migration >/dev/null
+[[ ! -s $calls ]] ||
+  fail "a repaired install is left untouched" "$(cat "$calls")"
+pass "the migration is idempotent"
+
+# An ALSA-only copy from the first revision must still pick up the DSP overlay
+# and the machine-wide files.
+rm -rf "$home" "$test_tmp/etc" "$test_tmp/usr"
+mkdir -p "$(dirname "$conf")"
+cp "$dropin" "$conf"
+run_migration >/dev/null
+[[ -f $dsp && -f $sys_conf && -f $sys_dsp ]] ||
+  fail "the migration adds the DSP overlay to an ALSA-only install" "$(ls -R "$home" "$test_tmp/etc" "$test_tmp/usr" 2>&1)"
+grep -Fq $'systemctl\t--user\trestart\twireplumber.service' "$calls" ||
+  fail "the migration restarts WirePlumber after adding the DSP overlay" "$(cat "$calls")"
+pass "the migration adds the DSP overlay to an ALSA-only install"
+
+rm -rf "$home" "$test_tmp/etc" "$test_tmp/usr"
+mkdir -p "$home"
+run_migration 0 >/dev/null
+[[ ! -e $conf ]] ||
+  fail "the migration skips hardware without the popping amplifiers" "$(cat "$conf")"
+[[ ! -e $dsp ]] ||
+  fail "the migration does not install the DSP overlay off Apple Silicon" "$(cat "$dsp")"
+[[ ! -e $sys_conf ]] ||
+  fail "the migration does not install the machine-wide drop-in off Apple Silicon" "$(cat "$sys_conf")"
+[[ ! -s $calls ]] ||
+  fail "the migration restarts nothing without Apple Silicon" "$(cat "$calls")"
+pass "the migration skips hardware without the popping amplifiers"
+
+echo "apple-speaker-pop: all checks passed"

--- a/test/shell.d/unowned-system-paths-test.sh
+++ b/test/shell.d/unowned-system-paths-test.sh
@@ -40,6 +40,9 @@ allowed = {
   # upgrade carrying the handler is the one that would hit the conflict, and the
   # handler only helps once it is on disk. Package it the release after.
   "/usr/lib/chromium/initial_preferences",
+  # Hardware-conditional WirePlumber overlay. It shadows node/software-dsp.lua
+  # so it must not ship in omarchy-settings, which is installed on x86 too.
+  "/usr/local/share/wireplumber",
 }
 
 # One-time 3.x upgrade. It runs before this rule existed and cannot be made to


### PR DESCRIPTION
PipeWire's default idle suspend closes the raw Apple Silicon speaker node five seconds after playback stops. That powers down the TAS2764 amplifiers; the next stream powers them back up with an audible pop. Clients that tear the stream down immediately (Chromium, YouTube seeks, and anything else using Pulse/PipeWire) also pause the asahi-audio convolver, which chops the FIR tail and clicks even when ALSA stays open. Same class of bug as [asahi-audio#84](https://github.com/AsahiLinux/asahi-audio/issues/84).

This is OS-wide and session-wide, not per-app: every current or future PipeWire/Pulse client on Apple Silicon goes through these nodes, and every user session on the machine gets the files.

- WirePlumber drop-in pins `session.suspend-timeout-seconds` to `0` for every `hw:AppleJ*,0/1` output (speakers and headphone jack on J274 through J615). Matches `api.alsa.path` because `99-asahi.conf` hides the speaker node. Inert off Apple Silicon.
- `software-dsp.lua` overlay keeps speaker graphs from pausing on idle. Mic graphs are unchanged. Lives under `/usr/local/share/wireplumber` (and the user's XDG data dir) so it shadows the packaged script only on machines that run the Apple Silicon hardware leaf, not on x86.
- **Machine-wide:** `install/hardware/apple/fix-speaker-pop.sh` writes `/etc/wireplumber/wireplumber.conf.d/asahi-audio-no-suspend.conf` and `/usr/local/share/wireplumber/scripts/node/software-dsp.lua`. The `/etc` drop-in is also shipped from `etc/` so `omarchy-settings` owns it on package install.
- **Per-user:** `install/user/hardware/apple/fix-speaker-pop.sh` copies the same files into `$HOME` during finalize-user, covering users created after install.
- **Existing installs:** reviewed Asahi migration `1788345489.sh` installs any missing layer (including ALSA-only copies of the first revision) and restarts WirePlumber so the fix applies without a logout.

Trade-off: the amplifiers and speaker DSP stay powered while idle (small battery/CPU cost). The one remaining click is the first playback after login or wake.

## Hardware evidence (J314 — MacBook Pro 14", M1 Pro, 2021)

- Radio Atlas (`mpv`) start/stop no longer pops after the ALSA drop-in
- Chromium end-of-stream pops gone after the DSP overlay (convolver stays `running` after a Pulse teardown)
- Headphone sink and convolver report `suspend-timeout = 0` / `pause-on-idle = false`

## Verification

- `bash test/shell.d/apple-speaker-pop-test.sh` — wiring, ALSA match, DSP overlay, user + machine-wide install, non-Apple no-op, migration idempotency, ALSA-only upgrade path
- `bash test/shell.d/migrate-asahi-test.sh` — new migration is reviewed `run` on Asahi and fails closed for unknowns
- `OMARCHY_PKGS_PATH=... bash test/shell.d/unowned-system-paths-test.sh` — `/usr/local` overlay is recorded as hardware-conditional