### PR TITLE
Publish verified 4.0.3 Stable runtime release details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ Release notes for the maintained Apple Silicon line are version-controlled in
 [`docs/releases/`](docs/releases/). GitHub Releases publish those files
 verbatim.
 
-## [4.0.3-mac.1] - Unreleased
+## [4.0.3-mac.1] - 2026-09-12
 
 - Integrate upstream 4.0.3 security fixes, AI integrations, and migrations.
 - Retain Apple Silicon package, boot, network, and migration protections.
-- Prepare OpenClaw and Perplexity ARM packages and current Asahi platform pins.
-- Publication and physical qualification remain pending. See
-  [preparation notes](docs/releases/v4.0.3-mac.1.md).
+- Publish OpenClaw and Perplexity ARM packages, mise 2026.9.4, and shared
+  runtime channel 31 after signed M1 upgrade and native ARM64 VM acceptance.
+- The RC fresh-install OS remains 4.0.2. Final-pair physical reboot and a
+  4.0.3 OS payload remain unqualified. See
+  [release notes](docs/releases/v4.0.3-mac.1.md).
 
 ## [4.0.2-mac.1] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Omarchy 4 (Quattro) is the maintained release:
 
 | Version | Status | Installation |
 | --- | --- | --- |
-| Omarchy `4.0.3-mac.1` | Prepared update (unpublished) | Accepted test candidate; qualification and release details below |
+| Omarchy `4.0.3-mac.1` | Recommended stable version | Existing installations: run `omarchy update` |
 | Omarchy `4.0.2-mac.1` | Current RC fresh-install image | Install from macOS using the app below |
 | Omarchy `3.8.4-mac.4` | Legacy | Existing installations can update to Omarchy 4 |
 
@@ -118,9 +118,15 @@ files are reused only when their size and SHA-256 match that catalog.
 
 Omarchy 4.0.3 brings upstream security fixes and AI integrations, Apple Silicon
 migration support, and ARM OpenClaw/Perplexity integration while retaining Mac
-boot, package, and network protections. The signed runtime candidate passed its recorded qualification, but public
-promotion is pending. The published runtime channel remains sequence 30. A
-4.0.3 OS payload has not yet been built and qualified.
+boot, package, and network protections. The signed runtime and packages are now
+published to the shared Stable update feed. Existing Omarchy Macs receive them
+through `omarchy update`.
+
+[Stable packages](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-packages-stable-74b8da66fca29137b4988aac1845a2fac1e1ddd9)
+and [runtime channel 31](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-quattro-channel-31)
+carry the accepted `4.0.3.r6941.g5e7965f-1` runtime/settings pair. A 4.0.3
+fresh-install OS payload has not yet been built and qualified; the RC image
+above remains 4.0.2.
 
 See [4.0.3 release notes](docs/releases/v4.0.3-mac.1.md).
 

--- a/docs/releases/v4.0.3-mac.1.md
+++ b/docs/releases/v4.0.3-mac.1.md
@@ -1,7 +1,11 @@
 # Omarchy MX Mac 4.0.3-mac.1
 
-Unreleased preparation based on upstream Omarchy v4.0.3. This version is not
-published to a public update or installation channel.
+Published to the Stable package repository and shared runtime update feed on
+2026-09-12, based on upstream Omarchy v4.0.3. Existing Omarchy Macs can run
+`omarchy update`.
+
+The macOS app's RC fresh-install image remains `os-v4.0.2-mac.1.20260907`.
+A 4.0.3 OS payload has not yet been built and qualified.
 
 ## Changes
 
@@ -9,16 +13,39 @@ published to a public update or installation channel.
   fork's ARM package and boot protections.
 - Review the nine new migrations for Apple Silicon, including Kitty security,
   sleep-hook ownership, and user-preserving AI wrapper setup.
-- Prepare ARM OpenClaw and Perplexity packages. Keep x86-only Hermes Desktop
+- Publish ARM OpenClaw and Perplexity packages. Keep x86-only Hermes Desktop
   and T3 Code entries behind package-availability checks.
 - Prepare Linux Asahi 7.1.13 and U-Boot 2026.07 with signature-verified inputs.
