### PR TITLE
Identify Apple Silicon without PATH or a vendor substring

### DIFF
--- a/bin/omarchy-hw-aarch64
+++ b/bin/omarchy-hw-aarch64
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the machine is aarch64.
+
+# Codebase split: pacman tree, installer, package filter, aarch64-only tools.
+# Self-contained so bootstrap can invoke it by absolute path before PATH is set.
+arch=$("$(dirname -- "${BASH_SOURCE[0]}")/omarchy-hw-arch") || exit 1
+[[ $arch == "aarch64" ]]

--- a/bin/omarchy-hw-apple-silicon
+++ b/bin/omarchy-hw-apple-silicon
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-# omarchy:summary=Detect whether the computer is an Apple Silicon Mac.
+# omarchy:summary=Detect Apple Silicon (Asahi) hardware.
 
-# Apple Silicon Macs have no DMI, so omarchy-hw-match cannot see them. The
-# device tree Asahi's m1n1 hands the kernel names every board "apple,<model>",
-# which is the one identifier that survives across M1 through M4.
-proc_root="${OMARCHY_PROC_ROOT:-/proc}"
-
-[[ $(uname -m) == "aarch64" ]] &&
-  grep -aq 'apple,' "$proc_root/device-tree/compatible" 2>/dev/null
+# Hardware split: notch, Asahi HID, vulkan-asahi, wf-recorder, asahi-audio.
+# aarch64 is not enough — a Raspberry Pi must not take the Apple path.
+# OMARCHY_APPLE_COMPATIBLE stubs the device-tree file for tests.
+"$(dirname -- "${BASH_SOURCE[0]}")/omarchy-hw-aarch64" || exit 1
+compatible_file="${OMARCHY_APPLE_COMPATIBLE:-/proc/device-tree/compatible}"
+[[ -r $compatible_file ]] || exit 1
+# Device-tree compatible is a NUL-separated list of vendor,model strings.
+# A vendor substring (for example pineapple,board) is not Apple identity.
+while IFS= read -r -d '' compatible || [[ -n $compatible ]]; do
+  [[ $compatible == apple,* ]] && exit 0
+done <"$compatible_file"
+exit 1

--- a/bin/omarchy-hw-arch
+++ b/bin/omarchy-hw-arch
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Print the canonical machine architecture (aarch64 or x86_64).
+
+# Maps uname's arm64 alias; unsupported or failed detection returns no name.
+# OMARCHY_UNAME_M stubs uname for tests (same idea as OMARCHY_PCI_DEVICES_PATH).
+arch="${OMARCHY_UNAME_M:-$(uname -m)}" || exit 1
+case $arch in
+aarch64 | arm64) printf '%s\n' aarch64 ;;
+x86_64) printf '%s\n' x86_64 ;;
+*) exit 1 ;;
+esac

--- a/test/shell.d/apple-silicon-test.sh
+++ b/test/shell.d/apple-silicon-test.sh
@@ -12,27 +12,31 @@ proc_root="$test_tmp/proc"
 mutation_log="$test_tmp/mutations.log"
 mkdir -p "$stub_bin" "$proc_root/device-tree" "$test_tmp/home"
 
-cat >"$stub_bin/uname" <<'EOF'
-#!/bin/bash
-printf '%s\n' "${OMARCHY_TEST_ARCH:-aarch64}"
-EOF
-chmod +x "$stub_bin/uname"
-
-printf 'apple,j314s\0apple,arm-platform\0' >"$proc_root/device-tree/compatible"
-OMARCHY_PROC_ROOT="$proc_root" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-hw-apple-silicon" ||
+compatible="$proc_root/device-tree/compatible"
+printf 'apple,j314s\0apple,arm-platform\0' >"$compatible"
+OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$compatible" "$ROOT/bin/omarchy-hw-apple-silicon" ||
   fail "Apple Silicon detector accepts aarch64 Apple device trees"
 pass "Apple Silicon detector accepts aarch64 Apple device trees"
 
-if OMARCHY_TEST_ARCH=x86_64 OMARCHY_PROC_ROOT="$proc_root" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-hw-apple-silicon"; then
+if OMARCHY_UNAME_M=x86_64 OMARCHY_APPLE_COMPATIBLE="$compatible" "$ROOT/bin/omarchy-hw-apple-silicon"; then
   fail "Apple Silicon detector rejects non-aarch64 systems"
 fi
 pass "Apple Silicon detector rejects non-aarch64 systems"
 
