### PR TITLE
Offer the Aurora kernel payload as an RC (Aurora) installer channel

### DIFF
--- a/apps/omarchy-apple-installer/Packaging/Info.plist
+++ b/apps/omarchy-apple-installer/Packaging/Info.plist
@@ -19,7 +19,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>2.0.1</string>
+  <string>2.0.2</string>
   <key>CFBundleVersion</key>
   <string>21</string>
 	<key>LSApplicationCategoryType</key>

--- a/apps/omarchy-apple-installer/Packaging/build-app.sh
+++ b/apps/omarchy-apple-installer/Packaging/build-app.sh
@@ -107,8 +107,8 @@ descriptor_schema="$(plutil -extract schema_version raw -o - "$release_descripto
 descriptor_service="$(plutil -extract helper_mach_service_name raw -o - "$release_descriptor")"
 descriptor_requirement="$(plutil -extract helper_code_signing_requirement raw -o - "$release_descriptor")"
 descriptor_fingerprint="$(plutil -extract trust_root_fingerprint raw -o - "$release_descriptor")"
-if [[ $descriptor_schema != "2" ]]; then
-  fail "release.json schema_version must be 2"
+if [[ $descriptor_schema != "3" ]]; then
+  fail "release.json schema_version must be 3"
 fi
 descriptor_default_channel="$(plutil -extract default_channel raw -o - "$release_descriptor")"
 if [[ $descriptor_default_channel != "stable" && $descriptor_default_channel != "rc" ]]; then