+- Include mise 2026.9.4 and the verified ALARM snapshot 20260910 in the
+  accepted build and VM inputs. Installed systems retain their configured
+  upstream ALARM/Asahi repositories.
+
+## Published artifacts
+
+- [Stable package snapshot](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-packages-stable-74b8da66fca29137b4988aac1845a2fac1e1ddd9): 57 repository packages, promoted byte-for-byte from the accepted candidate.
+- [Shared runtime channel 31](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-quattro-channel-31) and [signed runtime bundle](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-quattro-5e7965f8): runtime/settings version `4.0.3.r6941.g5e7965f-1`, source `5e7965f8e30672a1428077716223d615175d5706`.
+- [Accepted immutable candidate](https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-packages-candidate-74b8da66fca29137b4988aac1845a2fac1e1ddd9): descriptor SHA-256 `dd72a46691f16c55dd2654be8b1257307737b4cac09822e222bf200b5e92e1d5`.
 
 ## Validation
 
-Local runtime/settings packages build successfully. Package-contract and
-Asahi platform/signature/branding checks pass. Full runtime-suite results,
-ALARM snapshot qualification, signed candidates, local OS payloads, graphical
-acceptance, and M1 Pro upgrade/fresh-install evidence must be recorded before
-publication. See [the preparation record](4.0.3-mac.1-preparation.md).
+All 63 candidate package outputs built, and clean-install/upgrade transaction
+gates passed. Stable publication preserves all 142 candidate assets exactly;
+signatures, manifests and public readback were verified.
+
+The signed runtime upgrade passed on the M1 Pro with user Hyprland settings and
+boot artifacts preserved. Fresh native ARM64 VM installation, reboot,
+interruption/resume, all 23 optional installs and completed-installer rerun
+protection passed. The logged-in desktop and installed AI menu were inspected.
+
+The final runtime pair has not been physically reboot-qualified; no 4.0.3
+physical fresh installation or tap override test is claimed. The M1 retained
+its Asahi kernel during runtime testing. The portable macOS app's separate
+M2 end-to-end installation confirmation applies to the existing RC OS image.
+
+Shell CI passed 273 of 275 files. The two unchanged baseline failures are
+`apple-installer-channel-publish-test.sh` and `apple-platform-stack-test.sh`;
+whole-repository CI is not green. See the [candidate build](https://github.com/maralcbr/omarchy-pkgs/actions/runs/34670127548),
+[runtime publication](https://github.com/maralcbr/omarchy-pkgs/actions/runs/34674411802)
+and [preparation history](4.0.3-mac.1-preparation.md).
 
 **Full Changelog**: https://github.com/omacom/omarchy/compare/v4.0.2...v4.0.3

--- a/site/index.html
+++ b/site/index.html
@@ -45,7 +45,7 @@
   <section aria-labelledby="releases">
     <h2 id="releases">Release details</h2>
     <p><strong>RC fresh installation: Omarchy 4.0.2.</strong> The current signed image is <code>os-v4.0.2-mac.1.20260907</code>. A newer app download does not change the OS image published in a channel.</p>
-    <p><strong>Omarchy 4.0.3 runtime:</strong> accepted test candidate; public promotion is pending. The published runtime channel remains sequence 30.</p>
+    <p><strong>Omarchy 4.0.3 runtime: Stable update available.</strong> Existing Omarchy Macs can run <code>omarchy update</code> to receive the signed runtime and packages from the shared update feed. <a href="https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-quattro-channel-31">Runtime channel 31</a> · <a href="https://github.com/maralcbr/omarchy-pkgs/releases/tag/asahi-packages-stable-74b8da66fca29137b4988aac1845a2fac1e1ddd9">Stable packages</a>.</p>
     <ul>
       <li>Upstream 4.0.3 security fixes, AI integrations, and Apple Silicon migration support.</li>
       <li>ARM OpenClaw and Perplexity integration, with package-availability checks for unsupported applications.</li>


### PR DESCRIPTION
The homepage still describes 4.0.3 as an unpublished candidate after its Stable package and shared runtime promotion. Update README, the public page, release notes and changelog to link the verified Stable snapshot and runtime channel 31 and tell installed users to run `omarchy update`.

Keep the macOS installer distinction explicit: its RC fresh-install OS is still 4.0.2, and the final 4.0.3 pair has not been physically reboot-qualified. Preserve the portable ZIP link and the owner's separate M2 installer confirmation.

Validation: the stable-release contract passes; all 142 Stable assets match the accepted candidate; 24 runtime assets and 4 channel assets passed independent digest/signature verification; both authentic updater `--check` commands discover the live feeds in a disposable ARM fixture. Runtime publication workflow 34674411802 passed. Pages deployment and visual public-page readback follow this documentation merge. The two previously recorded source-CI baseline failures are unchanged.
