### PR TITLE
Offer the portable Mac installer on the project home

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,28 @@
+name: Publish project home
+on:
+  push:
+    branches: [main]
+    paths: ['site/**', '.github/workflows/pages.yml']
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: site
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/README.md
+++ b/README.md
@@ -13,36 +13,45 @@ Omarchy 4 (Quattro) is the maintained release:
 
 | Version | Status | Installation |
 | --- | --- | --- |
-| Omarchy `4.0.3-mac.1` | Prepared update (unpublished) | Awaiting package, payload, and M1 qualification |
-| Omarchy `4.0.2-mac.1` | Recommended stable version | Direct signed installation on Asahi Arch Minimal |
+| Omarchy `4.0.3-mac.1` | Accepted test candidate; not publicly promoted | Qualification and release details below |
+| Omarchy `4.0.2-mac.1` | Current RC fresh-install image | Install from macOS using the app below |
 | Omarchy `3.8.4-mac.4` | Legacy | Existing installations can update to Omarchy 4 |
 
 > [!NOTE]
-> Omarchy Mac has been tested on M1, M2, and M3 Macs. Physical Apple-hardware
-> qualification is recorded per release against a 14-inch 2021 MacBook Pro
-> with M1 Pro (`apple,j314s`). The current `4.0.1-mac.2` release was accepted in
-> a generic ARM64 QEMU/HVF VM and does not claim physical Apple-hardware
-> qualification. Apple Silicon support still depends on the upstream Asahi
-> Linux support available for each model.
+> The portable macOS app’s end-to-end installation was confirmed by the owner
+> on an M2 Max. Runtime 4.0.3 passed a signed M1 Pro upgrade and a fresh generic
+> ARM64 VM reboot with all 23 optional application installations passing. The
+> final runtime pair has not been physically reboot-qualified. These are
+> separate checks; they do not establish that a 4.0.3 fresh-install image has
+> shipped. Hardware support depends on Asahi Linux support for each model.
 
 ## Download For Apple Silicon
 
-Download the installer, open it, then open **Omarchy MX Mac Installer** from
-your Applications folder. The link never changes and always serves the current
-installer:
+Download the ZIP, extract it, and open **Omarchy MX Mac Installer.app**.
+You can run it directly from Downloads; no PKG or Applications-folder installation is required.
 