-printf 'linux,dummy-virt\0' >"$proc_root/device-tree/compatible"
-if OMARCHY_PROC_ROOT="$proc_root" PATH="$stub_bin:$PATH" "$ROOT/bin/omarchy-hw-apple-silicon"; then
+printf 'linux,dummy-virt\0' >"$compatible"
+if OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$compatible" "$ROOT/bin/omarchy-hw-apple-silicon"; then
   fail "Apple Silicon detector rejects non-Apple aarch64 systems"
 fi
 pass "Apple Silicon detector rejects non-Apple aarch64 systems"
+
+printf 'pineapple,board\0vendor,apple-similar\0' >"$compatible"
+if OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$compatible" "$ROOT/bin/omarchy-hw-apple-silicon"; then
+  fail "an Apple substring is not the Apple device-tree vendor"
+fi
+printf 'vendor,board\0apple,arm-platform\0' >"$compatible"
+OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$compatible" "$ROOT/bin/omarchy-hw-apple-silicon" ||
+  fail "Apple compatible identity can follow another NUL-delimited entry"
+pass "Apple detection matches vendor entries in the complete device-tree list"
 
 cat >"$stub_bin/omarchy-hw-apple-silicon" <<'EOF'
 #!/bin/bash

--- a/test/shell.d/hw-arch-test.sh
+++ b/test/shell.d/hw-arch-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+hw() {
+  local name="$1"
+  shift
+  PATH="$ROOT/bin:$PATH" "$ROOT/bin/omarchy-hw-$name" "$@"
+}
+
+arch=$(OMARCHY_UNAME_M=x86_64 hw arch)
+[[ $arch == "x86_64" ]] || fail "x86_64 prints x86_64" "actual: $arch"
+pass "x86_64 prints x86_64"
+
+OMARCHY_UNAME_M=x86_64 hw aarch64 && fail "x86_64 is not aarch64" || true
+pass "x86_64 is not aarch64"
+
+printf 'apple,j413\n' >"$tmp_dir/compatible"
+OMARCHY_UNAME_M=x86_64 OMARCHY_APPLE_COMPATIBLE="$tmp_dir/compatible" hw apple-silicon &&
+  fail "x86_64 with an apple DT is not Apple Silicon" || true
+pass "x86_64 with an apple DT is not Apple Silicon"
+
+arch=$(OMARCHY_UNAME_M=aarch64 hw arch)
+[[ $arch == "aarch64" ]] || fail "aarch64 prints aarch64" "actual: $arch"
+pass "aarch64 prints aarch64"
+
+OMARCHY_UNAME_M=aarch64 hw aarch64 || fail "aarch64 detects aarch64"
+pass "aarch64 detects aarch64"
+
+OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$tmp_dir/missing" hw apple-silicon &&
+  fail "aarch64 without apple DT is not Apple Silicon" || true
+pass "aarch64 without apple DT is not Apple Silicon"
+
+arch=$(OMARCHY_UNAME_M=arm64 hw arch)
+[[ $arch == "aarch64" ]] || fail "arm64 canonicalizes to aarch64" "actual: $arch"
+pass "arm64 canonicalizes to aarch64"
+
+OMARCHY_UNAME_M=arm64 hw aarch64 || fail "arm64 detects as aarch64"
+pass "arm64 detects as aarch64"
+
+for unsupported in riscv64 armv7l unknown; do
+  if arch=$(OMARCHY_UNAME_M="$unsupported" hw arch); then
+    fail "unsupported architectures must fail detection" "$unsupported returned: $arch"
+  fi
+  [[ -z $arch ]] || fail "unsupported architectures print no canonical name" "$arch"
+done
+pass "unsupported architectures cannot be mistaken for x86_64"
+
+OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$tmp_dir/compatible" hw apple-silicon ||
+  fail "aarch64 with apple DT is Apple Silicon"
+pass "aarch64 with apple DT is Apple Silicon"
+
+# Invoke by absolute path with no bin/ on PATH, the way bootstrap and Quickshell do.
+PATH=/usr/bin:/bin OMARCHY_UNAME_M=aarch64 OMARCHY_APPLE_COMPATIBLE="$tmp_dir/compatible" \
+  "$ROOT/bin/omarchy-hw-apple-silicon" ||
+  fail "Apple Silicon detection works when invoked by absolute path"
+pass "Apple Silicon detection works when invoked by absolute path"


### PR DESCRIPTION
The overlay detector grepped `apple,` as text (so `pineapple,board` would count) and looked up `uname` on PATH. This splits architecture from Apple identity the way Naeem's architecture-support work did: helpers invoked next to the script, and only a real `apple,*` device-tree entry counts.

Co-authored-by Naeem Malik.