@@ -116,15 +116,18 @@ if [[ $descriptor_default_channel != "stable" && $descriptor_default_channel != 
 fi
 descriptor_stable_url="$(plutil -extract channels.stable.catalog_url raw -o - "$release_descriptor")"
 descriptor_rc_url="$(plutil -extract channels.rc.catalog_url raw -o - "$release_descriptor")"
-for descriptor_url in "$descriptor_stable_url" "$descriptor_rc_url"; do
+descriptor_rc_aurora_url="$(plutil -extract channels.rc-aurora.catalog_url raw -o - "$release_descriptor")"
+for descriptor_url in "$descriptor_stable_url" "$descriptor_rc_url" "$descriptor_rc_aurora_url"; do
   if [[ $descriptor_url != https://?*/?* ]]; then
     fail "release.json channel URLs must be https with a host and a path"
   fi
 done
-# Both channels pointing at one object would silently erase the separation
+# Two channels pointing at one object would silently erase the separation
 # between what testers see and what everyone else installs.
-if [[ $descriptor_stable_url == "$descriptor_rc_url" ]]; then
-  fail "release.json stable and rc channels must not share a URL"
+if [[ $descriptor_stable_url == "$descriptor_rc_url" ||
+  $descriptor_stable_url == "$descriptor_rc_aurora_url" ||
+  $descriptor_rc_url == "$descriptor_rc_aurora_url" ]]; then
+  fail "release.json channels must not share a URL"
 fi
 if [[ $descriptor_service != "$helper_identifier" ]]; then
   fail "release.json helper service does not match the compiled product"

--- a/apps/omarchy-apple-installer/Release/release.json
+++ b/apps/omarchy-apple-installer/Release/release.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "default_channel": "stable",
   "channels": {
     "stable": {
@@ -7,6 +7,9 @@
     },
     "rc": {
       "catalog_url": "https://downloads.aicodelabs.com.au/channels/rc/catalog.signed.json"
+    },
+    "rc-aurora": {
+      "catalog_url": "https://downloads.aicodelabs.com.au/channels/rc-aurora/catalog.signed.json"
     }
   },
   "trust_root_fingerprint": "sha256:0e86a878c2445009981a182a4642ec22ae14ab4d8365fad4b038cafc4802dc1b",

--- a/apps/omarchy-apple-installer/Sources/OmarchyAppleInstaller/InstallerReleaseConfiguration.swift
+++ b/apps/omarchy-apple-installer/Sources/OmarchyAppleInstaller/InstallerReleaseConfiguration.swift
@@ -18,27 +18,32 @@
     case invalidCatalogEnvelope
   }
 
-  /// The release channels a build can read. Every build names both, so the
-  /// rc channel can be opened later without shipping a new signed app.
+  /// The release channels a build can read. Every build names all of them, so
+  /// a channel can be opened later without shipping a new signed app.
+  ///
+  /// rcAurora serves the Aurora kernel payload. It is a separate channel rather
+  /// than a variant inside rc because it is a different OS image, and a tester
+  /// on rc must never be handed it by accident.
   public enum ReleaseChannel: String, CaseIterable, Codable, Sendable {
     case stable
     case rc
+    case rcAurora = "rc-aurora"
   }
 
   public struct ReleaseChannelEndpoints: Equatable, Sendable {
-    public let stable: URL
-    public let rc: URL
+    private let endpoints: [ReleaseChannel: URL]
 
-    public init(stable: URL, rc: URL) {
-      self.stable = stable
-      self.rc = rc
+    /// Every channel must be named; a build that cannot resolve one of its own
+    /// channels is not a build that should run.
+    public init?(endpoints: [ReleaseChannel: URL]) {
+      guard Set(endpoints.keys) == Set(ReleaseChannel.allCases) else {
+        return nil
+      }
+      self.endpoints = endpoints
     }
 
     public func catalogURL(for channel: ReleaseChannel) -> URL {
-      switch channel {
-      case .stable: stable
-      case .rc: rc
-      }
+      endpoints[channel]!
     }
   }
 
@@ -99,7 +104,7 @@
       } catch {
         throw InstallerReleaseConfigurationError.invalidDescriptor
       }
-      guard decoded.schemaVersion == 2 else {
+      guard decoded.schemaVersion == 3 else {
         throw InstallerReleaseConfigurationError.unsupportedSchema(
           decoded.schemaVersion
         )
@@ -122,13 +127,11 @@
       }
       // Two channels pointing at one object would silently defeat the
       // separation between what testers see and what users get.
-      guard endpoints[.stable] != endpoints[.rc] else {
+      guard Set(endpoints.values).count == ReleaseChannel.allCases.count,
+        let channels = ReleaseChannelEndpoints(endpoints: endpoints)
+      else {
         throw InstallerReleaseConfigurationError.invalidURL("channels")
       }
-      let channels = ReleaseChannelEndpoints(
-        stable: endpoints[.stable]!,
-        rc: endpoints[.rc]!
-      )
 
       let trustRoot: AppOwnedTrustRoot
       do {

--- a/apps/omarchy-apple-installer/Sources/OmarchyAppleInstallerApp/OmarchyAppleInstallerApp.swift
+++ b/apps/omarchy-apple-installer/Sources/OmarchyAppleInstallerApp/OmarchyAppleInstallerApp.swift
@@ -46,8 +46,8 @@ struct OmarchyAppleInstallerApp: App {
   @NSApplicationDelegateAdaptor(InstallerApplicationDelegate.self)
   private var applicationDelegate
 
-  /// Testers switch to the rc channel here. The choice only picks between the
-  /// two URLs already signed into this build; changing it restarts the check so
+  /// Testers switch to a pre-release channel here. The choice only picks among
+  /// the URLs already signed into this build; changing it restarts the check so
   /// nothing planned against one channel is installed from the other.
   @State private var channel: ReleaseChannel = ReleaseChannelPreference()
     .resolve(descriptorDefault: .stable)
@@ -72,6 +72,7 @@ struct OmarchyAppleInstallerApp: App {
         Picker(PlainLanguage.channelMenuTitle, selection: channelBinding) {
           Text(PlainLanguage.channelStable).tag(ReleaseChannel.stable)
           Text(PlainLanguage.channelRC).tag(ReleaseChannel.rc)
+          Text(PlainLanguage.channelRCAurora).tag(ReleaseChannel.rcAurora)
         }
         .pickerStyle(.inline)
       }

--- a/apps/omarchy-apple-installer/Sources/OmarchyAppleInstallerApp/OnePage/OnePageInstallerView.swift
+++ b/apps/omarchy-apple-installer/Sources/OmarchyAppleInstallerApp/OnePage/OnePageInstallerView.swift
@@ -140,8 +140,8 @@ struct OnePageInstallerView: View {
         } else {
           StatusBadge(text: PlainLanguage.supportedBadge, kind: .ok)
         }
-        if channel == .rc {
-          StatusBadge(text: PlainLanguage.rcBadge, kind: .ok)
+        if channel != .stable {
+          StatusBadge(text: PlainLanguage.badge(for: channel), kind: .ok)
         }
       }
       .lineLimit(1)

--- a/apps/omarchy-apple-installer/Sources/OmarchyInstallerUXCore/PlainLanguage.swift
+++ b/apps/omarchy-apple-installer/Sources/OmarchyInstallerUXCore/PlainLanguage.swift
@@ -170,9 +170,20 @@
     public static let startOver = "Start over"
     public static let downloadInstaller = "Download the installer"
     public static let rcBadge = "BETA"
+    public static let rcAuroraBadge = "AURORA"
+
+    /// What the header says a pre-release install is. Stable carries no badge.
+    public static func badge(for channel: ReleaseChannel) -> String {
+      switch channel {
+      case .stable: ""
+      case .rc: rcBadge
+      case .rcAurora: rcAuroraBadge
+      }
+    }
     public static let channelMenuTitle = "Release Channel"
     public static let channelStable = "Stable"
     public static let channelRC = "RC"
+    public static let channelRCAurora = "RC (Aurora)"
     public static let doneVerifiedRows = [
       PlanFactRow(label: "Boot chain", value: "m1n1 → U-Boot → GRUB → Omarchy"),
       PlanFactRow(

--- a/apps/omarchy-apple-installer/Tests/OmarchyAppleInstallerTrustCoreTests/InstallerAssetPreparerTests.swift
+++ b/apps/omarchy-apple-installer/Tests/OmarchyAppleInstallerTrustCoreTests/InstallerAssetPreparerTests.swift
@@ -398,7 +398,13 @@
         rcURL: envelope,
       ])
       let releaseConfiguration = InstallerReleaseConfiguration(
-        channels: ReleaseChannelEndpoints(stable: stableURL, rc: rcURL),
+        channels: ReleaseChannelEndpoints(endpoints: [
+          .stable: stableURL,
+          .rc: rcURL,
+          .rcAurora: URL(
+            string: "https://releases.example.com/channels/rc-aurora/catalog.signed.json"
+          )!,
+        ])!,
         defaultChannel: .stable,
         trustRoot: trustRoot,
         helperMachServiceName: "com.omarchy.apple-installer.helper",

--- a/apps/omarchy-apple-installer/Tests/OmarchyAppleInstallerTrustCoreTests/InstallerPlanReviewTests.swift
+++ b/apps/omarchy-apple-installer/Tests/OmarchyAppleInstallerTrustCoreTests/InstallerPlanReviewTests.swift
@@ -241,14 +241,17 @@
         catalogDocuments: documents
       )
       let configuration = InstallerReleaseConfiguration(
-        channels: ReleaseChannelEndpoints(
-          stable: URL(
+        channels: ReleaseChannelEndpoints(endpoints: [
+          .stable: URL(
             string: "https://releases.example.com/channels/stable/catalog.signed.json"
           )!,
-          rc: URL(
+          .rc: URL(
             string: "https://releases.example.com/channels/rc/catalog.signed.json"
-          )!
-        ),
+          )!,
+          .rcAurora: URL(
+            string: "https://releases.example.com/channels/rc-aurora/catalog.signed.json"
+          )!,
+        ])!,
         defaultChannel: .stable,
         trustRoot: trustRoot,
         helperMachServiceName: "com.omarchy.apple-installer.helper",

--- a/apps/omarchy-apple-installer/Tests/OmarchyAppleInstallerTrustCoreTests/InstallerReleaseConfigurationTests.swift
+++ b/apps/omarchy-apple-installer/Tests/OmarchyAppleInstallerTrustCoreTests/InstallerReleaseConfigurationTests.swift
@@ -30,6 +30,51 @@
       )
     }
 
+    func testTheAuroraChannelResolvesItsOwnCatalog() throws {
+      let key = Curve25519.Signing.PrivateKey().publicKey.rawRepresentation
+      let configuration = try InstallerReleaseConfigurationLoader().load(
+        descriptor: descriptor(fingerprint: digest(key)),
+        trustRootPublicKey: key
+      )
+
+      // The Aurora payload is a different OS image, so a tester who picks it
+      // must be reading a catalog no other channel points at.
+      XCTAssertEqual(
+        configuration.catalogURL(for: .rcAurora).absoluteString,
+        "https://releases.omarchy.example/channels/rc-aurora/catalog.signed.json"
+      )
+      XCTAssertNotEqual(
+        configuration.catalogURL(for: .rcAurora),
+        configuration.catalogURL(for: .rc)
+      )
+      XCTAssertNotEqual(
+        configuration.catalogURL(for: .rcAurora),
+        configuration.catalogURL(for: .stable)
+      )
+      XCTAssertEqual(ReleaseChannel(rawValue: "rc-aurora"), .rcAurora)
+    }
+
+    func testSchemaTwoDescriptorIsRejected() throws {
+      let key = Curve25519.Signing.PrivateKey().publicKey.rawRepresentation
+      let twoChannel = Data(
+        """
+        {"schema_version":2,"default_channel":"stable","channels":{"stable":{"catalog_url":"https://releases.omarchy.example/channels/stable/catalog.signed.json"},"rc":{"catalog_url":"https://releases.omarchy.example/channels/rc/catalog.signed.json"}},"trust_root_fingerprint":"\(digest(key))","helper_mach_service_name":"com.omarchy.mx.installer.helper","helper_code_signing_requirement":"identifier \\"com.omarchy.mx.installer.helper\\""}
+        """.utf8
+      )
+
+      XCTAssertThrowsError(
+        try InstallerReleaseConfigurationLoader().load(
+          descriptor: twoChannel,
+          trustRootPublicKey: key
+        )
+      ) {
+        XCTAssertEqual(
+          $0 as? InstallerReleaseConfigurationError,
+          .unsupportedSchema(2)
+        )
+      }
+    }
+
     func testSchemaOneDescriptorIsRejected() throws {
       let key = Curve25519.Signing.PrivateKey().publicKey.rawRepresentation
       let legacy = Data(
@@ -54,7 +99,8 @@
     func testDescriptorsMissingAChannelFailClosed() throws {
       try assertDescriptorRejected { value in
         value["channels"] = [
-          "stable": ["catalog_url": "https://releases.omarchy.example/s.json"]
+          "stable": ["catalog_url": "https://releases.omarchy.example/s.json"],
+          "rc": ["catalog_url": "https://releases.omarchy.example/r.json"],
         ]
       }
     }
@@ -97,6 +143,7 @@
       value["channels"] = [
         "stable": ["catalog_url": shared],
         "rc": ["catalog_url": shared],
+        "rc-aurora": ["catalog_url": "https://releases.omarchy.example/a.json"],
       ]
       let altered = try JSONSerialization.data(withJSONObject: value)
 
@@ -123,6 +170,7 @@
       value["channels"] = [
         "stable": ["catalog_url": "http://releases.omarchy.example/s.json"],
         "rc": ["catalog_url": "https://releases.omarchy.example/b.json"],
+        "rc-aurora": ["catalog_url": "https://releases.omarchy.example/a.json"],
       ]
       let altered = try JSONSerialization.data(withJSONObject: value)
 
@@ -455,7 +503,7 @@
     private func descriptor(fingerprint: String) -> Data {
       Data(
         """
-        {"schema_version":2,"default_channel":"stable","channels":{"stable":{"catalog_url":"https://releases.omarchy.example/channels/stable/catalog.signed.json"},"rc":{"catalog_url":"https://releases.omarchy.example/channels/rc/catalog.signed.json"}},"trust_root_fingerprint":"\(fingerprint)","helper_mach_service_name":"com.omarchy.mx.installer.helper","helper_code_signing_requirement":"identifier \\"com.omarchy.mx.installer.helper\\""}
+        {"schema_version":3,"default_channel":"stable","channels":{"stable":{"catalog_url":"https://releases.omarchy.example/channels/stable/catalog.signed.json"},"rc":{"catalog_url":"https://releases.omarchy.example/channels/rc/catalog.signed.json"},"rc-aurora":{"catalog_url":"https://releases.omarchy.example/channels/rc-aurora/catalog.signed.json"}},"trust_root_fingerprint":"\(fingerprint)","helper_mach_service_name":"com.omarchy.mx.installer.helper","helper_code_signing_requirement":"identifier \\"com.omarchy.mx.installer.helper\\""}
         """.utf8
       )
     }

--- a/apps/omarchy-apple-installer/scripts/make-release-descriptor
+++ b/apps/omarchy-apple-installer/scripts/make-release-descriptor
@@ -69,11 +69,14 @@ import sys
 
 output, fingerprint, base_url, default_channel, helper, requirement = sys.argv[1:7]
 descriptor = {
-    "schema_version": 2,
+    "schema_version": 3,
     "default_channel": default_channel,
     "channels": {
         "stable": {"catalog_url": f"{base_url}/channels/stable/catalog.signed.json"},
         "rc": {"catalog_url": f"{base_url}/channels/rc/catalog.signed.json"},
+        "rc-aurora": {
+            "catalog_url": f"{base_url}/channels/rc-aurora/catalog.signed.json"
+        },
     },
     "trust_root_fingerprint": fingerprint,
     "helper_mach_service_name": helper,

--- a/apps/omarchy-apple-installer/scripts/publish-channels
+++ b/apps/omarchy-apple-installer/scripts/publish-channels
@@ -43,9 +43,9 @@ channels_usage() {
   cat <<'USAGE'
 Usage:
   publish-channels envelope --catalog FILE --signature FILE --output FILE
-  publish-channels os-promote --tag TAG --to stable|rc [--minimum-sequence N] [--no-prune]
+  publish-channels os-promote --tag TAG --to stable|rc|rc-aurora [--minimum-sequence N] [--no-prune]
   publish-channels app-publish --pkg FILE --version X.Y.Z [--to stable|rc]
-  publish-channels channel-status [--channel stable|rc|all]
+  publish-channels channel-status [--channel stable|rc|rc-aurora|all]
   publish-channels prune [--confirm]
 
 Credentials come from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or the Keychain
@@ -60,7 +60,8 @@ validate_os_tag() {
 }
 
 validate_channel() {
-  [[ $1 == "stable" || $1 == "rc" ]] || die "invalid channel: $1"
+  [[ $1 == "stable" || $1 == "rc" || $1 == "rc-aurora" ]] ||
+    die "invalid channel: $1"
 }
 
 validate_installer_version() {
@@ -69,8 +70,8 @@ validate_installer_version() {
 
 mutable_key_allowed() {
   case $1 in
-    channels/stable/catalog.signed.json | channels/rc/catalog.signed.json) return 0 ;;
-    channels/stable/channel.json | channels/rc/channel.json) return 0 ;;
+    channels/stable/catalog.signed.json | channels/rc/catalog.signed.json | channels/rc-aurora/catalog.signed.json) return 0 ;;
+    channels/stable/channel.json | channels/rc/channel.json | channels/rc-aurora/channel.json) return 0 ;;
     installer/stable/$PKG_FILE_NAME | installer/rc/$PKG_FILE_NAME) return 0 ;;
     installer/stable/installer.json | installer/rc/installer.json) return 0 ;;
     *) return 1 ;;
@@ -406,7 +407,7 @@ channel_status() {
   local work channels channel failures=0
   work=$(make_scratch)
   if [[ $requested == "all" ]]; then
-    channels="stable rc"
+    channels="stable rc rc-aurora"
   else
     channels=$requested
   fi
@@ -450,7 +451,7 @@ channel_status() {
 # installer version is reachable when any channel's installer.json points at it.
 referenced_prefixes() {
   local work=$1 channel envelope catalog signature pointer
-  for channel in stable rc rc edge; do
+  for channel in stable rc rc-aurora edge; do
     envelope="$work/$channel.env.json"
     if fetch_public "channels/$channel/catalog.signed.json" "$envelope"; then
       catalog="$work/$channel.catalog"; signature="$work/$channel.sig"

--- a/apps/omarchy-apple-installer/scripts/release-inputs-aurora.template.json
+++ b/apps/omarchy-apple-installer/scripts/release-inputs-aurora.template.json
@@ -35,6 +35,6 @@
   "installer": {
     "minimum_version": "2.0.2",
     "latest_version": "2.0.2",
-    "download_url": "https://downloads.aicodelabs.com.au/installer/stable/Omarchy-MX-Mac-Installer.pkg"
+    "download_url": "https://downloads.aicodelabs.com.au/installer/rc/Omarchy-MX-Mac-Installer.pkg"
   }
 }

--- a/apps/omarchy-apple-installer/scripts/release-inputs-aurora.template.json
+++ b/apps/omarchy-apple-installer/scripts/release-inputs-aurora.template.json
@@ -1,0 +1,40 @@
+{
+  "payload_name": "omarchy-2026.09.07-aarch64-apple-silicon-aurora-os-package.zip",
+  "engine_name": "installer-v0.9.0-omarchy.14.tar.gz",
+  "metadata_name": "installer_data.json",
+  "engine_version": "v0.9.0-omarchy.14",
+  "evidence_revision": "4.0.2-mac.1.20260907-aurora",
+  "asahi_installer_tag": "v0.9.0",
+  "asahi_installer_revision": "f0469cea0899f3efed8efead604174c7a53c4451",
+  "asahi_installer_data_revision": "42648e71423eba308d2e3e6228253eff679b068b",
+  "downstream_revision": "dff6311446439e1f29f0f2e6c0cf82a9a190e5bc",
+  "device_identifiers": [
+    "apple,j314s",
+    "apple,j314c",
+    "apple,j316s",
+    "apple,j316c",
+    "apple,j274",
+    "apple,j293",
+    "apple,j313",
+    "apple,j456",
+    "apple,j457",
+    "apple,j375c",
+    "apple,j375d",
+    "apple,j413",
+    "apple,j415",
+    "apple,j493",
+    "apple,j473",
+    "apple,j474s",
+    "apple,j414s",
+    "apple,j414c",
+    "apple,j416s",
+    "apple,j416c",
+    "apple,j475c",
+    "apple,j475d"
+  ],
+  "installer": {
+    "minimum_version": "2.0.2",
+    "latest_version": "2.0.2",
+    "download_url": "https://downloads.aicodelabs.com.au/installer/stable/Omarchy-MX-Mac-Installer.pkg"
+  }
+}

--- a/bin/omarchy-debug-apple
+++ b/bin/omarchy-debug-apple
@@ -88,7 +88,7 @@ check_repos() {
 
 check_packages() {
   local pkg
-  for pkg in linux-asahi asahi-fwextract asahi-desktop-meta vulkan-asahi \
+  for pkg in "$(omarchy-hw-apple-kernel)" asahi-fwextract asahi-desktop-meta vulkan-asahi \
     mesa networkmanager iwd wireplumber speakersafetyd alsa-ucm-conf-asahi; do
     if pacman -Q "$pkg" >/dev/null 2>&1; then
       record PASS "pkg-$pkg" "$(pacman -Q "$pkg" 2>/dev/null)"

--- a/bin/omarchy-hw-apple-kernel
+++ b/bin/omarchy-hw-apple-kernel
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# omarchy:summary=Print which kernel package this Apple Silicon Mac runs.
+
+# The Aurora payload records its kernel here because it is not the Asahi one.
+# An Asahi install writes no such file, so the answer is linux-asahi unless the
+# system says otherwise. Callers can then name the kernel without caring which
+# payload they came from.
+
+kernel_file="${OMARCHY_APPLE_KERNEL_FILE:-/usr/share/omarchy/apple-silicon-kernel}"
+kernel=""
+
+if [[ -f $kernel_file && ! -L $kernel_file ]]; then
+  read -r kernel <"$kernel_file" || true
+fi
+
+[[ $kernel =~ ^linux-[a-z0-9]+$ ]] || kernel=linux-asahi
+printf '%s\n' "$kernel"

--- a/bin/omarchy-install-asahi-fresh
+++ b/bin/omarchy-install-asahi-fresh
@@ -65,10 +65,17 @@ done
 [[ -r /proc/device-tree/compatible ]] || fail "Apple device-tree information is unavailable"
 grep -aq 'apple,' /proc/device-tree/compatible || fail "Apple Silicon device tree not found"
 
-for package in linux-asahi linux-asahi-headers m1n1 grub; do
+kernel_marker=/usr/share/omarchy/apple-silicon-kernel
+kernel_package=linux-asahi
+if [[ -f $kernel_marker && ! -L $kernel_marker ]]; then
+  read -r kernel_package <"$kernel_marker" || true
+fi
+[[ $kernel_package =~ ^linux-[a-z0-9]+$ ]] || fail "Unreadable kernel package name"
+
+for package in "$kernel_package" "$kernel_package-headers" m1n1 grub; do
   pacman -Q "$package" >/dev/null 2>&1 || fail "Required Asahi package is not installed: $package"
 done
-[[ -f /boot/vmlinuz-linux-asahi ]] || fail "/boot/vmlinuz-linux-asahi is unavailable"
+[[ -f /boot/vmlinuz-$kernel_package ]] || fail "/boot/vmlinuz-$kernel_package is unavailable"
 [[ -f /boot/grub/grub.cfg ]] || fail "The existing Asahi GRUB configuration is unavailable"
 for repository in asahi-alarm core extra alarm aur; do
   pacman-conf --repo-list | grep -Fxq "$repository" || fail "Required repository is unavailable: $repository"
@@ -173,7 +180,7 @@ if [[ -d $state_dir ]]; then
   sha256sum --check --status <<<"$asahi_kernel_sha256" || fail "The Asahi kernel changed after the interrupted installation"
   sha256sum --check --status <<<"$grub_sha256" || fail "The GRUB configuration changed after the interrupted installation"
 else
-  asahi_kernel_sha256=$(sha256sum /boot/vmlinuz-linux-asahi)
+  asahi_kernel_sha256=$(sha256sum "/boot/vmlinuz-$kernel_package")
   grub_sha256=$(sha256sum /boot/grub/grub.cfg)
   owner_token=$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')
   install -d -m 0755 /var/lib/omarchy
@@ -200,14 +207,16 @@ mapfile -t runtime_packages < <(
 # compiled on the target machine during installation.
 repo_packages=()
 for package in "${runtime_packages[@]}"; do
-  if [[ $package == "linux-asahi" || $package == "linux-asahi-headers" || $package == "m1n1" ]]; then
+  if [[ $package == "$kernel_package" || $package == "$kernel_package-headers" ||
+    $package == "linux-asahi" || $package == "linux-asahi-headers" ||
+    $package == "m1n1" ]]; then
     continue
   fi
   repo_packages+=("$package")
 done
 
 echo "Installing the Omarchy 4 Apple Silicon package set"
-pacman -Syu --needed --noconfirm --ignore linux-asahi,linux-asahi-headers,m1n1 \
+pacman -Syu --needed --noconfirm --ignore "$kernel_package,$kernel_package-headers,m1n1" \
   base-devel sudo xdg-user-dirs "${repo_packages[@]}"
 
 echo "Installing the verified six-package Omarchy release"
@@ -275,7 +284,7 @@ runuser -u "$target_user" -- env \
 
 ln -sfn /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 
-pacman -Q omarchy-dev omarchy-settings-dev linux-asahi linux-asahi-headers m1n1 networkmanager iwd >/dev/null
+pacman -Q omarchy-dev omarchy-settings-dev "$kernel_package" "$kernel_package-headers" m1n1 networkmanager iwd >/dev/null
 [[ $(cat /usr/share/omarchy/version) == 4.* ]] || fail "Installed Omarchy version is not 4.x"
 NetworkManager --print-config 2>/dev/null | grep -Fxq 'wifi.backend=iwd' || fail "NetworkManager iwd backend was not configured"
 grep -Eqi '^[[:space:]]*LANG[[:space:]]*=[[:space:]]*"?[^"[:space:]#]*\.utf-?8(@[^"[:space:]#]+)?"?([[:space:]]*(#.*)?)?$' /etc/locale.conf || fail "The system locale is not UTF-8"

--- a/bin/omarchy-install-gaming-xbox-controllers
+++ b/bin/omarchy-install-gaming-xbox-controllers
@@ -11,7 +11,7 @@ echo "Installing Xbox controller Bluetooth support..."
 
 # Install xpadneo against the kernel headers for this platform.
 headers=linux-headers
-omarchy-hw-apple-silicon && headers=linux-asahi-headers
+omarchy-hw-apple-silicon && headers=$(omarchy-hw-apple-kernel)-headers
 omarchy-pkg-add "$headers" xpadneo-dkms
 
 # Prevent xpad/xpadneo driver conflict

--- a/bin/omarchy-update-asahi-bundle
+++ b/bin/omarchy-update-asahi-bundle
@@ -224,8 +224,10 @@ if [[ $mode == "check" ]]; then
   exit 0
 fi
 
-[[ -f $(root_path /boot/vmlinuz-linux-asahi) ]] || fail "/boot/vmlinuz-linux-asahi is missing"
-pacman -Qq linux-asahi >/dev/null 2>&1 || fail "linux-asahi is not installed"
+kernel_package=$(omarchy-hw-apple-kernel)
+[[ -f $(root_path "/boot/vmlinuz-$kernel_package") ]] ||
+  fail "/boot/vmlinuz-$kernel_package is missing"
+pacman -Qq "$kernel_package" >/dev/null 2>&1 || fail "$kernel_package is not installed"
 [[ -f $(root_path /boot/grub/grub.cfg) ]] || fail "GRUB configuration is missing"
 pacman_conf=$(root_path /etc/pacman.conf)
 for repository in asahi-alarm core extra alarm aur; do
@@ -313,7 +315,7 @@ fi
 backup="/var/lib/omarchy/backups/asahi-bundle-$(date +%Y%m%d%H%M%S)"
 backup_tmp=$(mktemp -d)
 pacman -Q >"$backup_tmp/installed-packages.txt"
-sha256sum "$(root_path /boot/vmlinuz-linux-asahi)" >"$backup_tmp/boot-sha256.txt"
+sha256sum "$(root_path "/boot/vmlinuz-$kernel_package")" >"$backup_tmp/boot-sha256.txt"
 sudo find "$(root_path /etc/pacman.conf)" "$(root_path /etc/pacman.d)" "$(root_path /etc/NetworkManager)" \
   -type f -exec sha256sum {} + >"$backup_tmp/config-sha256.txt"
 sudo install -d -o root -g root -m 0700 "$backup"

--- a/docs/apple-silicon-deployment.md
+++ b/docs/apple-silicon-deployment.md
@@ -233,6 +233,79 @@ rclone sync ~/.cache/omarchy/alarm-mirror/<date>/aarch64/<repo>/ r2:omarchy-rele
 and record the date in `apple-silicon-distribution-channels.md`. Snapshots are
 never modified or pruned automatically.
 
+## The Aurora lane
+
+The `RC (Aurora)` channel serves a second payload built from the Aurora Silicon
+kernel (`aurora-silicon/linux`, branch `aurora-wip`): DisplayPort alt-mode and
+USB4 for external monitors, variable refresh rate, ISP and AOP. It is a whole
+kernel, not a module, so it is a whole payload.
+
+The lane is deliberately parallel to the Asahi one rather than part of it. The
+kernel never enters the `[omarchy]` repository, it gets its own immutable
+release, and the payload is a second product descriptor. Nothing here runs
+during a normal Asahi release, and a build that does not ask for the aurora
+product produces the same bytes it did before this lane existed.
+
+| Artifact | Where | Made by |
+| --- | --- | --- |
+| kernel `aurora-packages-<pkgs commit>` | GitHub release, immutable, prerelease | `release-aurora-package.yml` |
+| payload `omarchy-<date>-aarch64-apple-silicon-aurora-os-package.zip` | this Mac | `omarchy-iso-make --product omarchy-mx-mac-aurora` |
+| channel `channels/rc-aurora` | R2 | `publish-channels os-promote --to rc-aurora` |
+
+1. Build and publish the kernel from `omarchy-pkgs`, then record the tag and
+   the `AURORA` digest the run prints:
+
+   ```bash
+   gh workflow run release-aurora-package.yml -f publish=true
+   ```
+
+2. Pin both halves in `omarchy-iso` — they are compared at build time and the
+   build stops if they disagree: `builder/aurora-package-snapshots.conf`
+   (`AURORA_REPOSITORY_RELEASE`, `_DESCRIPTOR_SHA256`, `_SOURCE_COMMIT`) and
+   the `[omarchy-aurora]` `Server` line in
+   `configs/airootfs/usr/share/omarchy-iso/pacman-online-installed-arm-aurora.conf`.
+
+3. Build the payload on this Mac. Give it its own checkpoint root so the Asahi
+   cache is untouched:
+
+   ```bash
+   OMARCHY_ASAHI_PRODUCT_NAME=omarchy-mx-mac-aurora OMARCHY_ASAHI_CHECKPOINT_ROOT=$HOME/.cache/omarchy/asahi-checkpoints-aurora bin/omarchy-iso-make --target aarch64/apple-silicon --artifact asahi-os-package --product omarchy-mx-mac-aurora --mode qualification
+   ```
+
+4. Publish as usual, with the aurora inputs, and promote to `rc-aurora`. Use
+   `--no-prune` the first time, before any stable promotion can prune a release
+   set the new channel is the only reference to:
+
+   ```bash
+   publish-channels os-promote --tag os-v4.0.2-mac.1.<date>-aurora --to rc-aurora --no-prune
+   ```
+
+Steps 2 through 4 need the owner's authorization, like every other publication.
+
+### What the Aurora lane does not do
+
+The kernel is pinned by commit. A new Aurora kernel is a new
+`aurora-packages-<sha>` release, a new pin, and a new payload; installed Aurora
+Macs do not follow it, because `[omarchy-aurora]` names one immutable release.
+Moving them is a manual repoint until that is worth automating.
+
+`test/vm/asahi-fresh` installs `linux-asahi` and boots a generic kernel, so it
+proves the runtime tolerates the Aurora name but cannot exercise the kernel.
+Aurora is qualified on real hardware.
+
+### Removing the lane
+
+Delete `pkgbuilds/linux-aurora`, `pkgbuilds/aurora-*`,
+`bin/aurora-package-descriptor`, `test/aurora-package-descriptor` and
+`.github/workflows/release-aurora-package.yml` from `omarchy-pkgs`; the
+`builder/*aurora*`, `products/omarchy-mx-mac-aurora.json`,
+`*-arm-aurora.conf` and `test/unit/aurora-product-test.sh` files from
+`omarchy-iso`; and `bin/omarchy-hw-apple-kernel` plus
+`scripts/release-inputs-aurora.template.json` here. Everything else is a hook
+that defaults to the Asahi behaviour, so reverting those files restores the
+previous lane exactly. Then drop `channels/rc-aurora/` and the aurora release
+sets from R2 and the `aurora-packages-*` releases from GitHub.
+
 ## Gates and timings
 
 | Step | Gate | Time |

--- a/docs/apple-silicon-distribution-channels.md
+++ b/docs/apple-silicon-distribution-channels.md
@@ -154,8 +154,7 @@ OMARCHY_APP_VERSION=2.0.0 OMARCHY_APP_BUILD_NUMBER=20 \
   OMARCHY_APP_SIGNING_IDENTITY="Developer ID Application: …" OMARCHY_TEAM_ID=T2C384FJBD \
   Packaging/build-app.sh "$PWD/Release" /tmp/app
 OMARCHY_NOTARY_PROFILE=omarchy-notary Packaging/notarize-app.sh "/tmp/app/Omarchy MX Mac Installer.app"
-Packaging/pkg/build-pkg.sh --app "/tmp/app/Omarchy MX Mac Installer.app" \
-  --plist Packaging/helper-launchdaemon.plist --version 2.0.0 --out /tmp/Installer.pkg
+Packaging/pkg/build-pkg.sh --app "/tmp/app/Omarchy MX Mac Installer.app" --version 2.0.0 --out /tmp/Installer.pkg
 xcrun notarytool submit /tmp/Installer.pkg --keychain-profile omarchy-notary --wait
 xcrun stapler staple /tmp/Installer.pkg
 scripts/publish-channels app-publish --pkg /tmp/Installer.pkg --version 2.0.0 --to rc

--- a/test/shell.d/asahi-fresh-install-test.sh
+++ b/test/shell.d/asahi-fresh-install-test.sh
@@ -18,8 +18,10 @@ pass "fresh Asahi installer exposes the verified bundle entrypoint"
 
 grep -Fq 'omarchy-base-asahi.packages' "$installer" || fail "fresh installer reads the Asahi package closure"
 grep -Fq 'pacman -Syu --needed --noconfirm' "$installer" || fail "fresh installer resolves the runtime package transaction"
-grep -Fq -- '--ignore linux-asahi,linux-asahi-headers,m1n1' "$installer" || fail "fresh installer excludes protected Asahi boot packages from the system upgrade"
-grep -Fq '[[ $package == "linux-asahi" || $package == "linux-asahi-headers" || $package == "m1n1" ]]' "$installer" || fail "fresh installer omits protected Asahi boot packages from explicit targets"
+grep -Fq -- '--ignore "$kernel_package,$kernel_package-headers,m1n1"' "$installer" || fail "fresh installer excludes protected boot packages from the system upgrade"
+grep -Fq '$package == "$kernel_package" || $package == "$kernel_package-headers"' "$installer" || fail "fresh installer omits the installed kernel from explicit targets"
+grep -Fq '$package == "linux-asahi" || $package == "linux-asahi-headers"' "$installer" || fail "fresh installer omits the Asahi kernel from explicit targets"
+grep -Fq '$package == "m1n1"' "$installer" || fail "fresh installer omits m1n1 from explicit targets"
 grep -Fq 'pacman -U --needed --noconfirm "${archives[@]}"' "$installer" || fail "fresh installer uses one exact six-package transaction"
 if grep -Fq 'makepkg' "$installer"; then
   fail "fresh installer must not compile packages on the target machine"

--- a/test/shell.d/hw-apple-kernel-test.sh
+++ b/test/shell.d/hw-apple-kernel-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# The runtime is shared by the Asahi and Aurora payloads, so every script that
+# names a kernel asks this helper. It must answer linux-asahi on an Asahi
+# install, where the marker file does not exist at all.
+
+source "$(dirname "$0")/base-test.sh"
+
+helper="$ROOT/bin/omarchy-hw-apple-kernel"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+[[ $(OMARCHY_APPLE_KERNEL_FILE="$work/absent" "$helper") == linux-asahi ]] ||
+  fail "an install with no marker reports the Asahi kernel"
+
+printf 'linux-aurora\n' >"$work/aurora"
+[[ $(OMARCHY_APPLE_KERNEL_FILE="$work/aurora" "$helper") == linux-aurora ]] ||
+  fail "an Aurora install reports the Aurora kernel"
+
+printf 'linux-asahi\n' >"$work/asahi"
+[[ $(OMARCHY_APPLE_KERNEL_FILE="$work/asahi" "$helper") == linux-asahi ]] ||
+  fail "an explicit Asahi marker reports the Asahi kernel"
+
+# The marker names a package that reaches pacman and a boot path, so anything
+# that is not a bare kernel package name is refused rather than passed along.
+for content in 'linux-aurora; rm -rf /' '../../etc/passwd' '' 'LINUX-AURORA'; do
+  printf '%s\n' "$content" >"$work/hostile"
+  [[ $(OMARCHY_APPLE_KERNEL_FILE="$work/hostile" "$helper") == linux-asahi ]] ||
+    fail "a marker holding '$content' is refused"
+done
+
+ln -sfn "$work/aurora" "$work/link"
+[[ $(OMARCHY_APPLE_KERNEL_FILE="$work/link" "$helper") == linux-asahi ]] ||
+  fail "a symlinked marker is refused"
+
+pass "the kernel helper defaults to Asahi and only accepts a real kernel name"


### PR DESCRIPTION
## Summary
- `omarchy-hw-apple-kernel` lets the shared runtime name whichever Apple Silicon kernel is installed; every script that named `linux-asahi` now asks it and defaults to `linux-asahi`
- Installer app 2.0.2: third channel `rc-aurora` ("RC (Aurora)"), descriptor schema 3, channel endpoints keyed by channel; packager and publish tooling accept it
- Aurora release-inputs template and an "Aurora lane" section in the deployment runbook, including the removal recipe

Companion changes: omarchy-pkgs #73/#74/#75 (kernel release), omarchy-iso `aurora/rc-channel` (payload).

## Test plan
- [x] 274 Swift tests, shell suite (no new failures vs baseline), CLI suite
- [x] Installer 2.0.2 built, notarized, stapled and published to `installer/rc`
- [ ] Runtime fast lane from the merge commit
- [ ] Aurora payload built against that runtime and promoted to `rc-aurora`
- [ ] Fresh install on the M2 Max via RC (Aurora); external monitor over USB-C