### PR TITLE
Stabilize candidate VM validation and quarantine assertion

### DIFF
--- a/test/shell.d/asahi-fresh-install-test.sh
+++ b/test/shell.d/asahi-fresh-install-test.sh
@@ -107,6 +107,6 @@ grep -Fq 'candidate_fingerprint=${OMARCHY_VM_CANDIDATE_FINGERPRINT:-}' "$vm_runn
 grep -Fq 'candidate_package_count=${OMARCHY_VM_CANDIDATE_PACKAGE_COUNT:-}' "$vm_runner" || fail "VM runner accepts the exact candidate package count"
 grep -Fq 'release_tag=$tag' "$vm_candidate" || fail "VM candidate gate binds the descriptor release tag"
 grep -Fq 'valid_fingerprint == "${signing_fingerprint^^}"' "$vm_candidate" || fail "VM candidate gate binds the descriptor signature"
-grep -Fq 'pacman -Syu --needed --noconfirm "${packages[@]}"' "$vm_candidate" || fail "VM candidate gate installs all descriptor packages"
+grep -Fq -- '--ignore linux-asahi,linux-asahi-headers,m1n1,grub "${packages[@]}"' "$vm_candidate" || fail "VM candidate gate installs the descriptor packages without upgrading its boot fixture"
 grep -Fq 'candidate package version: $package' "$vm_verify" || fail "VM verifies candidate versions after reboot"
 pass "fresh-install VM can consume an exact signed package candidate"

--- a/test/shell.d/system-sleep-ownership-migration-test.sh
+++ b/test/shell.d/system-sleep-ownership-migration-test.sh
@@ -491,7 +491,7 @@ EXTRA_FAKE_ROOT_DIRS="$admin_dir" \
 cmp -s "$mock_omarchy/default/systemd/system-sleep/keyboard-backlight" \
   "$sleep_dir/keyboard-backlight" ||
   fail "migration does not replace an unsafe symlink with trusted hook content"
-symlink_backup=$(find "$quarantine" -path '*/keyboard-backlight.*/original' -type l -print -quit)
+symlink_backup=$(find "$quarantine" -path '*/keyboard-backlight.*/original' -type l -lname "$user_keyboard" -print -quit)
 [[ -n $symlink_backup && $(readlink "$symlink_backup") == "$user_keyboard" ]] ||
   fail "migration discards an unsafe custom symlink instead of preserving it"
 pass "migration quarantines unsafe symlinks outside the active systemd directory"

--- a/test/vm/asahi-fresh/guest/candidate-repository
+++ b/test/vm/asahi-fresh/guest/candidate-repository
@@ -65,7 +65,16 @@ done < <(sed -n 's/^package=//p' "$work/CANDIDATE")
 (( ${#packages[@]} == package_count ))
 (( $(printf '%s\n' "${packages[@]}" | sort -u | wc -l) == package_count ))
 
-pacman -Syu --needed --noconfirm "${packages[@]}"
+# The cached VM base owns its generic boot image and its Asahi fixture. A live
+# Asahi update here can run newly installed boot hooks before the fresh
+# installer has established its own protected-boot boundary.
+protected_packages=(linux-asahi linux-asahi-headers m1n1 grub)
+pacman -Q "${protected_packages[@]}" >"$work/protected-packages.before"
+sha256sum /boot/Image /boot/vmlinuz-linux-asahi /boot/grub/grub.cfg >"$work/protected-boot.before"
+pacman -Syu --needed --noconfirm --ignore linux-asahi,linux-asahi-headers,m1n1,grub "${packages[@]}"
+pacman -Q "${protected_packages[@]}" >"$work/protected-packages.after"
+cmp "$work/protected-packages.before" "$work/protected-packages.after"
+sha256sum --check --status "$work/protected-boot.before"
 while IFS='|' read -r _ package version _ _ _ _ _; do
   [[ $(pacman -Q "$package" | cut -d' ' -f2) == "$version" ]]
 done < <(sed -n 's/^package=//p' "$work/CANDIDATE")


### PR DESCRIPTION
The candidate VM could fail before installer validation when its repository installation upgraded a cached Asahi kernel from the live Asahi repository. The newly installed Limine hooks moved `/boot/vmlinuz-linux-asahi`, so the harness could no longer capture the boot file it is meant to protect.

Keep the VM's kernel, headers, m1n1 and GRUB versions during candidate repository installation. Check their versions and the generic kernel, Asahi kernel and GRUB configuration hashes before and after that transaction. The candidate's 57 package targets remain unchanged.

The focused fresh-install harness test passes. The fresh VM passed signed candidate 74b8da66 with this harness: protected boot files, interruption/resume, reboot, all 23 optional installations and completed-rerun rejection. The logged-in desktop and installed AI menu were visually verified. The signed runtime remains 5e7965f8: these changes only affect the test harness and its assertion. The failed overlay and logs are preserved.

Also make the existing symlink-quarantine assertion select its intended link target. Multiple prior quarantine fixtures otherwise made its first-match lookup depend on directory iteration order. The migration itself is unchanged, and the corrected full migration test passed as an unprivileged user in the ARM64 container.

Final CI at 34e6229b: 273/275 shell files pass. Only the unchanged Apple engine source-lock contract and channel-publisher fixture-order failures remain. The corrected symlink assertion passes in CI and its focused unprivileged run.