-**[Download Omarchy MX Mac Installer](https://downloads.aicodelabs.com.au/installer/stable/Omarchy-MX-Mac-Installer.pkg)**
+**[Download Omarchy MX Mac Installer for macOS](https://downloads.aicodelabs.com.au/installer/previews/20260912-55064ca4f708/Omarchy-MX-Mac-Installer.zip)**
 
-The app fetches the current signed Omarchy release itself, so you do not need a
-new installer every time Omarchy is updated.
+The app is signed with Developer ID, notarized by Apple, and stapled. It defaults
+to **RC** and fetches the latest signed release from the selected existing channel
+each time you prepare an installation. Matching cached files are verified and
+reused instead of downloaded again. The existing installation screens remain the
+same, and the privileged worker runs only for the installation session.
 
-Verify the download before opening it. Both commands must report an Apple
-Developer ID for `MARCELO DE BARROS ALCANTARA (T2C384FJBD)`:
+The owner confirmed an end-to-end installation on the M2 Max. The app also saves
+credential-free diagnostic logs across reboots in
+`~/Library/Logs/Omarchy MX Mac Installer/` and root-worker diagnostics in
+`/var/db/com.omarchy.mx.installer/diagnostics/`.
+
+After extracting the ZIP, you can verify the app with:
 
 ```bash
-pkgutil --check-signature ~/Downloads/"Omarchy MX Mac Installer.pkg"
-spctl -a -vv -t install ~/Downloads/"Omarchy MX Mac Installer.pkg"
+codesign --verify --deep --strict ~/Downloads/"Omarchy MX Mac Installer.app"
+spctl -a -vv -t execute ~/Downloads/"Omarchy MX Mac Installer.app"
 ```
+
+Gatekeeper should report `Notarized Developer ID`. The signing identity is
+`MARCELO DE BARROS ALCANTARA (T2C384FJBD)`.
 
 > [!IMPORTANT]
 > Installers older than `2.0.0` were pinned to a single Omarchy release and
@@ -101,7 +110,21 @@ On Apple keyboards, the Command key is Hyprland's `SUPER` modifier.
 The existing Print Screen shortcuts and all Omarchy workspace bindings remain
 available.
 
-## Install Omarchy 4
+## Release Details
+
+The RC app currently installs signed image `os-v4.0.2-mac.1.20260907` (Omarchy
+4.0.2). It follows the latest signed catalog for the channel you select; cached
+files are reused only when their size and SHA-256 match that catalog.
+
+Omarchy 4.0.3 brings upstream security fixes and AI integrations, Apple Silicon
+migration support, and ARM OpenClaw/Perplexity integration while retaining Mac
+boot, package, and network protections. The signed runtime candidate passed its recorded qualification, but public
+promotion is pending. The published runtime channel remains sequence 30. A
+4.0.3 OS payload has not yet been built and qualified.
+
+See [4.0.3 release notes](docs/releases/v4.0.3-mac.1.md).
+
+## Alternative: Install From Asahi Arch Minimal
 
 The signed installer takes a prepared Asahi Arch Minimal system directly to
 Omarchy 4. It verifies immutable release metadata and never installs moving
@@ -109,8 +132,7 @@ Omarchy 4. It verifies immutable release metadata and never installs moving
 
 The `vX.Y.Z-mac.N` tag records the product source and release notes. Installer,
 channel, and package assets are published separately as immutable releases in
-[`maralcbr/omarchy-pkgs`](https://github.com/maralcbr/omarchy-pkgs). Stable
-channel sequence 25 installs product version `4.0.1-mac.2`.
+[`maralcbr/omarchy-pkgs`](https://github.com/maralcbr/omarchy-pkgs). The Linux bootstrap channel is separate from the macOS app’s RC image catalog.
 
 ### 1. Install Asahi Arch Minimal
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Omarchy 4 (Quattro) is the maintained release:
 
 | Version | Status | Installation |
 | --- | --- | --- |
-| Omarchy `4.0.3-mac.1` | Accepted test candidate; not publicly promoted | Qualification and release details below |
+| Omarchy `4.0.3-mac.1` | Prepared update (unpublished) | Accepted test candidate; qualification and release details below |
 | Omarchy `4.0.2-mac.1` | Current RC fresh-install image | Install from macOS using the app below |
 | Omarchy `3.8.4-mac.4` | Legacy | Existing installations can update to Omarchy 4 |
 

--- a/site/boot.sh
+++ b/site/boot.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# Set install mode to online since boot.sh is used for curl installations
+export OMARCHY_ONLINE_INSTALL=true
+
+# When running via `wget ... | bash`, stdin is the pipe and may be EOF.
+# Do NOT rebind stdin (FD 0), since bash may still be reading this script from it.
+# Instead, use /dev/tty explicitly for interactive prompts when available.
+TTY_IN=""
+if [[ -r /dev/tty ]]; then
+    TTY_IN="/dev/tty"
+fi
+
+if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+ansi_art='                 ▄▄▄
+ ▄█████▄    ▄███████████▄    ▄███████   ▄███████   ▄███████   ▄█   █▄    ▄█   █▄
+███   ███  ███   ███   ███  ███   ███  ███   ███  ███   ███  ███   ███  ███   ███
+███   ███  ███   ███   ███  ███   ███  ███   ███  ███   █▀   ███   ███  ███   ███
+███   ███  ███   ███   ███ ▄███▄▄▄███ ▄███▄▄▄██▀  ███       ▄███▄▄▄███▄ ███▄▄▄███
+███   ███  ███   ███   ███ ▀███▀▀▀███ ▀███▀▀▀▀    ███      ▀▀███▀▀▀███  ▀▀▀▀▀▀███
+███   ███  ███   ███   ███  ███   ███ ██████████  ███   █▄   ███   ███  ▄██   ███
+███   ███  ███   ███   ███  ███   ███  ███   ███  ███   ███  ███   ███  ███   ███
+ ▀█████▀    ▀█   ███   █▀   ███   █▀   ███   ███  ███████▀   ███   ▀    ▀█████▀ 
+                                       ███   █▀                                  '
+
+# Install gum if not present for enhanced UI
+install_gum() {
+    if ! command -v gum &>/dev/null; then
+        echo "Installing gum for elegant interface..."
+        ${SUDO:+$SUDO }pacman -S --noconfirm --needed gum 2>/dev/null || {
+            echo "Warning: Could not install gum, falling back to basic interface"
+            return 1
+        }
+    fi
+}
+
+# Show message with gum or fallback
+show_message() {
+    if command -v gum &>/dev/null; then
+        gum format "$@"
+    else
+        echo -e "$1"
+    fi
+}
+
+# Show spinner with gum or fallback
+show_spinner() {
+    local title="$1"
+    shift
+    
+    if command -v gum &>/dev/null; then
+        gum spin --spinner dot --title "$title" -- "$@"
+    else
+        echo "$title..."
+        "$@"
+    fi
+}
+
+# Ask for confirmation with gum or fallback
+ask_confirm() {
+    if command -v gum &>/dev/null; then
+        if [[ -n "${TTY_IN}" ]]; then
+            gum confirm "$1" <"${TTY_IN}"
+        else
+            gum confirm "$1"
+        fi
+    else
+        echo "$1 [Y/n]:"
+        if [[ -n "${TTY_IN}" ]]; then
+            read -r response <"${TTY_IN}" || return 0
+        else
+            read -r response || return 0
+        fi
+        [[ ! "${response}" =~ ^[Nn]$ ]]
+    fi
+}
+
+clear
+
+# Show banner with gum or fallback
+if command -v gum &>/dev/null; then
+    gum style \
+        --foreground 212 \
+        --border double \
+        --align center \
+        --margin "1 2" \
+        --padding "1 2" \
+        "$ansi_art" \
+        "$(gum style --foreground 212 --bold 'OMARCHY MAC BOOTSTRAP')"
+
+else
+    echo -e "\n$ansi_art\n"
+fi
+
+# Install gum for better experience
+install_gum
+
+# Validate privileges / sudo if needed
+if [[ -n "$SUDO" ]]; then
+    if ! command -v sudo &>/dev/null; then
+        show_message '❌ **Error**: `sudo` is required when not running as root.'
+        show_message "Run this script as root, or install sudo and re-run."
+        exit 1
+    fi
+
+    show_message "🔐 **Validating administrator access...**"
+    if ! sudo -v; then
+        show_message "❌ **Error**: sudo access required. Please run with proper permissions."
+        exit 1
+    fi
+
+        # Keep sudo alive during bootstrap
+        keep_sudo_alive() {
+            while true; do
+                sudo -v
+                sleep 50
+            done
+        }
+
+        keep_sudo_alive &
+        SUDO_KEEPALIVE_PID=$!
+
+        # Cleanup on exit
+        trap 'sudo -k; kill ${SUDO_KEEPALIVE_PID:-} 2>/dev/null' EXIT INT TERM
+fi
+
+show_spinner "Installing release download tools" \
+    ${SUDO:+$SUDO }pacman -Syu --noconfirm --needed curl gnupg
+
+release_url="https://github.com/${OMARCHY_REPO:-maralcbr/omarchy-mx-mac}/releases/latest/download/install-omarchy-mx-mac"
+installer=$(mktemp "${TMPDIR:-/tmp}/install-omarchy-mx-mac.XXXXXXXX")
+signature="$installer.sig"
+key_home=$(mktemp -d "${TMPDIR:-/tmp}/omarchy-release-key.XXXXXXXX")
+chmod 700 "$key_home"
+trap 'rm -f "$installer" "$signature"; rm -rf "$key_home"; sudo -k 2>/dev/null || true; kill ${SUDO_KEEPALIVE_PID:-} 2>/dev/null' EXIT INT TERM
+curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --output "$installer" "$release_url"
+curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --output "$signature" "$release_url.sig"
+fingerprint=5983B1CA32CB778F4D74D24ECFF35022CA5B5959
+keyring="$key_home/omarchy-release.gpg"
+key_url="https://raw.githubusercontent.com/${OMARCHY_REPO:-maralcbr/omarchy-mx-mac}/main/default/omarchy-release.gpg"
+curl --proto '=https' --tlsv1.2 --fail --location --retry 3 --output "$keyring" "$key_url"
+actual_fingerprint=$(gpg --batch --show-keys --with-colons "$keyring" | awk -F: '$1 == "fpr" { print $10; exit }')
+[[ $actual_fingerprint == "$fingerprint" ]] || { echo "Omarchy release key fingerprint mismatch" >&2; exit 1; }
+gpgv --keyring "$keyring" "$signature" "$installer"
+
+show_message "The stable release installer will verify the signed release before cloning it."
+${SUDO:+$SUDO } bash "$installer"

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Download the signed and notarized Omarchy MX Mac app for Apple Silicon. Install from macOS with the latest signed RC image.">
+  <title>Omarchy MX Mac — Download for Apple Silicon</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, sans-serif; color: #eeeaf6; background: #171421; }
+    body { margin: 0; line-height: 1.65; }
+    main { max-width: 800px; margin: auto; padding: 64px 24px; }
+    .eyebrow { color: #afbdff; letter-spacing: .12em; text-transform: uppercase; font-size: .8rem; }
+    h1 { font-size: clamp(2.4rem, 7vw, 4rem); line-height: 1.08; margin: 16px 0; }
+    h2 { font-size: 1.5rem; margin-top: 0; }
+    p, li { color: #cbc6d5; }
+    a { color: #afbdff; text-underline-offset: 3px; }
+    .download { display: inline-block; background: #afbdff; color: #171421; padding: 14px 22px; border-radius: 6px; font-weight: 700; text-decoration: none; margin: 12px 0; }
+    a:focus-visible { outline: 3px solid #fff; outline-offset: 5px; }
+    section { border-top: 1px solid #494252; padding-top: 28px; margin-top: 36px; }
+    .small { font-size: .9rem; }
+    code { overflow-wrap: anywhere; }
+    footer { margin-top: 44px; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <p class="eyebrow">Omarchy on Apple Silicon</p>
+    <h1>Omarchy MX Mac</h1>
+    <p>A complete Omarchy desktop for your Mac, powered by Arch Linux ARM and Asahi Linux.</p>
+    <a class="download" href="https://downloads.aicodelabs.com.au/installer/previews/20260912-55064ca4f708/Omarchy-MX-Mac-Installer.zip">Download the Mac app · ZIP</a>
+    <p class="small">Developer ID signed · Apple notarized · No PKG required</p>
+  </header>
+  <section aria-labelledby="install">
+    <h2 id="install">Install from macOS</h2>
+    <ol>
+      <li>Download and extract the ZIP.</li>
+      <li>Open <strong>Omarchy MX Mac Installer.app</strong> directly from Downloads.</li>
+      <li>Review your disk allocation, authorize installation, and follow the app’s Recovery instructions.</li>
+    </ol>
+    <p>The app defaults to <strong>RC</strong> and checks the selected channel’s latest signed release. Matching cached files are verified and reused. The familiar installation screens stay the same.</p>
+    <p>Back up your data and keep your Mac connected to power. Hardware support depends on your model’s <a href="https://asahilinux.org/fedora/#device-support">Asahi Linux support</a>.</p>
+    <p class="small">End-to-end installation with the portable app was confirmed by the owner on an M2 Max. Diagnostic logs survive reboot; credentials are never logged.</p>
+  </section>
+  <section aria-labelledby="releases">
+    <h2 id="releases">Release details</h2>
+    <p><strong>RC fresh installation: Omarchy 4.0.2.</strong> The current signed image is <code>os-v4.0.2-mac.1.20260907</code>. A newer app download does not change the OS image published in a channel.</p>
+    <p><strong>Omarchy 4.0.3 runtime:</strong> accepted test candidate; public promotion is pending. The published runtime channel remains sequence 30.</p>
+    <ul>
+      <li>Upstream 4.0.3 security fixes, AI integrations, and Apple Silicon migration support.</li>
+      <li>ARM OpenClaw and Perplexity integration, with package-availability checks for unsupported applications.</li>
+      <li>Apple Silicon package, boot, and network protections retained.</li>
+    </ul>
+    <p class="small">The signed 4.0.3 runtime upgrade passed on M1 Pro; a fresh generic ARM64 VM reboot and all 23 optional application installs also passed. The final runtime pair has not been physically reboot-qualified, and no 4.0.3 fresh-install image has been published. <a href="https://github.com/maralcbr/omarchy-mx-mac/blob/main/docs/releases/v4.0.3-mac.1.md">Read the release notes</a>.</p>
+  </section>
+  <footer>
+    <a href="https://github.com/maralcbr/omarchy-mx-mac">Project &amp; installation guide</a> ·
+    <a href="https://github.com/maralcbr/omarchy-mx-mac/issues">Report an issue</a>
+  </footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
The project home still sent macOS users to a PKG, and GitHub Pages showed the legacy shell bootstrap. Point both entry points to the published, notarized portable app ZIP, explain direct launch from Downloads, and document RC defaults, verified cache reuse, and persistent diagnostics.

Record the owner's M2 Max end-to-end acceptance. Keep 4.0.3 explicitly labeled as an accepted test candidate pending public promotion: the RC fresh-install image is still 4.0.2 and the published runtime channel is still sequence 30, as confirmed by the release task.

Add a minimal GitHub Pages deployment for the updated home. Preserve the existing public boot.sh byte-for-byte for legacy links.

Validation: rendered the local home in the browser; checked download URL, signed app publication, shell syntax, and git diff formatting. No installer source or channel metadata changes in this PR.
